### PR TITLE
docs: add CLAUDE.md and Mermaid Chart Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,6 @@
+<!-- mermaid-ai-skills:start -->
+## Mermaid Diagrams
+
+When the user asks to create, edit, or visualize a diagram, follow the
+instructions in `.github/instructions/mermaid.instructions.md`.
+<!-- mermaid-ai-skills:end -->

--- a/.github/instructions/mermaid.instructions.md
+++ b/.github/instructions/mermaid.instructions.md
@@ -1,0 +1,95 @@
+---
+applyTo: "**"
+---
+# Mermaid AI Skills
+
+When the user asks to create, edit, or visualize any diagram, use the Mermaid
+VS Code extension tools and commands described below.
+
+## Workflow
+
+1. Determine the diagram type and generate Mermaid syntax.
+2. Write the diagram to a `.mmd` file in the project.
+3. Validate syntax: correct first-line keyword, arrow types, balanced brackets.
+4. Preview via the Mermaid extension — open the `.mmd` file (auto-preview) or run
+   **MermaidChart: Preview Diagram** (`mermaidChart.preview`).
+
+## LM Tools — call these for every diagram interaction
+
+- `mermaid-diagram-validator` — validate Mermaid syntax before presenting any diagram
+- `mermaid-diagram-preview` — render a live preview inside VS Code after generating
+- `get-syntax-docs-mermaid` — fetch correct syntax docs for any diagram type
+
+## VS Code Commands
+
+Invoke via Command Palette or the VS Code command API (GitHub Copilot in VS Code only).
+Do not invent command IDs. Prefer writing/editing `.mmd` files when a command is not needed.
+
+### Diagram editing & preview
+
+- **Preview** (`mermaidChart.preview`) — preview the active Mermaid editor (`.mmd` / `.mermaid` must be open).
+- **Create Diagram** (`mermaidChart.createMermaidFile`) — creates a demo flowchart and opens preview side by side.
+- **Repair Diagram** (`mermaidChart.repairDiagram`) — Mermaid AI repair for
+  the active diagram; uses Mermaid AI credits — tell the user before running.
+- **Improve Diagram** (`mermaidChart.improveDiagram`) — uses Copilot / LM
+  API; suggests layout + styling variants for the active diagram.
+
+### Generate diagrams (GitHub Copilot required)
+
+- **Generate Diagram from Code** (`mermaidChart.generateDiagramFromCode`)
+- **Generate Cloud Diagram** (`mermaidChart.generateCloudDiagram`)
+- **Generate ER Diagram** (`mermaidChart.generateERDiagram`)
+- **Generate Docker Diagram** (`mermaidChart.generateDockerDiagram`)
+- **Open AI Chat** (`mermaidChart.openCopilotChat`)
+
+### Mermaid Chart cloud
+
+- **Login** (`mermaidChart.login`) / **Logout** (`mermaidChart.logout`)
+- **Connect Diagram** (`mermaidChart.connectDiagramToMermaidChart`) — link a local diagram to Mermaid Chart.
+- **Sync Diagram** (`mermaidChart.syncDiagramWithMermaid`) — only for
+  diagrams already connected (frontmatter has `id:`). Example:
+
+  ```yaml
+  ---
+  id: cbd9e9ba-a2cb-47c5-a98e-8c28a753428d
+  ---
+  ```
+
+### Review Mermaid Sync
+
+For diagrams updated by the Mermaid Chart GitHub Sync app (or pre-commit regenerate):
+
+- **Review Mermaid Sync** (`mermaidChart.reviewAppCommits`) — start / open the review flow.
+- **Regenerate with Mermaid AI** (`mermaidChart.regenerateDiagramWithMermaidAI`) — regenerate from source references.
+Do not manually rewrite diagrams managed by this workflow. Accept/reject/diff UI actions stay in the extension UI.
+
+### Install / update this pack
+
+- **MermaidChart: Install AI Skills…** (`mermaidChart.installAiSkills`)
+
+## @mermaid-chart slash commands
+
+| Command | Purpose |
+| --- | --- |
+| `/generate_diagram_from_code` | General diagram from any source file |
+| `/generate_execution_sequence` | Sequence diagram from code flow |
+| `/generate_er_diagram` | ER diagram from schema / models |
+| `/generate_cloud_architecture_diagram` | Cloud / CI-CD architecture |
+| `/generate_docker_diagram` | Architecture from Dockerfiles |
+| `/generate_c4_topdown_architecture` | C4 top-down architecture |
+| `/analyze_code_ownership` | Code ownership diagram |
+| `/generate_dependency_diagram` | Dependency / security visualisation |
+
+## Rules
+
+1. Always call `mermaid-diagram-validator` before showing any diagram.
+2. Always call `mermaid-diagram-preview` after generating a diagram.
+3. Use `get-syntax-docs-mermaid` before generating an unfamiliar diagram type.
+4. Prefer `@mermaid-chart` slash commands for complex generation.
+5. Write diagrams to `.mmd` files; never return unvalidated Mermaid syntax.
+6. Warn the user before Repair (Mermaid AI credits).
+7. Cooperate with the Sync workflow — do not manually regenerate managed diagrams.
+
+## Docs
+
+More commands and features: <https://marketplace.visualstudio.com/items?itemName=MermaidChart.vscode-mermaid-chart>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,13 +28,13 @@ repos:
     hooks:
       - id: mermaid-validate
         name: Mermaid diagram validation (mmdc)
-        entry: bash -c 'if [ ! -x node_modules/.bin/mmdc ]; then echo "ERROR: @mermaid-js/mermaid-cli not installed. Run: npm ci"; exit 1; fi; for f in "$@"; do echo "validating $f"; node_modules/.bin/mmdc -p docs/mermaid-puppeteer-config.json -i "$f" -o /tmp/mmdc-precommit.svg >/dev/null || exit 1; done' --
+        entry: scripts/validate-mermaid.sh
         language: system
         files: '\.mmd$'
         pass_filenames: true
 
       - id: check-dco
         name: Developer Certificate of Origin (Signed-off-by)
-        entry: bash -c 'grep -q "^Signed-off-by:" "$1" || { echo "ERROR: Commit message missing Signed-off-by trailer. Use \"git commit -s\"."; exit 1; }' --
+        entry: "bash -c 'grep -q \"^Signed-off-by:\" \"$1\" || { echo \"ERROR - Commit message missing Signed-off-by trailer. Use git commit -s.\"; exit 1; }' --"
         language: system
         stages: [commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: mermaid-validate
+        name: Mermaid diagram validation (mmdc)
+        entry: bash -c 'if [ ! -x node_modules/.bin/mmdc ]; then echo "ERROR: @mermaid-js/mermaid-cli not installed. Run: npm ci"; exit 1; fi; for f in "$@"; do echo "validating $f"; node_modules/.bin/mmdc -p docs/mermaid-puppeteer-config.json -i "$f" -o /tmp/mmdc-precommit.svg >/dev/null || exit 1; done' --
+        language: system
+        files: '\.mmd$'
+        pass_filenames: true
+
       - id: check-dco
         name: Developer Certificate of Origin (Signed-off-by)
         entry: bash -c 'grep -q "^Signed-off-by:" "$1" || { echo "ERROR: Commit message missing Signed-off-by trailer. Use \"git commit -s\"."; exit 1; }' --

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repository is
+
+A zero-trust Kubernetes platform on OCI Always Free Tier, built entirely as
+IaC + GitOps. It is currently **greenfield**: governance scaffolding, docs,
+and specs exist, but no OpenTofu modules or running infrastructure yet.
+Check `docs/00-overview/roadmap.md` for what milestone is actually in
+progress before assuming a component exists.
+
+## Commands
+
+- Full validation gate (run before pushing): `pre-commit run --all-files`
+- OpenTofu, once `infrastructure/modules/` or `infrastructure/compositions/`
+  exist: `tofu fmt -recursive infrastructure`, `tofu validate`,
+  `tflint --recursive`, `checkov -d infrastructure`, and `tofu test` for any
+  directory containing `*.tftest.hcl` (mirrors `.github/workflows/validate.yml`).
+- Markdown lint, matching CI (`.github/workflows/docs.yml`):
+  `npx markdownlint-cli2 --config .markdownlint-cli2.yaml "docs/**/*.md" "README.md" "SECURITY.md" "CONTRIBUTING.md" ".github/**/*.md"`.
+  Add `--fix` first — most findings are MD060 (tables must use the
+  *compact* pipe style: `| --- | --- |`, no interior padding) and MD040
+  (every fenced code block needs a language tag, e.g. `bash` or `text`);
+  `--fix` resolves MD060 automatically but not MD040.
+- Commits **must** be GPG-signed and DCO-attested: `git commit -s -S`.
+  Enforced locally by `.githooks/commit-msg` and in CI by
+  `.github/workflows/dco.yml`.
+- There is no application code, package manager, or test suite yet — don't
+  invent `npm test` / `make build` / similar.
+
+## How work is specified (read this before implementing anything)
+
+This repo deliberately separates the durable specification from disposable
+execution tracking — see `docs/specs/README.md` for the full contract:
+
+- `docs/specs/SPEC-<AREA>-<NNN>.md` is the canonical, versioned record of
+  **what** a capability must do and **why** — numbered `REQ-*` requirements,
+  acceptance criteria, security/threat-model/ADR impact. This is the file to
+  read before implementing anything it governs, not the GitHub issue title.
+- GitHub issues (Feature / Story / Enabler / Spike) are thin execution
+  contracts that point at a Spec by path rather than restating it. A
+  Story's "Read First" section names the exact Spec and requirement IDs.
+- `docs/02-decisions/ADR-*.md` records decisions that are settled, not open
+  for re-litigation without a superseding ADR (see below for what's already
+  decided).
+
+## Technology ownership boundaries — do not blur these
+
+Fixed by `CONTRIBUTING.md` and recorded in `docs/02-decisions/`:
+
+- **OpenTofu** owns OCI infrastructure resources; **Terragrunt** owns
+  environment composition and state boundaries. Layout:
+  `infrastructure/modules/` (resources) → `infrastructure/compositions/`
+  (wiring) → `infrastructure/live/<provider>/<region>/<env>/` (Terragrunt,
+  per-environment).
+- **Talos** owns node configuration — no SSH, only `talosctl` / declarative
+  machine config.
+- **Flux** owns Kubernetes desired state. GitHub Actions never deploys to
+  the cluster — CI only validates and plans (`validate.yml`, `plan.yml`).
+  Any workflow change that runs `kubectl`/`helm`/`flux` against a live
+  cluster contradicts ADR-0005 and should be treated as a bug, not a feature.
+- **Cilium / SPIRE / OpenBao / External Secrets Operator / Kyverno** own
+  their respective control planes. Kyverno is the policy engine — not
+  OPA/Gatekeeper (ADR-0004).
+
+## Network / trust-zone model
+
+`docs/arch/cloud-deployment.mmd` and ADR-0006 define one VCN
+(`10.10.0.0/16`) split into four trust zones: Edge (`10.10.10.0/24` — the
+only zone that may hold a public IP), Management (`10.10.20.0/24` —
+control plane and `kube-apiserver`), Workload (`10.10.30.0/24`), Data
+(`10.10.40.0/24`). The Kubernetes API has **no direct internet path**: the
+only route in is administrator → OpenZiti public edge router (Edge) → Ziti
+fabric → Ziti private router (Management) → `kube-apiserver` (ADR-0003).
+`SPEC-NET-001` through `SPEC-NET-004` implement this zone by zone — check
+any network change against this model, particularly the "no public IP
+outside Edge" and "port 6443 reachable only from the Ziti NSG" invariants.
+
+## Planning system
+
+Work is modeled as Initiatives (I01–I25) → Epics → Specs → Stories /
+Enablers / Spikes, tracked through GitHub Milestones (M0–M12) and Issues —
+see `docs/00-overview/roadmap.md` for the full model and critical path.
+Labels follow `area/*`, `type/*`, `risk/*`, `stage/*`, `priority/*`,
+`status/*` as defined in `.github/labels.yml`; extend that taxonomy rather
+than inventing a parallel one.
+
+## Branch / PR requirements
+
+Single-maintainer repo. Never push directly to `main` — branch protection
+requires a PR with signed + DCO commits and the `security` job set
+(gitleaks/semgrep/zizmor/trivy) plus `dco` green. `validate` and `plan` are
+path-filtered to `infrastructure/**`, and `docs` to `docs/**`/`*.md`, so
+they only run (and only block merge) when those paths are touched. Required
+PR-approval count is intentionally 0 — a PR is still mandatory, it's just
+not gated on a second reviewer who doesn't exist on this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,14 @@ progress before assuming a component exists.
 
 - Full validation gate (run before pushing): `pre-commit run --all-files`
 - OpenTofu, once `infrastructure/modules/` or `infrastructure/compositions/`
-  exist: `tofu fmt -recursive infrastructure`, `tofu validate`,
-  `tflint --recursive`, `checkov -d infrastructure`, and `tofu test` for any
-  directory containing `*.tftest.hcl` (mirrors `.github/workflows/validate.yml`).
+  exist: `tofu fmt -recursive infrastructure`, `tflint --recursive`,
+  `checkov -d infrastructure`, and, **per module/composition directory**
+  (there's no root-level config to validate against): `cd` into each
+  directory containing `main.tf`, `tofu init -backend=false`, then
+  `tofu validate` — and `tofu test` for any directory containing
+  `*.tftest.hcl` (mirrors `.github/workflows/validate.yml`'s actual loop;
+  running `tofu validate` unqualified from the repo root validates nothing
+  useful once modules exist).
 - Markdown lint, matching CI (`.github/workflows/docs.yml`):
   `npx markdownlint-cli2 --config .markdownlint-cli2.yaml "docs/**/*.md" "README.md" "SECURITY.md" "CONTRIBUTING.md" ".github/**/*.md"`.
   Add `--fix` first — most findings are MD060 (tables must use the
@@ -24,10 +29,16 @@ progress before assuming a component exists.
   (every fenced code block needs a language tag, e.g. `bash` or `text`);
   `--fix` resolves MD060 automatically but not MD040.
 - Commits **must** be GPG-signed and DCO-attested: `git commit -s -S`.
-  Enforced locally by `.githooks/commit-msg` and in CI by
-  `.github/workflows/dco.yml`.
-- There is no application code, package manager, or test suite yet — don't
-  invent `npm test` / `make build` / similar.
+  Only the DCO trailer is actually verified by tooling — both
+  `.githooks/commit-msg` and `.github/workflows/dco.yml` check for a
+  `Signed-off-by:` line, not a valid GPG signature. GPG signing is a repo
+  convention enforced by discipline (and by GitHub's own commit-signature
+  UI), not by either of those checks.
+- There is no application code or test suite yet — don't invent
+  `npm test` / `make build` / similar. `package.json` exists solely for
+  `docs/` tooling (`@mermaid-js/mermaid-cli`, pinned and used by
+  `docs.yml`'s `mermaid` job and this repo's pre-commit hook) — it is not
+  an application package manager.
 
 ## How work is specified (read this before implementing anything)
 
@@ -75,7 +86,10 @@ only route in is administrator → OpenZiti public edge router (Edge) → Ziti
 fabric → Ziti private router (Management) → `kube-apiserver` (ADR-0003).
 `SPEC-NET-001` through `SPEC-NET-004` implement this zone by zone — check
 any network change against this model, particularly the "no public IP
-outside Edge" and "port 6443 reachable only from the Ziti NSG" invariants.
+outside Edge" and "port 6443 reachable only from the `ziti` NSG
+(administrative access) and the `worker` NSG (cluster nodes — kubelet and
+kube-proxy must reach `kube-apiserver` to function), never any other
+source" invariant (`SPEC-NET-004.md` REQ-NET-019).
 
 ## Planning system
 

--- a/scripts/validate-mermaid.sh
+++ b/scripts/validate-mermaid.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Validate Mermaid diagrams with mmdc (mirrors `npm run validate:mermaid` in CI).
+# Usage: scripts/validate-mermaid.sh <file.mmd> [file2.mmd ...]
+set -euo pipefail
+
+MMDC="node_modules/.bin/mmdc"
+PUPPETEER_CONFIG="docs/mermaid-puppeteer-config.json"
+
+if [[ ! -x "$MMDC" ]]; then
+  echo "ERROR - @mermaid-js/mermaid-cli not installed. Run - npm ci" >&2
+  exit 1
+fi
+
+exit_code=0
+for f in "$@"; do
+  echo "validating $f"
+  if ! "$MMDC" -p "$PUPPETEER_CONFIG" -i "$f" -o /tmp/mmdc-precommit.svg >/dev/null; then
+    echo "FAILED - $f" >&2
+    exit_code=1
+  fi
+done
+exit "$exit_code"

--- a/scripts/validate-mermaid.sh
+++ b/scripts/validate-mermaid.sh
@@ -11,10 +11,21 @@ if [[ ! -x "$MMDC" ]]; then
   exit 1
 fi
 
+# Unique per-run output dir: a fixed /tmp path would collide across
+# concurrent pre-commit runs and doesn't get cleaned up.
+outdir="$(mktemp -d)"
+trap 'rm -rf "$outdir"' EXIT
+
 exit_code=0
 for f in "$@"; do
   echo "validating $f"
-  if ! "$MMDC" -p "$PUPPETEER_CONFIG" -i "$f" -o /tmp/mmdc-precommit.svg >/dev/null; then
+  # --no-sandbox/--disable-setuid-sandbox (in $PUPPETEER_CONFIG) is required
+  # for mmdc's headless Chromium to launch in most CI and containerized dev
+  # environments (this repo's own GitHub Actions job needs it too — see
+  # .github/workflows/docs.yml). Local machines with a working Chromium
+  # sandbox lose a little defense-in-depth here; there's no per-environment
+  # config in this repo, so this trade-off applies everywhere mmdc runs.
+  if ! "$MMDC" -p "$PUPPETEER_CONFIG" -i "$f" -o "$outdir/$(basename "$f" .mmd).svg" >/dev/null; then
     echo "FAILED - $f" >&2
     exit_code=1
   fi


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` — repository guidance for Claude Code (commands, the Spec/ADR/docs contract, technology ownership boundaries, network trust-zone model, planning system, branch/PR requirements). No `CLAUDE.md`, Cursor rules, or Copilot instructions existed before this session.
- Adds `.github/copilot-instructions.md` + `.github/instructions/mermaid.instructions.md` — GitHub Copilot / VS Code Mermaid Chart extension config for diagram authoring in this repo.
- Fixes 3 pre-existing MD013 line-length violations in `mermaid.instructions.md` so it's clean under `docs.yml`'s markdownlint gate now that it's tracked.
- Includes a local `mermaid-validate` pre-commit hook (mirrors the CI `mermaid` job from #28) — catches a broken `.mmd` before it's even pushed.

## Validation

- [x] `markdownlint-cli2` clean
- [x] Commit GPG signed + DCO sign-off

## Impact

- [ ] Architecture decision changed
- [ ] Threat model / trust boundaries / DFD / risk register affected
- [ ] New infrastructure state boundary introduced
- [ ] Credential, secret, or access policy touched
- [x] README / docs / runbooks updated