### PR TITLE
ci: exempt dependabot sign-off from DCO exact-match

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -54,7 +54,9 @@ jobs:
             BODY=$(git log -1 --format='%B' "$commit")
             EXPECTED_DCO="Signed-off-by: $AUTHOR_NAME <$AUTHOR_EMAIL>"
 
-            if echo "$BODY" | grep -Fq "$EXPECTED_DCO"; then
+            if [ "$AUTHOR_NAME" = "dependabot[bot]" ] && echo "$BODY" | grep -Fq "Signed-off-by: dependabot[bot] <support@github.com>"; then
+              echo "✓ Commit $commit satisfies DCO (dependabot canonical sign-off)"
+            elif echo "$BODY" | grep -Fq "$EXPECTED_DCO"; then
               echo "✓ Commit $commit satisfies DCO ($EXPECTED_DCO)"
             elif echo "$BODY" | grep -Fiq "Signed-off-by:"; then
               echo "::error::Commit $commit has Signed-off-by header but mismatches git author. Expected: '$EXPECTED_DCO'"


### PR DESCRIPTION
## Summary

Dependabot-authored commits sign off as `dependabot[bot] <support@github.com>` but author as `dependabot[bot] <49699333+…@users.noreply.github.com>`. The DCO workflow requires the `Signed-off-by` trailer to exactly match the git author, so every dependabot PR fails the DCO check (e.g. #1).

This special-cases dependabot's canonical sign-off so bot-authored commits pass, matching how GitHub's DCO app treats bots.

## Validation

- [x] Commits GPG signed + DCO sign-off
- [ ] CI checks green (`security`, `dco`)