### PR TITLE
docs: add identity/governance/CI-CD architecture tranche

### DIFF
--- a/docs/01-architecture/README.md
+++ b/docs/01-architecture/README.md
@@ -19,8 +19,8 @@ with conflicting architecture, that's drift: a bug, not a style choice.
 | --- | --- | --- |
 | **L0 — System Context** | What is this platform and what external systems interact with it? | `context/platform-context.mmd` |
 | **L1 — Cloud Deployment** | Where are the major platform components deployed? | `docs/arch/cloud-deployment.mmd` |
-| **L2 — Domain Architecture** | How does one platform domain work? | `network/network-overview.mmd`, `network/traffic-flows.mmd` |
-| **L3 — Component / Zone Detail** | How is this particular domain or trust zone configured? | `network/routing.mmd`, `network/edge-zone.mmd`, `network/management-zone.mmd`, `network/workload-zone.mmd`, `network/data-zone.mmd` |
+| **L2 — Domain Architecture** | How does one platform domain work? | `network/network-overview.mmd`, `network/traffic-flows.mmd`, `identity/oci-identity-governance.mmd`, `identity/human-identity.mmd`, `governance/platform-governance.mmd`, `cicd/software-supply-chain.mmd` |
+| **L3 — Component / Zone Detail** | How is this particular domain or trust zone configured? | `network/routing.mmd`, `network/edge-zone.mmd`, `network/management-zone.mmd`, `network/workload-zone.mmd`, `network/data-zone.mmd`, `governance/oci-access-control.mmd`, `identity/openziti-identity-network.mmd`, `cicd/iac-pipeline.mmd` |
 | **L4 — Dynamic / Flow View** | What happens during a particular operation? | none yet — see `views.md`'s Dynamic flow views note |
 
 Diagrams may intentionally repeat architectural concepts across levels —
@@ -62,9 +62,33 @@ Architecture
     │     ├── Workload       (network/workload-zone.mmd)
     │     └── Data            (network/data-zone.mmd)
     │
-    ├── Kubernetes    — planned, I05/I07 (views.md)
-    ├── Security         — planned, I08/I20 (views.md)
-    ├── Identity           — planned, I09/I10 (views.md)
+    ├── Identity
+    │     ├── OCI Identity      (identity/oci-identity-governance.mmd)
+    │     ├── Human Identity      (identity/human-identity.mmd)
+    │     ├── OpenZiti              (identity/openziti-identity-network.mmd)
+    │     ├── Workload Identity        — planned, I09 (views.md)
+    │     └── Kubernetes RBAC             — planned, I05/I09/I10 (views.md)
+    │
+    ├── Governance
+    │     ├── OCI Access Control   (governance/oci-access-control.mmd)
+    │     ├── Platform Governance    (governance/platform-governance.mmd)
+    │     └── Kubernetes Tenancy        — planned, I05 (views.md)
+    │
+    ├── Kubernetes
+    │     ├── Deployment   — planned, I04/I05/I06 (views.md)
+    │     ├── Network        — planned, I07 (views.md)
+    │     └── Security Boundaries — planned, I05/I07/I09 (views.md)
+    │
+    ├── CI/CD
+    │     ├── Supply Chain   (cicd/software-supply-chain.mmd)
+    │     ├── IaC              (cicd/iac-pipeline.mmd)
+    │     ├── Platform GitOps    — planned, I12 (views.md)
+    │     ├── Application          — no owning initiative (views.md)
+    │     ├── Policy                 — planned, I14 (views.md)
+    │     ├── Node Configuration       — planned, I04 (views.md)
+    │     └── Security Content           — planned, I17 (views.md)
+    │
+    ├── Security         — planned trust-boundaries synthesis, I08/I20 (views.md)
     ├── Storage              — planned, I15 (views.md)
     ├── Observability          — planned, I16 (views.md)
     └── Hybrid                    — planned, I21 (views.md)

--- a/docs/01-architecture/cicd/iac-pipeline.mmd
+++ b/docs/01-architecture/cicd/iac-pipeline.mmd
@@ -1,0 +1,24 @@
+%% VIEW-CICD-IAC — L3 Infrastructure CI/CD
+%% Question: what happens to an OpenTofu/Terragrunt change from commit to
+%% applied infrastructure?
+%% Governing: .github/workflows/validate.yml, plan.yml (live),
+%% SPEC-OCI-001 REQ-OCI-005..007, ADR-0001, ADR-0007
+%% GitHub Actions never applies — matches ADR-0005's constraint that CI
+%% only validates and plans.
+flowchart TB
+  SRC["OpenTofu / Terragrunt source — ARCH-CICD-IAC"] --> FMT["tofu fmt -check"]
+  FMT --> VALIDATE["tofu validate"]
+  VALIDATE --> TEST["tofu test (*.tftest.hcl)"]
+  TEST --> TFLINT["TFLint"]
+  TFLINT --> SECSCAN["Security scan — gitleaks, semgrep, zizmor, trivy (security.yml)"]
+  SECSCAN --> POLICY["Checkov policy scan — hard-fail (validate.yml)"]
+  POLICY --> PLAN["tofu plan — plan.yml, gated on infrastructure/live/**"]
+  PLAN --> AUTH["OCI auth: static keys via GitHub Actions secrets (REQ-OCI-006) — OIDC federation PLANNED, EPIC-OCI-04"]
+  PLAN --> STATEBACKEND["State backend — REQ-OCI-005/007, two-phase bootstrap"]
+  PLAN --> ARTIFACT["Plan artifact uploaded for review"]
+  ARTIFACT --> REVIEW["PR review — 0 required approvals, solo maintainer; CI checks required"]
+  REVIEW --> APPLY["Controlled apply — manual, outside CI (GitHub Actions never applies)"]
+  APPLY --> DRIFT["Drift detection — PLANNED, I23"]
+
+  classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class DRIFT planned;

--- a/docs/01-architecture/cicd/iac-pipeline.mmd
+++ b/docs/01-architecture/cicd/iac-pipeline.mmd
@@ -1,8 +1,8 @@
 %% VIEW-CICD-IAC — L3 Infrastructure CI/CD
 %% Question: what happens to an OpenTofu/Terragrunt change from commit to
 %% applied infrastructure?
-%% Governing: .github/workflows/validate.yml, plan.yml (live),
-%% SPEC-OCI-001 REQ-OCI-005..007, ADR-0001, ADR-0007
+%% Governing: .github/workflows/validate.yml, .github/workflows/plan.yml
+%% (both live), SPEC-OCI-001 REQ-OCI-005..007, ADR-0001, ADR-0007
 %% GitHub Actions never applies — matches ADR-0005's constraint that CI
 %% only validates and plans.
 flowchart TB
@@ -12,13 +12,16 @@ flowchart TB
   TEST --> TFLINT["TFLint"]
   TFLINT --> SECSCAN["Security scan — gitleaks, semgrep, zizmor, trivy (security.yml)"]
   SECSCAN --> POLICY["Checkov policy scan — hard-fail (validate.yml)"]
-  POLICY --> PLAN["tofu plan — plan.yml, gated on infrastructure/live/**"]
-  PLAN --> AUTH["OCI auth: static keys via GitHub Actions secrets (REQ-OCI-006) — OIDC federation PLANNED, EPIC-OCI-04"]
-  PLAN --> STATEBACKEND["State backend — REQ-OCI-005/007, two-phase bootstrap"]
+  POLICY --> AUTH["OCI auth: static keys via GitHub Actions secrets (REQ-OCI-006) — OIDC federation PLANNED, EPIC-OCI-04"]
+  AUTH -->|"credentials present"| STATEBACKEND["tofu init — state backend, REQ-OCI-005/007 two-phase bootstrap"]
+  AUTH -.->|"credentials absent — fork PRs, missing secrets"| NOCREDS["Notify missing credentials — plan.yml skips plan, no artifact produced"]
+  STATEBACKEND --> PLAN["tofu plan — plan.yml, gated on infrastructure/live/**"]
   PLAN --> ARTIFACT["Plan artifact uploaded for review"]
   ARTIFACT --> REVIEW["PR review — 0 required approvals, solo maintainer; CI checks required"]
   REVIEW --> APPLY["Controlled apply — manual, outside CI (GitHub Actions never applies)"]
   APPLY --> DRIFT["Drift detection — PLANNED, I23"]
 
   classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  classDef pending fill:#fff6d9,stroke:#b58b00,stroke-dasharray: 4 3;
   class DRIFT planned;
+  class NOCREDS pending;

--- a/docs/01-architecture/cicd/software-supply-chain.mmd
+++ b/docs/01-architecture/cicd/software-supply-chain.mmd
@@ -1,0 +1,38 @@
+%% VIEW-CICD-SUPPLYCHAIN — L2 Common Software Supply Chain
+%% Question: what happens to every change between a developer's commit and
+%% running behavior, common across all workload classes?
+%% Governing: .github/workflows/{validate,security,docs,dco}.yml (live),
+%% CONTRIBUTING.md (signed+DCO), ADR-0005 (Flux/GitOps), ADR-0004 (Kyverno)
+%% This repo has zero container workloads today — everything past "merge"
+%% is PLANNED, not invented. ARCH-CICD-SUPPLYCHAIN covers the whole chain.
+flowchart TB
+  DEV["Developer"] --> GH["GitHub — ARCH-GOV-GITHUB"] --> PR["Pull Request"] --> CI["CI — ARCH-CICD-IAC"]
+  CI --> LINT["Lint — markdownlint (docs.yml), tflint (validate.yml)"]
+  CI --> SAST["SAST — Semgrep (security.yml)"]
+  CI --> SECRETS["Secret scan — gitleaks (security.yml)"]
+  CI --> IACSCAN["IaC scan — Checkov (validate.yml)"]
+  CI --> WFLINT["Workflow lint — zizmor (security.yml)"]
+  CI --> DIAGRAM["Diagram validation — mmdc (docs.yml)"]
+
+  LINT --> MERGE["Merge — squash, DCO + GPG required"]
+  SAST --> MERGE
+  SECRETS --> MERGE
+  IACSCAN --> MERGE
+  WFLINT --> MERGE
+  DIAGRAM --> MERGE
+
+  MERGE --> DEPSCAN["Dependency scan — PLANNED, I18 (no application deps yet)"]
+  DEPSCAN -.-> SBOM["SBOM — PLANNED, I18"]
+  SBOM -.-> IMGBUILD["Image build — PLANNED (no container workloads exist yet)"]
+  IMGBUILD -.-> IMGSCAN["Image vulnerability scan — PLANNED, I18"]
+  IMGSCAN -.-> SIGN["Signing — cosign — PLANNED, I18"]
+  SIGN -.-> PROVENANCE["Provenance — PLANNED, I18"]
+  PROVENANCE -.-> REGISTRY["OCI registry — PLANNED (none selected yet)"]
+  REGISTRY -.-> GITOPSREF["GitOps reference — PLANNED, I12"]
+  GITOPSREF -.-> FLUX["Flux — PLANNED, I12 (ADR-0005 names it, not yet installed)"]
+  FLUX -.-> ADMISSIONV["Admission verification — Kyverno image signature check — PLANNED, I14/I18"]
+  ADMISSIONV -.-> DEPLOY["Deployment — PLANNED"]
+  DEPLOY -.-> RUNTIMEV["Runtime verification — PLANNED, I17"]
+
+  classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class DEPSCAN,SBOM,IMGBUILD,IMGSCAN,SIGN,PROVENANCE,REGISTRY,GITOPSREF,FLUX,ADMISSIONV,DEPLOY,RUNTIMEV planned;

--- a/docs/01-architecture/cicd/software-supply-chain.mmd
+++ b/docs/01-architecture/cicd/software-supply-chain.mmd
@@ -6,18 +6,18 @@
 %% This repo has zero container workloads today — everything past "merge"
 %% is PLANNED, not invented. ARCH-CICD-SUPPLYCHAIN covers the whole chain.
 flowchart TB
-  DEV["Developer"] --> GH["GitHub — ARCH-GOV-GITHUB"] --> PR["Pull Request"] --> CI["CI — ARCH-CICD-IAC"]
+  DEV["Developer"] --> GH["GitHub — ARCH-GOV-GITHUB"] --> PR["Pull Request"] --> CI["CI — ARCH-CICD-SUPPLYCHAIN"]
   CI --> LINT["Lint — markdownlint (docs.yml), tflint (validate.yml)"]
   CI --> SAST["SAST — Semgrep (security.yml)"]
   CI --> SECRETS["Secret scan — gitleaks (security.yml)"]
-  CI --> IACSCAN["IaC scan — Checkov (validate.yml)"]
+  CI --> IACSCAN["IaC scan — Checkov (validate.yml) — DoD control; validate.yml is not yet a required branch-protection check, only runs on infrastructure/** changes"]
   CI --> WFLINT["Workflow lint — zizmor (security.yml)"]
   CI --> DIAGRAM["Diagram validation — mmdc (docs.yml)"]
 
   LINT --> MERGE["Merge — squash, DCO + GPG required"]
   SAST --> MERGE
   SECRETS --> MERGE
-  IACSCAN --> MERGE
+  IACSCAN -.->|"advisory today — see SPEC-OCI-001 Failure Modes"| MERGE
   WFLINT --> MERGE
   DIAGRAM --> MERGE
 

--- a/docs/01-architecture/governance/oci-access-control.mmd
+++ b/docs/01-architecture/governance/oci-access-control.mmd
@@ -26,7 +26,7 @@ flowchart TB
     D_LOG["Logging: log-content write — REQ-OCI-015 — PRESENT"]
     D_OBJ_STATE["Object Storage — state bucket: bootstrap identity only — REQ-OCI-005/006 — PRESENT"]
     D_OBJ_BACKUP["Object Storage — backup bucket — PLANNED, I19"]
-    D_NET["Network: VCN / NSG / route management — covered by general compartment policy, REQ-OCI-002 — PRESENT (not resource-type-specific yet)"]
+    D_NET["Network: VCN / NSG / route management — DECISION PENDING: REQ-OCI-002 requires policies to enumerate specific verbs/resource-types, it does not itself grant network permissions"]
     D_COMPUTE["Compute: Talos node lifecycle — PLANNED, I04"]
     D_MONITOR["Monitoring — DECISION PENDING: no policy Spec'd yet"]
     D_HYBRID["Hybrid / DRG route management — PLANNED, I21"]
@@ -36,7 +36,7 @@ flowchart TB
   POLICY --> D_LOG
   POLICY --> D_OBJ_STATE
   POLICY -.-> D_OBJ_BACKUP
-  POLICY --> D_NET
+  POLICY -.-> D_NET
   POLICY -.-> D_COMPUTE
   POLICY -.-> D_MONITOR
   POLICY -.-> D_HYBRID
@@ -44,4 +44,4 @@ flowchart TB
   classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
   classDef pending fill:#fff6d9,stroke:#b58b00,stroke-dasharray: 4 3;
   class D_OBJ_BACKUP,D_COMPUTE,D_HYBRID,PRINCIPAL_INSTANCE planned;
-  class D_MONITOR pending;
+  class D_MONITOR,D_NET pending;

--- a/docs/01-architecture/governance/oci-access-control.mmd
+++ b/docs/01-architecture/governance/oci-access-control.mmd
@@ -1,0 +1,47 @@
+%% VIEW-GOV-OCI-ACCESS — L3 OCI Access Control
+%% Question: who or what may access which OCI resources, through which
+%% principal, policy, compartment, and trust boundary?
+%% Governing: SPEC-OCI-001 (REQ-OCI-002), SPEC-OCI-002 (REQ-OCI-010),
+%% SPEC-OCI-003 (REQ-OCI-015)
+%% Every permission domain is labeled PRESENT (Spec'd today), PLANNED (owning
+%% initiative not yet spec'd), or DECISION PENDING (no Spec addresses it) —
+%% none are invented.
+flowchart TB
+  PRINCIPAL_HUMAN["Human: OCI IAM User — bootstrap/CI (REQ-OCI-006)"]
+  PRINCIPAL_INSTANCE["Machine: Instance Principal (I04, not yet provisioned)"]
+  DYNGROUP["Dynamic Group (REQ-OCI-003) — ARCH-ID-DYNAMIC-GROUP"]
+
+  PRINCIPAL_INSTANCE -.->|"membership, not yet provisioned"| DYNGROUP
+
+  POLICY["Compartment-scoped IAM Policy (REQ-OCI-002) — ARCH-GOV-OCI"]
+  COMPARTMENT["Platform Compartment — ARCH-OCI-COMPARTMENT"]
+
+  DYNGROUP --> POLICY
+  PRINCIPAL_HUMAN --> POLICY
+  POLICY -->|"scoped to"| COMPARTMENT
+
+  subgraph DOMAINS["Permission domains"]
+    direction TB
+    D_KMS["KMS: use keys / use key-delegate — REQ-OCI-010 — PRESENT"]
+    D_LOG["Logging: log-content write — REQ-OCI-015 — PRESENT"]
+    D_OBJ_STATE["Object Storage — state bucket: bootstrap identity only — REQ-OCI-005/006 — PRESENT"]
+    D_OBJ_BACKUP["Object Storage — backup bucket — PLANNED, I19"]
+    D_NET["Network: VCN / NSG / route management — covered by general compartment policy, REQ-OCI-002 — PRESENT (not resource-type-specific yet)"]
+    D_COMPUTE["Compute: Talos node lifecycle — PLANNED, I04"]
+    D_MONITOR["Monitoring — DECISION PENDING: no policy Spec'd yet"]
+    D_HYBRID["Hybrid / DRG route management — PLANNED, I21"]
+  end
+
+  POLICY --> D_KMS
+  POLICY --> D_LOG
+  POLICY --> D_OBJ_STATE
+  POLICY -.-> D_OBJ_BACKUP
+  POLICY --> D_NET
+  POLICY -.-> D_COMPUTE
+  POLICY -.-> D_MONITOR
+  POLICY -.-> D_HYBRID
+
+  classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  classDef pending fill:#fff6d9,stroke:#b58b00,stroke-dasharray: 4 3;
+  class D_OBJ_BACKUP,D_COMPUTE,D_HYBRID,PRINCIPAL_INSTANCE planned;
+  class D_MONITOR pending;

--- a/docs/01-architecture/governance/platform-governance.mmd
+++ b/docs/01-architecture/governance/platform-governance.mmd
@@ -3,21 +3,24 @@
 %% behavior, and where does that chain currently stop?
 %% Governing: docs/specs/README.md (Spec->Feature->Story->PR->Verification
 %% chain), .github/workflows/*.yml (live CI), ADR-0004 (Kyverno, not yet
-%% installed), SPEC-OCI-003 REQ-OCI-014 (OCI Audit)
+%% installed), ADR-0005 (Flux is the only path to the cluster — Kyverno
+%% admission is reconciled through it, never applied by CI directly),
+%% SPEC-OCI-003 REQ-OCI-014 (OCI Audit)
 flowchart TB
   SPEC["Specification — docs/specs/*.md — ARCH-GOV-GITHUB"]
   PR["Pull Request — branch protection, signed + DCO commits"]
   CI["CI validation — validate.yml, security.yml, docs.yml, dco.yml"]
   IAC["IaC — OpenTofu/Terragrunt (tooling ready; infrastructure/ not yet populated)"]
-  POLICY_ADMISSION["Kyverno admission policy — PLANNED, I14 (ADR-0004 names the engine, not yet installed)"]
+  FLUX["Flux — ADR-0005, the only path to the cluster — PLANNED, I12 (not yet installed)"]
+  POLICY_ADMISSION["Kyverno admission policy — PLANNED, I14 (ADR-0004 names the engine, reconciled via Flux, not yet installed)"]
   ADMISSION["Kubernetes admission control — PLANNED (no cluster yet)"]
   RUNTIME["Runtime enforcement — Cilium NetworkPolicy (I07), Tetragon/Falco (I17) — PLANNED"]
   AUDIT_OCI["OCI Audit — ARCH-GOV-OCI (REQ-OCI-014) — PRESENT"]
   AUDIT_K8S["Kubernetes audit log — PLANNED"]
 
-  SPEC --> PR --> CI --> IAC --> POLICY_ADMISSION --> ADMISSION --> RUNTIME
+  SPEC --> PR --> CI --> IAC --> FLUX --> POLICY_ADMISSION --> ADMISSION --> RUNTIME
   IAC --> AUDIT_OCI
   RUNTIME -.-> AUDIT_K8S
 
   classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
-  class POLICY_ADMISSION,ADMISSION,RUNTIME,AUDIT_K8S planned;
+  class FLUX,POLICY_ADMISSION,ADMISSION,RUNTIME,AUDIT_K8S planned;

--- a/docs/01-architecture/governance/platform-governance.mmd
+++ b/docs/01-architecture/governance/platform-governance.mmd
@@ -1,0 +1,23 @@
+%% VIEW-GOV-PLATFORM — L2 Platform Governance
+%% Question: what enforces the chain from a written decision to running
+%% behavior, and where does that chain currently stop?
+%% Governing: docs/specs/README.md (Spec->Feature->Story->PR->Verification
+%% chain), .github/workflows/*.yml (live CI), ADR-0004 (Kyverno, not yet
+%% installed), SPEC-OCI-003 REQ-OCI-014 (OCI Audit)
+flowchart TB
+  SPEC["Specification — docs/specs/*.md — ARCH-GOV-GITHUB"]
+  PR["Pull Request — branch protection, signed + DCO commits"]
+  CI["CI validation — validate.yml, security.yml, docs.yml, dco.yml"]
+  IAC["IaC — OpenTofu/Terragrunt (tooling ready; infrastructure/ not yet populated)"]
+  POLICY_ADMISSION["Kyverno admission policy — PLANNED, I14 (ADR-0004 names the engine, not yet installed)"]
+  ADMISSION["Kubernetes admission control — PLANNED (no cluster yet)"]
+  RUNTIME["Runtime enforcement — Cilium NetworkPolicy (I07), Tetragon/Falco (I17) — PLANNED"]
+  AUDIT_OCI["OCI Audit — ARCH-GOV-OCI (REQ-OCI-014) — PRESENT"]
+  AUDIT_K8S["Kubernetes audit log — PLANNED"]
+
+  SPEC --> PR --> CI --> IAC --> POLICY_ADMISSION --> ADMISSION --> RUNTIME
+  IAC --> AUDIT_OCI
+  RUNTIME -.-> AUDIT_K8S
+
+  classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class POLICY_ADMISSION,ADMISSION,RUNTIME,AUDIT_K8S planned;

--- a/docs/01-architecture/identity/human-identity.mmd
+++ b/docs/01-architecture/identity/human-identity.mmd
@@ -1,0 +1,41 @@
+%% VIEW-ID-HUMAN — L2 Human Identity / OIDC
+%% Question: how do human actors authenticate, and to what?
+%% Governing: ADR-0003 (OpenZiti ZTNA), CONTRIBUTING.md (GitHub identity),
+%% roadmap.md SPIKE-IDP-01 (IdP selection — open, not yet decided)
+%% Authentication is shown separately from authorization. The IdP is NOT
+%% assumed to be any specific product — SPIKE-IDP-01 is still open.
+flowchart TB
+  ADMIN["Platform Administrator — ARCH-ID-HUMAN"]
+  GH["GitHub account — signed commits, DCO — ARCH-GOV-GITHUB"]
+  IDP["FOSS OIDC IdP — DECISION PENDING, SPIKE-IDP-01"]
+  ZITI_ADMIN["OpenZiti identity — administrative enrollment (ADR-0003) — ARCH-ID-ZITI"]
+
+  subgraph AUTHN["Authentication"]
+    OIDC_TOKEN["OIDC token — ARCH-ID-OIDC (mechanism decided, provider pending)"]
+  end
+
+  subgraph TARGETS["Authentication targets"]
+    K8SAPI["Kubernetes API — OIDC integration PLANNED, I10"]
+    ZITI_CTRL["OpenZiti controller — administrative enrollment, ADR-0003"]
+    OPENBAO["OpenBao — auth backend PLANNED, I11"]
+    OBSERVABILITY["Observability login (e.g. dashboards) — PLANNED, I16"]
+  end
+
+  subgraph AUTHZ["Authorization (separate concern)"]
+    RBAC["Kubernetes RBAC — PLANNED, I05/I09/I10"]
+  end
+
+  ADMIN --> GH
+  ADMIN --> IDP
+  ADMIN --> ZITI_ADMIN
+  IDP --> OIDC_TOKEN
+  ZITI_ADMIN --> ZITI_CTRL
+  OIDC_TOKEN -.-> K8SAPI
+  OIDC_TOKEN -.-> OPENBAO
+  OIDC_TOKEN -.-> OBSERVABILITY
+  K8SAPI -.-> RBAC
+
+  classDef pending fill:#fff6d9,stroke:#b58b00,stroke-dasharray: 4 3;
+  classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class IDP,OIDC_TOKEN pending;
+  class K8SAPI,OPENBAO,OBSERVABILITY,RBAC planned;

--- a/docs/01-architecture/identity/oci-identity-governance.mmd
+++ b/docs/01-architecture/identity/oci-identity-governance.mmd
@@ -1,0 +1,45 @@
+%% VIEW-ID-OCI — L2 OCI Identity and Governance
+%% Question: what identity hierarchy and authorization model does OCI itself use?
+%% Governing: SPEC-OCI-001 (REQ-OCI-001..007), SPEC-OCI-002 (REQ-OCI-008..011),
+%% SPEC-OCI-003 (REQ-OCI-012..015)
+%% Human, machine/instance, and resource identity are shown as distinct
+%% concepts, never collapsed into one "IAM" box. Anything not yet backed by
+%% a Spec requirement is marked accordingly, not invented.
+flowchart TB
+  subgraph HUMAN["Human identity — ARCH-ID-HUMAN"]
+    IAMUSER["OCI IAM User — bootstrap/CI credentials (REQ-OCI-006)"]
+  end
+
+  subgraph MACHINE["Machine / instance identity"]
+    INSTPRINC["Instance Principal — Talos nodes — ARCH-ID-OCI-PRINCIPAL (I04, not yet provisioned)"]
+    RESPRINC["Resource Principal — not used by any current Spec"]
+  end
+
+  subgraph GROUPS["Group membership"]
+    DYNGROUP["Dynamic Group — matches instance principals by compartment/tag (REQ-OCI-003) — ARCH-ID-DYNAMIC-GROUP"]
+  end
+
+  subgraph POLICY["Policy — ARCH-GOV-OCI"]
+    POL_COMPARTMENT["Compartment-scoped IAM policy (REQ-OCI-002)"]
+    POL_KMS["KMS key-usage policy: use keys, use key-delegate (REQ-OCI-010)"]
+    POL_LOG["Log-write policy (REQ-OCI-015)"]
+  end
+
+  subgraph RESOURCES["Compartment / resources"]
+    COMPARTMENT["Platform Compartment (REQ-OCI-001) — ARCH-OCI-COMPARTMENT"]
+    VAULT["OCI Vault / KMS (REQ-OCI-008/009) — ARCH-SVC-KMS"]
+    LOGGROUP["OCI Log Group (REQ-OCI-012) — ARCH-SVC-LOGGING"]
+    STATEBUCKET["OpenTofu state bucket (REQ-OCI-005)"]
+  end
+
+  IAMUSER -->|"bootstraps, REQ-OCI-006"| COMPARTMENT
+  INSTPRINC -.->|"membership, not yet provisioned"| DYNGROUP
+  DYNGROUP --> POL_KMS --> VAULT
+  DYNGROUP --> POL_LOG --> LOGGROUP
+  POL_COMPARTMENT -->|"scopes access to"| COMPARTMENT
+  COMPARTMENT --> VAULT
+  COMPARTMENT --> LOGGROUP
+  IAMUSER -->|"bootstrap access (REQ-OCI-005/006)"| STATEBUCKET
+
+  classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class RESPRINC,INSTPRINC planned;

--- a/docs/01-architecture/identity/openziti-identity-network.mmd
+++ b/docs/01-architecture/identity/openziti-identity-network.mmd
@@ -1,0 +1,39 @@
+%% VIEW-ID-ZITI — L3 OpenZiti Identity / Network
+%% Question: how do identity and private network access intersect?
+%% Governing: ADR-0003 (OpenZiti ZTNA), SPEC-NET-002 (gateways),
+%% SPEC-NET-004 REQ-NET-019 (control NSG sources)
+%% OpenZiti provides identity-aware service connectivity — it does not
+%% replace Kubernetes RBAC (see VIEW-ID-K8S-RBAC, PLANNED). Service/dial/
+%% bind policy objects are I08 territory and not yet Spec'd; marked PLANNED
+%% rather than invented.
+flowchart TB
+  subgraph WHOAREYOU["WHO ARE YOU? — identity"]
+    HUMAN_ID["Human identity — administrator — ARCH-ID-HUMAN"]
+    DEVICE_ID["Device identity — PLANNED, I08 (enrollment not yet Spec'd)"]
+    ZITI_ID["OpenZiti identity — ARCH-ID-ZITI (ADR-0003)"]
+  end
+
+  subgraph WHATDIAL["WHAT SERVICE MAY YOU DIAL? — authorization"]
+    DIAL_POLICY["Dial Policy — PLANNED, I08"]
+    BIND_POLICY["Bind Policy — PLANNED, I08"]
+    SERVICE_DEF["Service definition: kube-apiserver — implied by ADR-0003, not yet a formal Ziti service object"]
+  end
+
+  subgraph WHEREFLOW["WHERE DOES TRAFFIC FLOW? — network path"]
+    EDGE_ROUTER["Ziti public edge router — Edge zone (SPEC-NET-002, SPEC-NET-004)"]
+    ZITI_FABRIC["Ziti fabric"]
+    PRIV_ROUTER["Ziti private router — Management zone (SPEC-NET-004, control NSG source)"]
+    K8SAPI["Kubernetes API — port 6443 (REQ-NET-019)"]
+  end
+
+  HUMAN_ID --> ZITI_ID
+  DEVICE_ID -.-> ZITI_ID
+  ZITI_ID --> DIAL_POLICY
+  DIAL_POLICY -.-> SERVICE_DEF
+  BIND_POLICY -.-> SERVICE_DEF
+  SERVICE_DEF -.-> K8SAPI
+
+  ZITI_ID --> EDGE_ROUTER --> ZITI_FABRIC --> PRIV_ROUTER --> K8SAPI
+
+  classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class DEVICE_ID,DIAL_POLICY,BIND_POLICY,SERVICE_DEF planned;

--- a/docs/01-architecture/traceability.md
+++ b/docs/01-architecture/traceability.md
@@ -193,6 +193,7 @@ governing Spec.
   file's decoupling was designed to survive without any Spec needing to
   change. Untouched by the multi-view work described here.
 - `docs/01-architecture/context/platform-context.mmd` and everything under
-  `docs/01-architecture/network/` — new, committed, `mmdc`-validated views
-  introduced to answer questions `cloud-deployment.mmd` was being asked to
-  answer all at once. See [`views.md`](views.md) for the full catalog.
+  `docs/01-architecture/{network,identity,governance,cicd}/` — new,
+  committed, `mmdc`-validated views introduced to answer questions
+  `cloud-deployment.mmd` was being asked to answer all at once. See
+  [`views.md`](views.md) for the full catalog.

--- a/docs/01-architecture/traceability.md
+++ b/docs/01-architecture/traceability.md
@@ -1,7 +1,8 @@
 # Architecture traceability
 
 `docs/arch/cloud-deployment.mmd` and every file under
-`docs/01-architecture/{context,network}/` are visualizations. Their Mermaid
+`docs/01-architecture/{context,network,identity,governance,cicd}/` are
+visualizations. Their Mermaid
 node/group/junction IDs are implementation details of *that rendering* —
 free to be renamed, collapsed, expanded, or replaced entirely whenever a
 diagram is redrawn for clarity. `cloud-deployment.mmd` has already been
@@ -119,6 +120,30 @@ in [`views.md`](views.md).
 | `ARCH-SVC-LOGGING` | OCI Logging. | VIEW-CLOUD-DEPLOYMENT | — (planned: VIEW-OBSERVABILITY, I16) |
 | `ARCH-SVC-MONITORING` | OCI Monitoring. | VIEW-CLOUD-DEPLOYMENT | — (planned: VIEW-OBSERVABILITY, I16) |
 | `ARCH-SVC-BACKUP-BUCKET` | OCI Object Storage backup target — reserved for I19/M9, not yet specified. | VIEW-NET-DATA | — (planned: VIEW-STORAGE, I15) |
+
+### Identity
+
+| ID | Meaning | Primary View | Detail View |
+| --- | --- | --- | --- |
+| `ARCH-ID-HUMAN` | A human actor (the platform administrator) as a distinct identity class from machine/workload identity. | VIEW-ID-HUMAN | VIEW-ID-ZITI |
+| `ARCH-ID-OIDC` | An OIDC token/identity as a mechanism — decoupled from which IdP issues it (SPIKE-IDP-01 is still open). | VIEW-ID-HUMAN | — |
+| `ARCH-ID-ZITI` | An OpenZiti identity — the principal Ziti's dial/bind policies authorize, distinct from the human or device behind it. | VIEW-ID-ZITI | — |
+| `ARCH-ID-OCI-PRINCIPAL` | An OCI principal generically — user, instance, or resource principal (OCI's own identity primitive). | VIEW-ID-OCI | VIEW-GOV-OCI-ACCESS |
+| `ARCH-ID-DYNAMIC-GROUP` | An OCI Dynamic Group — matches instance principals by rule (REQ-OCI-003), the mechanism machine identity is granted policy through. | VIEW-ID-OCI | VIEW-GOV-OCI-ACCESS |
+
+### Governance
+
+| ID | Meaning | Primary View | Detail View |
+| --- | --- | --- | --- |
+| `ARCH-GOV-OCI` | The OCI policy-enforcement mechanism — compartment-scoped IAM policy statements binding principals/groups to permitted actions. | VIEW-GOV-OCI-ACCESS | VIEW-ID-OCI |
+| `ARCH-GOV-GITHUB` | GitHub as a governance control plane — branch protection, required signed/DCO commits, Specs/ADRs/Issues as the durable record. | VIEW-GOV-PLATFORM | VIEW-ID-HUMAN |
+
+### CI/CD
+
+| ID | Meaning | Primary View | Detail View |
+| --- | --- | --- | --- |
+| `ARCH-CICD-SUPPLYCHAIN` | The common lifecycle every change goes through, independent of workload class. | VIEW-CICD-SUPPLYCHAIN | VIEW-CICD-IAC |
+| `ARCH-CICD-IAC` | The infrastructure-specific pipeline — the only workload-class pipeline with real, running content today. | VIEW-CICD-IAC | — |
 
 This list grows only when a Spec needs a concept it doesn't already cover.
 Don't pre-mint IDs for initiatives that haven't reached specification depth

--- a/docs/01-architecture/views.md
+++ b/docs/01-architecture/views.md
@@ -153,6 +153,132 @@ maps to Specs and ARCH-* concept IDs.
 - **Related views:** VIEW-NET-WORKLOAD, VIEW-NET-TRAFFIC
 - **Status:** Active
 
+### VIEW-ID-OCI
+
+- **File:** `identity/oci-identity-governance.mmd`
+- **Level:** L2 — Domain Architecture (Identity)
+- **Purpose:** What identity hierarchy and authorization model does OCI
+  itself use?
+- **Audience:** Cloud/Security Engineers, autonomous agents implementing
+  `SPEC-OCI-*`.
+- **Scope:** Human identity (bootstrap IAM user), machine/instance
+  identity, dynamic groups, policy, compartment/resource targets — each
+  shown as a distinct concept, never collapsed into one "IAM" box.
+- **Out of scope:** Resource principals (not used by any current Spec,
+  shown as absent rather than omitted silently); Kubernetes/workload
+  identity (see VIEW-ID-WORKLOAD, planned).
+- **Governing Specs:** `SPEC-OCI-001`, `SPEC-OCI-002`, `SPEC-OCI-003`.
+- **Related views:** VIEW-GOV-OCI-ACCESS
+- **Status:** Active
+
+### VIEW-GOV-OCI-ACCESS
+
+- **File:** `governance/oci-access-control.mmd`
+- **Level:** L3 — Component Detail
+- **Purpose:** Who or what may access which OCI resources, through which
+  principal, policy, compartment, and trust boundary?
+- **Audience:** Security Engineers, autonomous agents, future IAM
+  optimization phase.
+- **Scope:** Principal → Group → Policy → Resource chain across every
+  permission domain (KMS, logging, object storage, network, compute,
+  monitoring, hybrid), each labeled PRESENT, PLANNED, or DECISION PENDING.
+- **Out of scope:** Kubernetes RBAC (see VIEW-ID-K8S-RBAC, planned).
+- **Governing Specs:** `SPEC-OCI-001` (REQ-OCI-002), `SPEC-OCI-002`
+  (REQ-OCI-010), `SPEC-OCI-003` (REQ-OCI-015).
+- **Related views:** VIEW-ID-OCI
+- **Status:** Active
+
+### VIEW-ID-HUMAN
+
+- **File:** `identity/human-identity.mmd`
+- **Level:** L2 — Domain Architecture (Identity)
+- **Purpose:** How do human actors authenticate, and to what?
+- **Audience:** Security Engineers, Platform Administrator, future IAM/PAM
+  phase.
+- **Scope:** GitHub identity (real), OpenZiti administrative identity
+  (real, ADR-0003), OIDC as a mechanism (real) — the IdP itself is
+  explicitly DECISION PENDING (`SPIKE-IDP-01`), not assumed.
+  Authentication shown separately from authorization.
+- **Out of scope:** Which OIDC product is selected — that's `SPIKE-IDP-01`'s
+  job, not this view's.
+- **Governing Specs:** none directly — ADR-0003, `CONTRIBUTING.md`,
+  `docs/00-overview/roadmap.md` (`SPIKE-IDP-01`).
+- **Related views:** VIEW-ID-ZITI
+- **Status:** Active
+
+### VIEW-ID-ZITI
+
+- **File:** `identity/openziti-identity-network.mmd`
+- **Level:** L3 — Component Detail
+- **Purpose:** How do identity and private network access intersect in
+  OpenZiti?
+- **Audience:** Security Engineers, autonomous agents implementing I08.
+- **Scope:** WHO ARE YOU (identity) vs. WHAT MAY YOU DIAL (authorization)
+  vs. WHERE DOES TRAFFIC FLOW (network path) shown as three explicitly
+  separated concerns. The network path (Edge → fabric → Management → API)
+  is real (ADR-0003, `SPEC-NET-004`); dial/bind policy objects are I08
+  territory, marked PLANNED.
+- **Out of scope:** Kubernetes RBAC — OpenZiti is not a substitute for it.
+- **Governing Specs:** `SPEC-NET-002`, `SPEC-NET-004` (REQ-NET-019),
+  ADR-0003.
+- **Related views:** VIEW-ID-HUMAN, VIEW-NET-MANAGEMENT
+- **Status:** Active
+
+### VIEW-GOV-PLATFORM
+
+- **File:** `governance/platform-governance.mmd`
+- **Level:** L2 — Domain Architecture (Governance)
+- **Purpose:** What enforces the chain from a written decision to running
+  behavior, and where does that chain currently stop?
+- **Audience:** Everyone — this is the single clearest "what's real vs.
+  aspirational" view in the repo.
+- **Scope:** Specification → PR → CI → IaC → admission → runtime → audit,
+  with each stage marked PRESENT or PLANNED against what's actually
+  installed today.
+- **Out of scope:** Per-domain policy content (Kyverno rule bodies, once
+  they exist, live in `policy/` — this view shows the chain, not the
+  rules).
+- **Governing Specs:** `docs/specs/README.md`'s own contract, ADR-0004,
+  `SPEC-OCI-003` (REQ-OCI-014).
+- **Related views:** VIEW-CICD-SUPPLYCHAIN
+- **Status:** Active
+
+### VIEW-CICD-SUPPLYCHAIN
+
+- **File:** `cicd/software-supply-chain.mmd`
+- **Level:** L2 — Domain Architecture (CI/CD)
+- **Purpose:** What happens to every change between commit and running
+  behavior, common across all workload classes?
+- **Audience:** DevSecOps Engineers, autonomous agents, future supply-chain
+  hardening phase (I18).
+- **Scope:** The real, live chain through merge (lint/SAST/secret-scan/
+  IaC-scan/workflow-lint/diagram-validation, all in `.github/workflows/`)
+  — everything after merge (dependency scan onward) is PLANNED, since this
+  repo has zero container workloads today.
+- **Out of scope:** Per-workload-class detail — see VIEW-CICD-IAC and the
+  planned per-class views.
+- **Governing Specs:** none directly — `.github/workflows/{validate,
+  security,docs,dco}.yml`, ADR-0005.
+- **Related views:** VIEW-CICD-IAC, VIEW-GOV-PLATFORM
+- **Status:** Active
+
+### VIEW-CICD-IAC
+
+- **File:** `cicd/iac-pipeline.mmd`
+- **Level:** L3 — Component Detail
+- **Purpose:** What happens to an OpenTofu/Terragrunt change from commit
+  to applied infrastructure?
+- **Audience:** Cloud Engineers, autonomous agents implementing any
+  `SPEC-OCI-*`/`SPEC-NET-*` Enabler.
+- **Scope:** fmt/validate/test/tflint/security-scan/checkov/plan/auth/
+  state-backend/review/apply — the only workload-class pipeline with real,
+  running content today. Explicitly states GitHub Actions never applies.
+- **Out of scope:** Drift detection (PLANNED, I23).
+- **Governing Specs:** `SPEC-OCI-001` (REQ-OCI-005..007), ADR-0001,
+  ADR-0007.
+- **Related views:** VIEW-CICD-SUPPLYCHAIN
+- **Status:** Active
+
 ## Planned views
 
 Registered so they aren't reinvented ad hoc later, and so their absence is
@@ -161,15 +287,24 @@ reaches specification depth — see `docs/00-overview/roadmap.md`.
 
 | View ID | Domain | Owning initiative | Elaborated at |
 | --- | --- | --- | --- |
-| VIEW-K8S-CLUSTER | Kubernetes cluster topology | I05 | M2 |
-| VIEW-K8S-NETWORK | Cilium/CNI, NetworkPolicy | I07 | M3 |
-| VIEW-SECURITY-ZTNA | OpenZiti application-layer behavior | I08 | M3 |
-| VIEW-IDENTITY | SPIFFE/SPIRE + human IdP/OIDC | I09, I10 | M4 |
+| VIEW-ID-WORKLOAD | SPIFFE/SPIRE workload identity issuance/consumption | I09 | M4 |
+| VIEW-ID-K8S-RBAC | OIDC subject/ServiceAccount → RoleBinding → Role/ClusterRole | I05, I09, I10 | M2/M4 |
+| VIEW-GOV-K8S-TENANCY | Namespace boundaries, quotas, admission scope | I05 | M2 |
+| VIEW-K8S-DEPLOYMENT | What Kubernetes/platform component runs where | I04, I05, I06 | M2 |
+| VIEW-K8S-NETWORK | Cilium/CNI, Pod/Service CIDR, NetworkPolicy | I07 | M3 |
+| VIEW-K8S-SECURITY-BOUNDARIES | Cross-cutting K8s trust boundaries (depends on the four rows above existing first) | I05, I07, I09 | M3/M4 |
+| VIEW-SECURITY-ZTNA-POLICY | OpenZiti dial/bind/service policy objects (network-identity intersection is already Active — see VIEW-ID-ZITI) | I08 | M3 |
+| VIEW-SERVICE-MESH | Service mesh / mTLS layer ownership | **undecided — no initiative names this decision yet** | unscheduled |
 | VIEW-SECRETS | OpenBao, ESO, PKI | I11 | M4 |
 | VIEW-SECURITY-TRUST-BOUNDARIES | DFD-derived trust boundaries | I20 (EPIC-TM-01) | ongoing from M0, first artifact expected around M3 |
 | VIEW-STORAGE | Longhorn/SeaweedFS/backup topology | I15 | M6 |
 | VIEW-OBSERVABILITY | Metrics/logs/traces architecture | I16 | M7 |
-| VIEW-SUPPLY-CHAIN | Image signing, SBOM | I18 | M8 |
+| VIEW-CICD-PLATFORM-GITOPS | Flux reconciliation pipeline | I12 | M5 |
+| VIEW-CICD-APPLICATION | Application container pipeline | **no owning initiative — this program's I01-I25 model has no application-workload initiative; may never apply unless one is added** | unscheduled |
+| VIEW-CICD-POLICY | Kyverno/Cilium/Conftest policy pipeline | I14 | M8 |
+| VIEW-CICD-NODE-CONFIG | Talos node configuration pipeline | I04 | M2 |
+| VIEW-CICD-SECURITY-CONTENT | Tetragon/Falco security-content pipeline | I17 | M7 |
+| VIEW-SUPPLY-CHAIN-CONTENT | SBOM/signing/provenance detail populating VIEW-CICD-SUPPLYCHAIN's already-scaffolded shape | I18 | M8 |
 | VIEW-HYBRID | Real DRG peering/routing once active | I21 | M11 |
 
 ## Dynamic flow views

--- a/docs/01-architecture/views.md
+++ b/docs/01-architecture/views.md
@@ -257,8 +257,9 @@ maps to Specs and ARCH-* concept IDs.
   repo has zero container workloads today.
 - **Out of scope:** Per-workload-class detail — see VIEW-CICD-IAC and the
   planned per-class views.
-- **Governing Specs:** none directly — `.github/workflows/{validate,
-  security,docs,dco}.yml`, ADR-0005.
+- **Governing Specs:** none directly — `.github/workflows/validate.yml`,
+  `.github/workflows/security.yml`, `.github/workflows/docs.yml`,
+  `.github/workflows/dco.yml`, ADR-0005.
 - **Related views:** VIEW-CICD-IAC, VIEW-GOV-PLATFORM
 - **Status:** Active
 


### PR DESCRIPTION
## Summary

Second architecture tranche before threat modeling, per the required sequence: Cloud/Network (done, #28) → **Identity/Governance → CI/CD per workload** (this PR) → Kubernetes Deployment/Network (mostly PLANNED — no Spec depth exists yet) → then DFDs.

7 new `mmdc`-validated views, created only where a Spec or ADR already backs the content:

- `identity/oci-identity-governance.mmd` — human vs. machine vs. resource identity kept distinct
- `governance/oci-access-control.mmd` — Principal → Group → Policy → Resource, every permission domain labeled PRESENT/PLANNED/DECISION PENDING
- `identity/human-identity.mmd` — authn separated from authz; IdP marked DECISION PENDING (SPIKE-IDP-01 still open)
- `identity/openziti-identity-network.mmd` — WHO ARE YOU / WHAT MAY YOU DIAL / WHERE DOES TRAFFIC FLOW kept separate
- `governance/platform-governance.mmd` — Spec→PR→CI→IaC→admission→runtime→audit, showing exactly where enforcement stops today
- `cicd/software-supply-chain.mmd` — real chain through merge, PLANNED from dependency-scan onward (zero container workloads exist)
- `cicd/iac-pipeline.mmd` — the one workload-class pipeline with real running content today

This repo only has specification depth for I02 (OCI foundation) and I03 (network). Everything requiring I04-I18 spec depth (SPIFFE/SPIRE, Kubernetes RBAC, namespaces, K8s deployment/network/security, service mesh, GitOps/app/policy/node/security-content pipelines) is registered `PLANNED` in `views.md` rather than invented. Two views (`VIEW-SERVICE-MESH`, `VIEW-CICD-APPLICATION`) have no owning initiative in the I01-I25 model at all — flagged as gaps.

Extends `traceability.md` with 8 new ARCH-* IDs (only for concepts appearing in these 7 views), updates `README.md`'s navigation and L0-L4 table.

## Validation

- [x] `mmdc` exit 0 on all 16 `.mmd` files (9 existing + 7 new)
- [x] `markdownlint-cli2` clean
- [x] Commit GPG signed + DCO sign-off

## Impact

- [x] Architecture decision changed (identity/governance/CI-CD view catalog extended)
- [ ] Threat model / trust boundaries / DFD / risk register affected
- [ ] New infrastructure state boundary introduced
- [ ] Credential, secret, or access policy touched
- [x] README / docs updated