### PR TITLE
docs: Kubernetes deployment/network/security + delivery pipeline views

### DIFF
--- a/docs/01-architecture/README.md
+++ b/docs/01-architecture/README.md
@@ -19,8 +19,8 @@ with conflicting architecture, that's drift: a bug, not a style choice.
 | --- | --- | --- |
 | **L0 — System Context** | What is this platform and what external systems interact with it? | `context/platform-context.mmd` |
 | **L1 — Cloud Deployment** | Where are the major platform components deployed? | `docs/arch/cloud-deployment.mmd` |
-| **L2 — Domain Architecture** | How does one platform domain work? | `network/network-overview.mmd`, `network/traffic-flows.mmd`, `identity/oci-identity-governance.mmd`, `identity/human-identity.mmd`, `governance/platform-governance.mmd`, `cicd/software-supply-chain.mmd` |
-| **L3 — Component / Zone Detail** | How is this particular domain or trust zone configured? | `network/routing.mmd`, `network/edge-zone.mmd`, `network/management-zone.mmd`, `network/workload-zone.mmd`, `network/data-zone.mmd`, `governance/oci-access-control.mmd`, `identity/openziti-identity-network.mmd`, `cicd/iac-pipeline.mmd` |
+| **L2 — Domain Architecture** | How does one platform domain work? | `network/network-overview.mmd`, `network/traffic-flows.mmd`, `identity/oci-identity-governance.mmd`, `identity/human-identity.mmd`, `identity/workload-identity.mmd`, `governance/platform-governance.mmd`, `cicd/software-supply-chain.mmd`, `kubernetes/kubernetes-deployment.mmd`, `kubernetes/kubernetes-network.mmd` |
+| **L3 — Component / Zone Detail** | How is this particular domain or trust zone configured? | `network/routing.mmd`, `network/edge-zone.mmd`, `network/management-zone.mmd`, `network/workload-zone.mmd`, `network/data-zone.mmd`, `governance/oci-access-control.mmd`, `governance/kubernetes-tenancy.mmd`, `identity/openziti-identity-network.mmd`, `identity/kubernetes-identity-rbac.mmd`, `cicd/iac-pipeline.mmd`, `cicd/platform-gitops-pipeline.mmd`, `cicd/policy-pipeline.mmd`, `cicd/node-configuration-pipeline.mmd`, `kubernetes/container-runtime.mmd`, `kubernetes/kubernetes-security-boundaries.mmd` |
 | **L4 — Dynamic / Flow View** | What happens during a particular operation? | none yet — see `views.md`'s Dynamic flow views note |
 
 Diagrams may intentionally repeat architectural concepts across levels —
@@ -44,7 +44,12 @@ current commit status.
 
 See [`views.md`](views.md) for every active view (ID, level, purpose,
 audience, scope, out-of-scope, governing Specs, status) and every
-registered-but-not-yet-elaborated planned view.
+registered-but-not-yet-elaborated planned view. See
+[`identity-reconciliation.md`](identity-reconciliation.md) for the
+delivery identity matrix, governance matrix, and cross-domain identity
+reconciliation — the durable record behind every identity claim these
+views make, including where two similarly-named principals are
+deliberately *not* the same one.
 
 ## Navigation
 
@@ -66,26 +71,27 @@ Architecture
     │     ├── OCI Identity      (identity/oci-identity-governance.mmd)
     │     ├── Human Identity      (identity/human-identity.mmd)
     │     ├── OpenZiti              (identity/openziti-identity-network.mmd)
-    │     ├── Workload Identity        — planned, I09 (views.md)
-    │     └── Kubernetes RBAC             — planned, I05/I09/I10 (views.md)
+    │     ├── Workload Identity        (identity/workload-identity.mmd)
+    │     └── Kubernetes RBAC             (identity/kubernetes-identity-rbac.mmd)
     │
     ├── Governance
     │     ├── OCI Access Control   (governance/oci-access-control.mmd)
     │     ├── Platform Governance    (governance/platform-governance.mmd)
-    │     └── Kubernetes Tenancy        — planned, I05 (views.md)
+    │     └── Kubernetes Tenancy        (governance/kubernetes-tenancy.mmd)
     │
     ├── Kubernetes
-    │     ├── Deployment   — planned, I04/I05/I06 (views.md)
-    │     ├── Network        — planned, I07 (views.md)
-    │     └── Security Boundaries — planned, I05/I07/I09 (views.md)
+    │     ├── Deployment   (kubernetes/kubernetes-deployment.mmd)
+    │     ├── Runtime         (kubernetes/container-runtime.mmd)
+    │     ├── Network            (kubernetes/kubernetes-network.mmd)
+    │     └── Security Boundaries   (kubernetes/kubernetes-security-boundaries.mmd)
     │
     ├── CI/CD
     │     ├── Supply Chain   (cicd/software-supply-chain.mmd)
     │     ├── IaC              (cicd/iac-pipeline.mmd)
-    │     ├── Platform GitOps    — planned, I12 (views.md)
+    │     ├── Platform GitOps    (cicd/platform-gitops-pipeline.mmd)
     │     ├── Application          — no owning initiative (views.md)
-    │     ├── Policy                 — planned, I14 (views.md)
-    │     ├── Node Configuration       — planned, I04 (views.md)
+    │     ├── Policy                 (cicd/policy-pipeline.mmd)
+    │     ├── Node Configuration       (cicd/node-configuration-pipeline.mmd)
     │     └── Security Content           — planned, I17 (views.md)
     │
     ├── Security         — planned trust-boundaries synthesis, I08/I20 (views.md)

--- a/docs/01-architecture/cicd/node-configuration-pipeline.mmd
+++ b/docs/01-architecture/cicd/node-configuration-pipeline.mmd
@@ -1,0 +1,18 @@
+%% VIEW-CICD-NODE-CONFIG — L3 Talos Node Configuration Pipeline
+%% Question: how is a Talos node configuration change applied safely?
+%% Governing: ADR-0002 (Talos), CONTRIBUTING.md/CLAUDE.md ("no SSH, only
+%% talosctl / declarative machine config"). I04 has zero Spec depth for
+%% bootstrap/talos/ content — the pipeline SHAPE below follows from the
+%% ADR's explicit no-SSH constraint; the specifics are all PLANNED.
+flowchart TB
+  SRC["Talos machine-config source — bootstrap/talos/, not yet created, I04"] --> VALIDATE["Validation — not yet defined"]
+  VALIDATE --> SECRETS["Secret-material handling — SOPS-encrypted per CONTRIBUTING.md, not yet Spec'd for Talos specifically"]
+  SECRETS --> GEN["Machine config generation"]
+  GEN --> REVIEW["Review — PR, no dedicated CI job yet"]
+  REVIEW --> TALOSCTL["talosctl — no SSH, ever"]
+  TALOSCTL --> MACHINE["Machine"]
+  MACHINE --> HEALTH["Health verification — not yet defined"]
+  MACHINE -.-> UPGRADE["Upgrade lifecycle — separate concern, not yet Spec'd"]
+
+  classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class SRC,VALIDATE,GEN,REVIEW,HEALTH,UPGRADE planned;

--- a/docs/01-architecture/cicd/platform-gitops-pipeline.mmd
+++ b/docs/01-architecture/cicd/platform-gitops-pipeline.mmd
@@ -1,0 +1,19 @@
+%% VIEW-CICD-PLATFORM-GITOPS — L3 Platform GitOps Pipeline
+%% Question: how does a platform-manifest change reach the cluster?
+%% Governing: ADR-0005 (Flux owns K8s desired state, GitHub Actions never
+%% deploys). I12 has zero Spec depth — the shape below follows directly
+%% from ADR-0005 and CONTRIBUTING.md's ownership rule; the specifics
+%% (validation job, policy check, platform/ layout) are all PLANNED.
+flowchart TB
+  CONFIG["Platform config — platform/ directory, not yet created, I12"] --> PR["Pull Request"]
+  PR --> VALIDATION["Validation — CI job not yet defined for platform/"]
+  VALIDATION --> POLICY["Policy — Kyverno pre-admission check, not yet Spec'd"]
+  POLICY --> MERGE["Merge"]
+  MERGE --> FLUXSRC["Flux source-controller — ADR-0005"]
+  FLUXSRC --> RECONCILE["Reconciliation — kustomize/helm-controller"]
+  RECONCILE --> K8SAPI["Kubernetes API"]
+  K8SAPI --> HEALTH["Health status"]
+  HEALTH -.-> REMEDIATION["Rollback / remediation — conceptual, not yet implemented"]
+
+  classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class CONFIG,VALIDATION,POLICY,RECONCILE,HEALTH,REMEDIATION planned;

--- a/docs/01-architecture/cicd/policy-pipeline.mmd
+++ b/docs/01-architecture/cicd/policy-pipeline.mmd
@@ -1,0 +1,18 @@
+%% VIEW-CICD-POLICY — L3 Policy Pipeline
+%% Question: how does a policy change reach enforcement?
+%% Governing: ADR-0004 (Kyverno owns Kubernetes admission policy — not
+%% OPA/Gatekeeper), docs/00-overview/roadmap.md (Cilium policy named).
+%% I14 has zero Spec depth — the engine choice is decided, the actual
+%% policy content and CI wiring are PLANNED. Conftest/OPA are not shown:
+%% zero evidence they're used anywhere in this repo.
+flowchart TB
+  POLICIES["Policy source — Kyverno rules (ADR-0004), Cilium policy (roadmap.md)"] --> TESTS["Policy tests — not yet defined, I14"]
+  TESTS --> PR["Pull Request"]
+  PR --> CIVALIDATE["CI validation — no dedicated job yet"]
+  CIVALIDATE --> MERGE["Merge"]
+  MERGE --> FLUX["Flux — ADR-0005"]
+  FLUX --> ADMISSION["Kyverno admission enforcement — PLANNED"]
+  FLUX --> NETENFORCE["Cilium network enforcement — PLANNED"]
+
+  classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class TESTS,CIVALIDATE,ADMISSION,NETENFORCE planned;

--- a/docs/01-architecture/governance/kubernetes-tenancy.mmd
+++ b/docs/01-architecture/governance/kubernetes-tenancy.mmd
@@ -1,0 +1,39 @@
+%% VIEW-GOV-K8S-TENANCY — L3 Kubernetes Tenancy and Namespace Governance
+%% Question: where are namespace, policy, identity, and ownership boundaries?
+%% Governing: none — I05 has zero Spec depth. Every namespace name below is
+%% a CANDIDATE, not a decision; none exists in any Spec or ADR yet.
+flowchart TB
+  subgraph CANDIDATES["Candidate namespace taxonomy — none Spec'd, I05"]
+    NS_FLUX["flux-system"]
+    NS_NET["networking"]
+    NS_ID["identity"]
+    NS_SEC["security"]
+    NS_SECRETS["secrets"]
+    NS_STOR["storage"]
+    NS_OBS["observability"]
+    NS_DELIVERY["delivery"]
+    NS_PLATFORM["platform-system"]
+    NS_WORKLOAD["workload namespaces"]
+  end
+
+  NS_EXAMPLE["Namespace (generic — structure below applies once real)"]
+  SA_EXAMPLE["ServiceAccount"]
+  RBAC_EXAMPLE["RBAC — see identity/kubernetes-identity-rbac.mmd"]
+  NP_EXAMPLE["NetworkPolicy — Cilium named, rules not Spec'd"]
+  ADM_EXAMPLE["Admission policy — Kyverno named, not Spec'd"]
+  QUOTA_EXAMPLE["ResourceQuota — not Spec'd"]
+  LIMIT_EXAMPLE["LimitRange — not Spec'd"]
+  SECRET_EXAMPLE["Secrets boundary — OpenBao/ESO named, not Spec'd"]
+  OWNER_EXAMPLE["Workload ownership — not Spec'd"]
+
+  NS_EXAMPLE --> SA_EXAMPLE --> RBAC_EXAMPLE
+  NS_EXAMPLE --> NP_EXAMPLE
+  NS_EXAMPLE --> ADM_EXAMPLE
+  NS_EXAMPLE --> QUOTA_EXAMPLE
+  NS_EXAMPLE --> LIMIT_EXAMPLE
+  NS_EXAMPLE --> SECRET_EXAMPLE
+  NS_EXAMPLE --> OWNER_EXAMPLE
+
+  classDef candidate fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class NS_FLUX,NS_NET,NS_ID,NS_SEC,NS_SECRETS,NS_STOR,NS_OBS,NS_DELIVERY,NS_PLATFORM,NS_WORKLOAD candidate;
+  class NP_EXAMPLE,ADM_EXAMPLE,QUOTA_EXAMPLE,LIMIT_EXAMPLE,SECRET_EXAMPLE,OWNER_EXAMPLE candidate;

--- a/docs/01-architecture/identity-reconciliation.md
+++ b/docs/01-architecture/identity-reconciliation.md
@@ -1,0 +1,60 @@
+# Identity reconciliation
+
+This is the durable record behind [`VIEW-ID-*`](views.md), [`VIEW-GOV-*`](views.md),
+and every `VIEW-CICD-*` identity claim: it exists so that no two views can
+silently imply two different principals are interchangeable. See
+[`traceability.md`](traceability.md) for the ARCH-* IDs each row below
+maps to.
+
+## Delivery identity matrix
+
+| Workload | Human | Workflow Identity | Cloud Principal | K8s Principal | Secret Identity |
+| --- | --- | --- | --- | --- | --- |
+| IaC | OCI IAM User (bootstrap) | GitHub Actions workflow | Static OCI keys (REQ-OCI-006); OIDC federation PLANNED, EPIC-OCI-04 | N/A | N/A |
+| Platform GitOps | GitHub contributor | GitHub Actions (validates only) | N/A | Flux ServiceAccount — PLANNED, I12 | N/A |
+| Policy | GitHub contributor | GitHub Actions | N/A | Kyverno ServiceAccount — PLANNED, I14 | N/A |
+| Node configuration | GitHub contributor / Platform Administrator | GitHub Actions (review only) | Instance Principal, once provisioned — PLANNED, I04 | N/A | SOPS-encrypted secrets (`CONTRIBUTING.md`); Talos-specific handling not yet Spec'd |
+| Application | — | — | — | — | **ARCHITECTURE GAP — no owning initiative in the I01-I25 model; see `views.md`'s VIEW-CICD-APPLICATION entry** |
+
+## Governance matrix
+
+| Control Plane | Principal | Authorization Mechanism | Scope | Evidence |
+| --- | --- | --- | --- | --- |
+| GitHub | Contributors | Branch protection, CODEOWNERS, signed+DCO | `main`, sensitive paths | Live — branch protection API |
+| OCI IAM | Human user + Dynamic Groups | Compartment-scoped policy | Platform compartment | REQ-OCI-002 |
+| OCI KMS | Dynamic Group | Key-usage policy | Vault/master key | REQ-OCI-010 |
+| OCI Logging | Dynamic Group | Log-write policy | Log group | REQ-OCI-015 |
+| OpenZiti | Ziti identity | Dial/bind policy | `kube-apiserver` network path | ADR-0003 (path is real); policy objects PLANNED, I08 |
+| Kyverno | K8s admission requests | ClusterPolicy | Cluster-wide | ADR-0004 (engine is real); rules PLANNED, I14 |
+| Cilium | Pod/Service identity | CiliumNetworkPolicy | Pod/Service network | `roadmap.md` (named); rules PLANNED, I07 |
+| SPIRE | Workload | SPIFFE ID issuance | Trust domain | `roadmap.md` (named); PLANNED, I09 |
+| OpenBao | Workload / Human | Policy engine | Secrets | `roadmap.md` (named); PLANNED, I11 |
+| Flux | N/A (controller) | Source/Kustomization RBAC | Cluster-wide | ADR-0005 (owner is real); PLANNED, I12 |
+
+## Cross-domain identity reconciliation
+
+None of the identities below are interchangeable. Where a mapping exists,
+it's named; where it doesn't yet, that's recorded as an architecture gap
+rather than assumed.
+
+| Boundary | Same principal? | Mapping mechanism | Evidence | Gap |
+| --- | --- | --- | --- | --- |
+| GitHub ↔ OCI IAM | No | None automated — a human currently holds both credential sets separately | REQ-OCI-006 (static keys) | **GAP** — GitHub OIDC → OCI federation is EPIC-OCI-04, not yet built |
+| GitHub ↔ Human IdP | No | None | — | **GAP** — `SPIKE-IDP-01` is still open |
+| Human IdP ↔ OpenZiti | No | None documented | ADR-0003 (Ziti's own enrollment, independent of any OIDC IdP) | **GAP** — no Spec binds an OIDC login to Ziti identity issuance |
+| OpenZiti ↔ Kubernetes API | No | Ziti provides network-layer reachability only; K8s authenticates separately once the packet arrives | ADR-0003, REQ-NET-019 | None at the network layer — this is by design, not a gap |
+| Kubernetes API ↔ Kubernetes RBAC | No | Standard K8s separation: API server authenticates, RBAC authorizes | Standard Kubernetes design, real once I05/I10 land | None — expected separation |
+| Kubernetes RBAC ↔ ServiceAccount | No, but natively integrated | ServiceAccount is one of RBAC's subject types, alongside User/Group | Standard Kubernetes design | None — expected integration |
+| ServiceAccount ↔ SPIFFE/SVID | **Explicitly no** | ServiceAccount contributes to SPIRE's workload attestation; SPIRE issues a distinct SPIFFE ID | `roadmap.md` (SPIFFE named), directive's own explicit invariant | **GAP** — exact attestation mechanism (e.g. `k8s_psat` vs `k8s_sat` node attestor) not yet decided, I09 |
+| SPIFFE/SVID ↔ OpenBao | No | SVID as an OpenBao auth method — planned integration point | `roadmap.md` (both named) | **GAP** — not yet Spec'd, I11 |
+| OpenBao ↔ Flux | No relationship expected | External Secrets Operator, not Flux, is the named consumer of OpenBao-issued secrets | `roadmap.md` names ESO, not a direct Flux-OpenBao path | None — clarifying a relationship that shouldn't exist, not a gap |
+
+## Summary of architecture gaps from this reconciliation
+
+1. GitHub → OCI federation (EPIC-OCI-04) — static keys only today.
+2. Human IdP selection (`SPIKE-IDP-01`) — blocks every downstream human-auth mapping.
+3. OIDC login → OpenZiti identity binding — no Spec addresses this at all.
+4. SPIRE node/workload attestation mechanism — named as a component, not yet configured.
+5. SPIFFE ↔ OpenBao auth integration — named as a component, not yet configured.
+6. Application workload pipeline has no owning initiative — a product-scope
+   question, not an architecture gap this session can close.

--- a/docs/01-architecture/identity/kubernetes-identity-rbac.mmd
+++ b/docs/01-architecture/identity/kubernetes-identity-rbac.mmd
@@ -1,0 +1,32 @@
+%% VIEW-ID-K8S-RBAC — L3 Kubernetes Identity and RBAC
+%% Question: how are Kubernetes principals authorized?
+%% Governing: standard Kubernetes RBAC mechanism, applied to the two
+%% identity sources this platform already names (VIEW-ID-HUMAN's OIDC
+%% subject, VIEW-ID-WORKLOAD's — no, ServiceAccount is distinct). No
+%% concrete Role/RoleBinding content exists yet — I05/I09/I10 unspec'd.
+%% Cluster-scoped privilege is visually distinct (red) from
+%% namespace-scoped privilege.
+flowchart TB
+  OIDC_USER["OIDC User — IdP DECISION PENDING, SPIKE-IDP-01"]
+  OIDC_GROUP["OIDC group claim"]
+  SA["Kubernetes ServiceAccount"]
+
+  ROLEBINDING_U["RoleBinding"]
+  ROLE_U["Role — no concrete roles defined yet"]
+  NS_U["Namespace resource — see governance/kubernetes-tenancy.mmd"]
+
+  ROLEBINDING_S["RoleBinding"]
+  ROLE_S["Role — no concrete roles defined yet"]
+  NS_S["Namespace resource"]
+
+  CLUSTERROLE["ClusterRole — cluster-scoped"]
+  CLUSTERROLEBINDING["ClusterRoleBinding — cluster-scoped"]
+
+  OIDC_USER --> OIDC_GROUP --> ROLEBINDING_U --> ROLE_U --> NS_U
+  SA --> ROLEBINDING_S --> ROLE_S --> NS_S
+  OIDC_GROUP -.->|"privileged, cluster-scoped"| CLUSTERROLEBINDING --> CLUSTERROLE
+
+  classDef pending fill:#fff6d9,stroke:#b58b00,stroke-dasharray: 4 3;
+  classDef privileged fill:#ffdcdc,stroke:#c0392b,stroke-dasharray: 4 3;
+  class OIDC_USER,ROLE_U,ROLE_S pending;
+  class CLUSTERROLE,CLUSTERROLEBINDING privileged;

--- a/docs/01-architecture/identity/workload-identity.mmd
+++ b/docs/01-architecture/identity/workload-identity.mmd
@@ -1,0 +1,33 @@
+%% VIEW-ID-WORKLOAD — L2 SPIFFE/SPIRE Workload Identity
+%% Question: how does a Kubernetes workload obtain and use workload identity?
+%% Governing: docs/00-overview/roadmap.md MVP definition (SPIFFE named),
+%% roadmap.md SPIKE-SPIFFE-01 (federation model, open)
+%% ServiceAccount and Pod are shown contributing to attestation, never as
+%% the SPIFFE identity itself — a Kubernetes ServiceAccount != a SPIFFE ID.
+flowchart TB
+  TRUSTDOMAIN["SPIFFE Trust Domain — named in roadmap.md MVP definition"]
+  SPIRE_SERVER["SPIRE Server"]
+  SPIRE_AGENT["SPIRE Agent"]
+  NODE_ATTEST["Node attestation — mechanism not yet Spec'd"]
+  WORKLOAD_ATTEST["Workload attestation — mechanism not yet Spec'd"]
+  SPIFFE_ID["SPIFFE ID"]
+  SVID["SVID"]
+  POD["Kubernetes Pod"]
+  SA["Kubernetes ServiceAccount"]
+  OPENBAO["OpenBao — integration PLANNED, I11"]
+  MTLS["mTLS consumer — PLANNED"]
+  FEDERATION["Cross-cluster federation — DECISION PENDING, SPIKE-SPIFFE-01"]
+
+  TRUSTDOMAIN --> SPIRE_SERVER --> SPIRE_AGENT
+  SPIRE_AGENT --> NODE_ATTEST --> WORKLOAD_ATTEST
+  WORKLOAD_ATTEST --> SPIFFE_ID --> SVID
+  POD -.->|"contributes to attestation — is NOT this identity"| WORKLOAD_ATTEST
+  SA -.->|"contributes to attestation — is NOT this identity"| WORKLOAD_ATTEST
+  SVID -.-> OPENBAO
+  SVID -.-> MTLS
+  TRUSTDOMAIN -.-> FEDERATION
+
+  classDef pending fill:#fff6d9,stroke:#b58b00,stroke-dasharray: 4 3;
+  classDef planned fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class NODE_ATTEST,WORKLOAD_ATTEST,FEDERATION pending;
+  class OPENBAO,MTLS planned;

--- a/docs/01-architecture/kubernetes/container-runtime.mmd
+++ b/docs/01-architecture/kubernetes/container-runtime.mmd
@@ -1,0 +1,13 @@
+%% VIEW-K8S-RUNTIME — L3 Container Runtime
+%% Question: what is the runtime hierarchy from kubelet down to the OCI runtime?
+%% Governing: ADR-0002 (containerd is Talos's default), SPIKE-RT-01 (youki, open)
+%% containerd, runc, and youki are NOT shown as equivalent peers — they sit
+%% at different abstraction layers (CRI shim vs. OCI runtime vs. an
+%% alternative OCI runtime still under evaluation).
+flowchart TB
+  KUBELET["kubelet"] -->|"CRI"| CONTAINERD["containerd — Talos default, ADR-0002"]
+  CONTAINERD -->|"OCI runtime"| RUNC["runc"]
+  CONTAINERD -.->|"experimental alternative — SPIKE-RT-01, open"| YOUKI["youki"]
+
+  classDef pending fill:#fff6d9,stroke:#b58b00,stroke-dasharray: 4 3;
+  class YOUKI pending;

--- a/docs/01-architecture/kubernetes/kubernetes-deployment.mmd
+++ b/docs/01-architecture/kubernetes/kubernetes-deployment.mmd
@@ -1,0 +1,53 @@
+%% VIEW-K8S-DEPLOYMENT — L2 Kubernetes Deployment
+%% Question: what runs where inside the Kubernetes infrastructure?
+%% Governing: ADR-0002 (Talos/containerd), ADR-0003 (OpenZiti), ADR-0004
+%% (Kyverno), ADR-0005 (Flux), docs/00-overview/roadmap.md's MVP definition
+%% (Cilium, SPIFFE, OpenBao+ESO named as MVP components)
+%% Placement only — no subsystem is exploded internally. "Named" (blue)
+%% means roadmap/ADR-decided but not yet configured by any Spec;
+%% "unspecified" (grey) means zero evidence anywhere in this repo.
+flowchart TB
+  subgraph MGMT_ZONE["Management Zone (network layer — existing views)"]
+    CP["Talos Control Plane — ADR-0002"]
+    APISERVER["kube-apiserver"]
+    ETCD["etcd"]
+    ZITI_PRIV["OpenZiti private router — ADR-0003"]
+  end
+
+  subgraph WORKLOAD_ZONE["Workload Zone (network layer — existing views)"]
+    WORKERS["Talos Workers — ADR-0002"]
+  end
+
+  subgraph RUNTIME["Container runtime — see container-runtime.mmd"]
+    KUBELET["kubelet"]
+    CONTAINERD["containerd — Talos default, ADR-0002"]
+  end
+
+  subgraph PLATFORM_SUBSYSTEMS["Platform subsystems — named in roadmap.md's MVP definition"]
+    CILIUM["Cilium — CNI, NetworkPolicy"]
+    SPIRE["SPIRE — workload identity"]
+    FLUX["Flux — ADR-0005"]
+    OPENBAO["OpenBao"]
+    ESO["External Secrets Operator"]
+    KYVERNO["Kyverno — ADR-0004"]
+  end
+
+  UNDECIDED["cert-manager / runtime-security agent — no ADR, not named anywhere in this repo"]
+
+  CP --> APISERVER
+  CP --> ETCD
+  CP --> ZITI_PRIV
+  WORKERS --> KUBELET --> CONTAINERD
+
+  WORKERS -.-> CILIUM
+  WORKERS -.-> SPIRE
+  WORKERS -.-> FLUX
+  WORKERS -.-> OPENBAO
+  WORKERS -.-> ESO
+  WORKERS -.-> KYVERNO
+  WORKERS -.-> UNDECIDED
+
+  classDef unspecified fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  classDef named fill:#dceeff,stroke:#2980b9,stroke-dasharray: 4 3;
+  class UNDECIDED unspecified;
+  class CILIUM,SPIRE,FLUX,OPENBAO,ESO,KYVERNO named;

--- a/docs/01-architecture/kubernetes/kubernetes-network.mmd
+++ b/docs/01-architecture/kubernetes/kubernetes-network.mmd
@@ -1,0 +1,34 @@
+%% VIEW-K8S-NETWORK — L2 Kubernetes Network
+%% Question: how does traffic move through OCI, nodes, Cilium, services,
+%% and workloads?
+%% Governing: docs/00-overview/roadmap.md MVP definition (Cilium named),
+%% existing network/* views (OCI/node layer)
+%% OCI network, node network, pod network, and service network are kept
+%% as distinct layers. Pod/Service CIDR values are DECISION PENDING — no
+%% Spec sets them yet. OpenZiti's identity overlay is explicitly NOT
+%% conflated with Cilium's workload identity — see VIEW-ID-ZITI.
+flowchart TB
+  VCN["OCI VCN — see network/network-overview.mmd"] --> VNIC["Node VNIC"]
+  VNIC --> CILIUM["Cilium dataplane — named in roadmap.md MVP definition"]
+
+  CILIUM --> PODNET["Pod network — Pod CIDR: DECISION PENDING"]
+  CILIUM --> SVCNET["Service network — Service CIDR: DECISION PENDING"]
+
+  PODNET --> PODPOD["pod-to-pod"]
+  SVCNET --> PODSVC["pod-to-service"]
+  VNIC --> NODENODE["node-to-node"]
+  VNIC --> APINODE["API-to-node / node-to-API"]
+
+  CILIUM --> CILIUM_NP["Cilium NetworkPolicy — named in roadmap.md, rules not yet Spec'd"]
+  CILIUM --> CILIUM_ID["Cilium identity"]
+  CILIUM -.-> HUBBLE["Hubble — candidate, not decided anywhere in this repo"]
+  CILIUM -.-> GWAPI["Gateway API — not evaluated, zero evidence"]
+
+  VNIC -.->|"distinct identity plane — not conflated with Cilium identity"| ZITI["OpenZiti overlay — ADR-0003, see VIEW-ID-ZITI"]
+  VCN --> EGRESS["Private egress — NAT Gateway, SPEC-NET-002"]
+  VCN --> INGRESS["Public ingress — Edge zone, SPEC-NET-004"]
+
+  classDef pending fill:#fff6d9,stroke:#b58b00,stroke-dasharray: 4 3;
+  classDef unspecified fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class PODNET,SVCNET,CILIUM_NP pending;
+  class HUBBLE,GWAPI unspecified;

--- a/docs/01-architecture/kubernetes/kubernetes-security-boundaries.mmd
+++ b/docs/01-architecture/kubernetes/kubernetes-security-boundaries.mmd
@@ -1,0 +1,32 @@
+%% VIEW-K8S-SECURITY-BOUNDARIES — L3 Kubernetes Security Boundaries
+%% Question: where are the major Kubernetes security boundaries?
+%% Governing: everything below it in the chain — SPEC-NET-*, ADR-0002/3/4,
+%% VIEW-K8S-DEPLOYMENT, VIEW-K8S-NETWORK, VIEW-ID-* (all Active or above)
+%% This is a boundary inventory, not a configuration — it names each
+%% boundary and its evidence status without asserting specific rules.
+%% Primary future threat-model input (EPIC-TM-01).
+flowchart TB
+  B1["OCI VCN boundary — SPEC-NET-001..006"]
+  B2["Node boundary — Talos, ADR-0002"]
+  B3["Control-plane boundary — Management zone, REQ-NET-019"]
+  B4["Namespace boundary — candidate only, see governance/kubernetes-tenancy.mmd"]
+  B5["Pod boundary"]
+  B6["ServiceAccount boundary — mechanism only, no roles Spec'd"]
+  B7["NetworkPolicy boundary — Cilium named, rules not Spec'd"]
+  B8["SPIFFE trust domain — named in roadmap.md, federation open (SPIKE-SPIFFE-01)"]
+  B9["Secret boundary — OpenBao named, policy not Spec'd"]
+  B10["Admission boundary — Kyverno, ADR-0004, policy not Spec'd"]
+  B11["Runtime security boundary — no tool named anywhere in this repo"]
+
+  B1 --> B2 --> B3
+  B2 --> B4 --> B5 --> B6
+  B5 --> B7
+  B5 --> B8
+  B5 --> B9
+  B3 --> B10
+  B5 --> B11
+
+  classDef pending fill:#fff6d9,stroke:#b58b00,stroke-dasharray: 4 3;
+  classDef unspecified fill:#f2f2f2,stroke:#888,stroke-dasharray: 4 3;
+  class B4,B6,B7,B8,B9,B10 pending;
+  class B11 unspecified;

--- a/docs/01-architecture/traceability.md
+++ b/docs/01-architecture/traceability.md
@@ -144,6 +144,26 @@ in [`views.md`](views.md).
 | --- | --- | --- | --- |
 | `ARCH-CICD-SUPPLYCHAIN` | The common lifecycle every change goes through, independent of workload class. | VIEW-CICD-SUPPLYCHAIN | VIEW-CICD-IAC |
 | `ARCH-CICD-IAC` | The infrastructure-specific pipeline — the only workload-class pipeline with real, running content today. | VIEW-CICD-IAC | — |
+| `ARCH-CICD-PLATFORM` | The platform-manifest → Flux pipeline shape ADR-0005 mandates; specifics PLANNED, I12. | VIEW-CICD-PLATFORM-GITOPS | VIEW-GOV-PLATFORM |
+| `ARCH-CICD-POLICY` | The policy → Kyverno/Cilium enforcement pipeline shape ADR-0004 mandates; specifics PLANNED, I14. | VIEW-CICD-POLICY | — |
+| `ARCH-CICD-NODE` | The Talos machine-config → talosctl pipeline shape (no SSH, ever); specifics PLANNED, I04. | VIEW-CICD-NODE-CONFIG | — |
+
+### Kubernetes
+
+| ID | Meaning | Primary View | Detail View |
+| --- | --- | --- | --- |
+| `ARCH-K8S-CONTROL` | Kubernetes control-plane placement (kube-apiserver, etcd) — Talos-hosted, network layer already Active. | VIEW-K8S-DEPLOYMENT | VIEW-NET-MANAGEMENT |
+| `ARCH-K8S-WORKER` | Kubernetes worker placement — Talos-hosted. | VIEW-K8S-DEPLOYMENT | VIEW-NET-WORKLOAD |
+| `ARCH-K8S-NETWORK` | The pod/service network layer Cilium owns, distinct from the OCI/node network beneath it. | VIEW-K8S-NETWORK | — |
+| `ARCH-K8S-NAMESPACE` | The namespace boundary concept — every concrete namespace remains a candidate pending I05. | VIEW-GOV-K8S-TENANCY | VIEW-K8S-SECURITY-BOUNDARIES |
+
+### Identity (Kubernetes/workload)
+
+| ID | Meaning | Primary View | Detail View |
+| --- | --- | --- | --- |
+| `ARCH-ID-SPIFFE` | A SPIFFE ID/SVID — the workload identity SPIRE issues, distinct from a Kubernetes ServiceAccount. | VIEW-ID-WORKLOAD | — |
+| `ARCH-ID-SA` | A Kubernetes ServiceAccount — contributes to SPIFFE attestation but is not the SPIFFE identity itself. | VIEW-ID-K8S-RBAC | VIEW-ID-WORKLOAD |
+| `ARCH-ID-RBAC` | The Kubernetes RBAC authorization mechanism (Role/RoleBinding/ClusterRole/ClusterRoleBinding). | VIEW-ID-K8S-RBAC | VIEW-GOV-K8S-TENANCY |
 
 This list grows only when a Spec needs a concept it doesn't already cover.
 Don't pre-mint IDs for initiatives that haven't reached specification depth

--- a/docs/01-architecture/views.md
+++ b/docs/01-architecture/views.md
@@ -279,6 +279,158 @@ maps to Specs and ARCH-* concept IDs.
 - **Related views:** VIEW-CICD-SUPPLYCHAIN
 - **Status:** Active
 
+### VIEW-K8S-DEPLOYMENT
+
+- **File:** `kubernetes/kubernetes-deployment.mmd`
+- **Level:** L2 — Domain Architecture (Kubernetes)
+- **Purpose:** What runs where inside the Kubernetes infrastructure?
+- **Audience:** Platform Engineers, autonomous agents implementing I04/I05.
+- **Scope:** Placement only. Talos control plane/workers (ADR-0002),
+  containerd (ADR-0002), OpenZiti private router (ADR-0003) are real;
+  Cilium/SPIRE/Flux/OpenBao/ESO/Kyverno are named in `roadmap.md`'s MVP
+  definition but not yet configured; cert-manager and a runtime-security
+  agent are named nowhere in this repo and shown as explicitly undecided.
+- **Out of scope:** Internal configuration of any subsystem — this is
+  placement, not application flow.
+- **Governing Specs:** none directly — ADR-0002, ADR-0003, ADR-0004,
+  ADR-0005, `docs/00-overview/roadmap.md`.
+- **Related views:** VIEW-K8S-RUNTIME, VIEW-NET-MANAGEMENT, VIEW-NET-WORKLOAD
+- **Status:** Active
+
+### VIEW-K8S-RUNTIME
+
+- **File:** `kubernetes/container-runtime.mmd`
+- **Level:** L3 — Component Detail
+- **Purpose:** What is the runtime hierarchy from kubelet to the OCI runtime?
+- **Audience:** Platform Engineers.
+- **Scope:** kubelet → containerd (ADR-0002) → runc, with youki shown as
+  the still-open `SPIKE-RT-01` alternative — never as an equivalent peer.
+- **Out of scope:** Kata/gVisor — zero evidence either is being considered.
+- **Governing Specs:** none directly — ADR-0002, `SPIKE-RT-01`.
+- **Related views:** VIEW-K8S-DEPLOYMENT
+- **Status:** Active
+
+### VIEW-K8S-NETWORK
+
+- **File:** `kubernetes/kubernetes-network.mmd`
+- **Level:** L2 — Domain Architecture (Kubernetes)
+- **Purpose:** How does traffic move through OCI, nodes, Cilium, services,
+  and workloads?
+- **Audience:** Platform/Security Engineers, autonomous agents implementing I07.
+- **Scope:** OCI/node/pod/service network kept as distinct layers; Cilium
+  named (roadmap.md); Pod/Service CIDR marked DECISION PENDING (no Spec
+  sets them); Hubble and Gateway API marked as zero-evidence candidates.
+  OpenZiti's identity overlay explicitly not conflated with Cilium identity.
+- **Out of scope:** OpenZiti policy internals (see VIEW-ID-ZITI).
+- **Governing Specs:** none directly — `docs/00-overview/roadmap.md`.
+- **Related views:** VIEW-ID-ZITI, VIEW-NET-OVERVIEW
+- **Status:** Active
+
+### VIEW-K8S-SECURITY-BOUNDARIES
+
+- **File:** `kubernetes/kubernetes-security-boundaries.mmd`
+- **Level:** L3 — Component Detail
+- **Purpose:** Where are the major Kubernetes security boundaries?
+- **Audience:** Security Engineers, future threat-model phase (EPIC-TM-01).
+- **Scope:** A boundary inventory (OCI VCN through runtime security),
+  each boundary labeled by its actual evidence status — not a
+  configuration.
+- **Out of scope:** Configuring any boundary — that's each owning Spec's job.
+- **Governing Specs:** SPEC-NET-* (transitively), ADR-0002/0003/0004.
+- **Related views:** VIEW-K8S-DEPLOYMENT, VIEW-K8S-NETWORK, VIEW-ID-K8S-RBAC
+- **Status:** Active
+
+### VIEW-ID-WORKLOAD
+
+- **File:** `identity/workload-identity.mmd`
+- **Level:** L2 — Domain Architecture (Identity)
+- **Purpose:** How does a Kubernetes workload obtain and use workload identity?
+- **Audience:** Security Engineers, autonomous agents implementing I09.
+- **Scope:** SPIFFE Trust Domain → SPIRE Server/Agent → attestation → SPIFFE
+  ID/SVID, named in `roadmap.md`'s MVP definition. ServiceAccount and Pod
+  shown contributing to attestation, never as the identity itself.
+  Cross-cluster federation marked DECISION PENDING (`SPIKE-SPIFFE-01`).
+- **Out of scope:** Kubernetes RBAC (see VIEW-ID-K8S-RBAC) — a
+  ServiceAccount is a separate principal from a SPIFFE ID.
+- **Governing Specs:** none directly — `docs/00-overview/roadmap.md`,
+  `SPIKE-SPIFFE-01`.
+- **Related views:** VIEW-ID-K8S-RBAC
+- **Status:** Active
+
+### VIEW-ID-K8S-RBAC
+
+- **File:** `identity/kubernetes-identity-rbac.mmd`
+- **Level:** L3 — Component Detail
+- **Purpose:** How are Kubernetes principals authorized?
+- **Audience:** Security Engineers, future IAM/RBAC-optimization phase.
+- **Scope:** The standard Kubernetes RBAC mechanism (OIDC subject/group and
+  ServiceAccount → RoleBinding → Role, plus cluster-scoped
+  ClusterRole/ClusterRoleBinding shown as visually distinct/privileged).
+  No concrete Role content exists — I05/I09/I10 unspec'd.
+- **Out of scope:** Which namespaces/roles actually exist (see
+  VIEW-GOV-K8S-TENANCY).
+- **Governing Specs:** none directly — standard Kubernetes RBAC applied to
+  this platform's named identity sources.
+- **Related views:** VIEW-ID-HUMAN, VIEW-ID-WORKLOAD, VIEW-GOV-K8S-TENANCY
+- **Status:** Active
+
+### VIEW-GOV-K8S-TENANCY
+
+- **File:** `governance/kubernetes-tenancy.mmd`
+- **Level:** L3 — Component Detail
+- **Purpose:** Where are namespace, policy, identity, and ownership boundaries?
+- **Audience:** Platform Engineers, future IAM/RBAC-optimization phase.
+- **Scope:** A candidate namespace taxonomy (none Spec'd — I05 has zero
+  depth) plus the generic per-namespace structure (ServiceAccount, RBAC,
+  NetworkPolicy, admission, quota, secrets, ownership) every real
+  namespace will carry once specified.
+- **Out of scope:** Asserting any namespace as decided.
+- **Governing Specs:** none — explicitly provisional pending I05.
+- **Related views:** VIEW-ID-K8S-RBAC, VIEW-K8S-SECURITY-BOUNDARIES
+- **Status:** Active
+
+### VIEW-CICD-PLATFORM-GITOPS
+
+- **File:** `cicd/platform-gitops-pipeline.mmd`
+- **Level:** L3 — Component Detail
+- **Purpose:** How does a platform-manifest change reach the cluster?
+- **Audience:** Platform Engineers, autonomous agents implementing I12.
+- **Scope:** The pipeline shape ADR-0005 already mandates (Flux
+  reconciles, GitHub Actions never deploys); every stage's specifics
+  (validation job, policy check, `platform/` layout) marked PLANNED.
+- **Out of scope:** Kyverno policy content (see VIEW-CICD-POLICY).
+- **Governing Specs:** none directly — ADR-0005.
+- **Related views:** VIEW-CICD-POLICY, VIEW-GOV-PLATFORM
+- **Status:** Active
+
+### VIEW-CICD-POLICY
+
+- **File:** `cicd/policy-pipeline.mmd`
+- **Level:** L3 — Component Detail
+- **Purpose:** How does a policy change reach enforcement?
+- **Audience:** Security Engineers, autonomous agents implementing I14.
+- **Scope:** Kyverno (ADR-0004) and Cilium policy (roadmap.md) named as
+  the engines; policy content, tests, and CI wiring all marked PLANNED.
+  Conftest/OPA not shown — zero evidence either is used in this repo.
+- **Out of scope:** Namespace-level policy assignment (see
+  VIEW-GOV-K8S-TENANCY).
+- **Governing Specs:** none directly — ADR-0004.
+- **Related views:** VIEW-CICD-PLATFORM-GITOPS
+- **Status:** Active
+
+### VIEW-CICD-NODE-CONFIG
+
+- **File:** `cicd/node-configuration-pipeline.mmd`
+- **Level:** L3 — Component Detail
+- **Purpose:** How is a Talos node configuration change applied safely?
+- **Audience:** Platform Engineers, autonomous agents implementing I04.
+- **Scope:** The pipeline shape ADR-0002's explicit "no SSH, only
+  talosctl" constraint mandates; every stage's specifics marked PLANNED.
+- **Out of scope:** Compute provisioning itself (see `SPEC-OCI-*`).
+- **Governing Specs:** none directly — ADR-0002, `CONTRIBUTING.md`.
+- **Related views:** VIEW-K8S-DEPLOYMENT
+- **Status:** Active
+
 ## Planned views
 
 Registered so they aren't reinvented ad hoc later, and so their absence is
@@ -287,22 +439,13 @@ reaches specification depth — see `docs/00-overview/roadmap.md`.
 
 | View ID | Domain | Owning initiative | Elaborated at |
 | --- | --- | --- | --- |
-| VIEW-ID-WORKLOAD | SPIFFE/SPIRE workload identity issuance/consumption | I09 | M4 |
-| VIEW-ID-K8S-RBAC | OIDC subject/ServiceAccount → RoleBinding → Role/ClusterRole | I05, I09, I10 | M2/M4 |
-| VIEW-GOV-K8S-TENANCY | Namespace boundaries, quotas, admission scope | I05 | M2 |
-| VIEW-K8S-DEPLOYMENT | What Kubernetes/platform component runs where | I04, I05, I06 | M2 |
-| VIEW-K8S-NETWORK | Cilium/CNI, Pod/Service CIDR, NetworkPolicy | I07 | M3 |
-| VIEW-K8S-SECURITY-BOUNDARIES | Cross-cutting K8s trust boundaries (depends on the four rows above existing first) | I05, I07, I09 | M3/M4 |
 | VIEW-SECURITY-ZTNA-POLICY | OpenZiti dial/bind/service policy objects (network-identity intersection is already Active — see VIEW-ID-ZITI) | I08 | M3 |
 | VIEW-SERVICE-MESH | Service mesh / mTLS layer ownership | **undecided — no initiative names this decision yet** | unscheduled |
 | VIEW-SECRETS | OpenBao, ESO, PKI | I11 | M4 |
 | VIEW-SECURITY-TRUST-BOUNDARIES | DFD-derived trust boundaries | I20 (EPIC-TM-01) | ongoing from M0, first artifact expected around M3 |
 | VIEW-STORAGE | Longhorn/SeaweedFS/backup topology | I15 | M6 |
 | VIEW-OBSERVABILITY | Metrics/logs/traces architecture | I16 | M7 |
-| VIEW-CICD-PLATFORM-GITOPS | Flux reconciliation pipeline | I12 | M5 |
 | VIEW-CICD-APPLICATION | Application container pipeline | **no owning initiative — this program's I01-I25 model has no application-workload initiative; may never apply unless one is added** | unscheduled |
-| VIEW-CICD-POLICY | Kyverno/Cilium/Conftest policy pipeline | I14 | M8 |
-| VIEW-CICD-NODE-CONFIG | Talos node configuration pipeline | I04 | M2 |
 | VIEW-CICD-SECURITY-CONTENT | Tetragon/Falco security-content pipeline | I17 | M7 |
 | VIEW-SUPPLY-CHAIN-CONTENT | SBOM/signing/provenance detail populating VIEW-CICD-SUPPLYCHAIN's already-scaffolded shape | I18 | M8 |
 | VIEW-HYBRID | Real DRG peering/routing once active | I21 | M11 |


### PR DESCRIPTION
## Summary

Stacked on #29 (Identity/Governance/CI-CD tranche) — this PR completes the second architecture tranche with Kubernetes Deployment, Kubernetes Networking, Kubernetes Security Boundaries, and the remaining identity/CI-CD pipeline views, per the required sequence: Cloud/Network → Identity/Governance/CI-CD (#29) → **Kubernetes Deployment/Network/Security** (this PR) → then DFDs.

10 new `mmdc`-validated views (26 total in the repo, all individually re-verified: 26 validated, 0 failed). Every view stays inside the evidence discipline established across this whole program:

- `kubernetes/kubernetes-deployment.mmd` — placement only; Talos/containerd/OpenZiti-private-router real (ADR-0002/0003), Cilium/SPIRE/Flux/OpenBao/ESO/Kyverno named in `roadmap.md`'s MVP definition but not configured, cert-manager/runtime-security-agent named nowhere and shown as explicitly undecided
- `kubernetes/container-runtime.mmd` — kubelet→containerd→runc, youki as the open `SPIKE-RT-01` alternative, never an equivalent peer
- `kubernetes/kubernetes-network.mmd` — OCI/node/pod/service network kept distinct; Pod/Service CIDR marked DECISION PENDING; Hubble/Gateway API marked zero-evidence
- `kubernetes/kubernetes-security-boundaries.mmd` — boundary inventory, each labeled by evidence status
- `identity/workload-identity.mmd` — SPIFFE/SPIRE; ServiceAccount/Pod explicitly NOT the SPIFFE identity itself; federation DECISION PENDING (`SPIKE-SPIFFE-01`)
- `identity/kubernetes-identity-rbac.mmd` — standard K8s RBAC mechanism, no concrete Role content invented
- `governance/kubernetes-tenancy.mmd` — every namespace marked CANDIDATE (none Spec'd, I05 has zero depth)
- `cicd/platform-gitops-pipeline.mmd`, `policy-pipeline.mmd`, `node-configuration-pipeline.mmd` — pipeline shape follows from an existing ADR, stage content marked PLANNED

New `docs/01-architecture/identity-reconciliation.md`: delivery identity matrix, governance matrix, and an explicit cross-domain reconciliation table (GitHub ↔ OCI IAM ↔ Human IdP ↔ OpenZiti ↔ Kubernetes API ↔ RBAC ↔ ServiceAccount ↔ SPIFFE ↔ OpenBao ↔ Flux) — same-principal or not, mapping mechanism if any, gap if none.

Promotes 9 rows from `views.md`'s Planned table to Active, extends `traceability.md` with 9 new ARCH-* IDs. `application-pipeline.mmd` deliberately **not** created — no owning initiative exists in the I01-I25 model for an application workload; flagged as a product-scope question, not fabricated.

## Validation

- [x] `mmdc` exit 0 on all 26 `.mmd` files, individually re-verified (26/26, 0 failed)
- [x] `markdownlint-cli2` clean
- [x] Commit GPG signed + DCO sign-off

## Impact

- [x] Architecture decision changed (Kubernetes/delivery view catalog extended)
- [ ] Threat model / trust boundaries / DFD / risk register affected
- [ ] New infrastructure state boundary introduced
- [ ] Credential, secret, or access policy touched
- [x] README / docs updated