### PR TITLE
feat: threat-model normalized corpus schema + network domain proof of concept

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,3 +47,16 @@ jobs:
           node-version: "22"
       - run: npm ci
       - run: npm run validate:mermaid
+
+  threat-model:
+    name: Threat-model corpus validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+      - run: npm ci
+      - run: npm run validate:threat-model

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,13 @@ repos:
         files: '\.mmd$'
         pass_filenames: true
 
+      - id: threat-model-validate
+        name: Threat-model corpus validation (schema + referential integrity)
+        entry: scripts/validate-threat-model.mjs
+        language: system
+        files: '^docs/03-threat-model/model/'
+        pass_filenames: false
+
       - id: check-dco
         name: Developer Certificate of Origin (Signed-off-by)
         entry: .githooks/commit-msg

--- a/docs/03-threat-model/README.md
+++ b/docs/03-threat-model/README.md
@@ -1,6 +1,33 @@
 # Threat model
 
-Status: not started — EPIC-TM-01 (I20) is Ready but not yet implemented.
+Status: Phase 3A in progress — EPIC-TM-01 (I20) is Ready. The pipeline
+below is followed in order; each phase is a distinct, reviewed step, not a
+single pass:
+
+```text
+Architecture corpus (docs/01-architecture/**, Specs, ADRs)
+      |
+      v
+model/ — normalized, schema-validated corpus       <- Phase 3A, in progress
+      |
+      v
+DFD L0 -> L1 -> L2/L3                               <- Phase 3A
+      |
+      v
+4 Questions Framework -> STRIDE (+ LINDDUN)          <- Phase 3B
+      |
+      v
+Attack Trees -> Attack Forest -> MITRE ATT&CK        <- Phase 3B
+      |
+      v
+Risk + Controls + Residual Risk                      <- Phase 3B
+      |
+      v
+IriusRisk validation/reconciliation                  <- Phase 3C
+      |
+      v
+IAM/PAM authorization graph -> RBAC + JIT + JEA       <- Phase 3C
+```
 
 ## Evidence chain
 
@@ -19,20 +46,40 @@ Nothing here may be invented ahead of evidence — no architecture, asset,
 threat, or control is recorded without a corresponding Spec, ADR, or
 diagram backing it.
 
-## First artifact (EPIC-TM-01)
+## Phase 3A: normalized model (in progress)
 
-A DFD L0/L1 derived directly from
-[`docs/arch/cloud-deployment.mmd`](../arch/cloud-deployment.mmd) and
-[ADR-0006](../02-decisions/ADR-0006-trust-zone-network-segmentation.md)'s
+See [`model/README.md`](model/README.md) for the full contract. The
+critical design goal: DFDs and every later phase (STRIDE, attack trees,
+MITRE mapping, IriusRisk, IAM/PAM) are generated from
+`model/instances/*.yaml`, not by re-interpreting the 26 Mermaid views from
+scratch each time — that reinterpretation happens exactly once, here,
+schema-validated and evidence-checked.
+
+Status: schema (`model/schema/threat-model.schema.json`) and tooling
+(`npm run validate:threat-model`) built and validated against one domain
+(`model/instances/network.yaml`) as a proof of concept. Remaining domains
+(`identity`, `governance`, `cicd`, `kubernetes`, `context`) and DFD L0-L3
+generation from the corpus come next.
+
+## First DFD artifact (EPIC-TM-01)
+
+A DFD L0/L1 derived from the normalized corpus above (not directly from
+Mermaid), covering [ADR-0006](../02-decisions/ADR-0006-trust-zone-network-segmentation.md)'s
 four trust zones (Edge / Management / Workload / Data). `SPEC-NET-004.md`
-(Security Lists + NSGs) is the first Spec expected to feed this directly —
-its Threat Model Impact section names the trust boundaries it establishes.
+(Security Lists + NSGs) is the first Spec feeding this directly — its
+Threat Model Impact section names the trust boundaries it establishes.
 
 ## Structure (once populated)
 
+- `model/` — Phase 3A normalized corpus (schema + instances).
 - `dfd-l0.md` — system context.
 - `dfd-l1.md` — trust-zone-level data flows.
+- `dfd-l2-l3.md` — component/zone-detail flows.
 - `trust-boundaries.md` — the boundary list ADR-0006 establishes.
-- `threats.md` — STRIDE inventory per boundary.
-- `attack-paths.md` — validated attack paths, not hypothetical ones.
-- `risk-register.md` — risk, control, residual risk per threat.
+- `threats.md` — STRIDE (+ LINDDUN) inventory per boundary — Phase 3B.
+- `attack-trees.md`, `attack-forest.md` — Phase 3B.
+- `mitre-attack-mapping.md` — Phase 3B.
+- `attack-paths.md` — validated attack paths, not hypothetical ones — Phase 3B.
+- `risk-register.md` — risk, control, residual risk per threat — Phase 3B.
+- `iriusrisk-reconciliation.md` — Phase 3C.
+- `iam-pam-graph.md` — RBAC/JIT/JEA derivation — Phase 3C.

--- a/docs/03-threat-model/model/README.md
+++ b/docs/03-threat-model/model/README.md
@@ -1,0 +1,111 @@
+# Threat-model normalized corpus
+
+A machine-readable, schema-validated representation of the architecture,
+normalized once from the 26 Mermaid views + Specs + ADRs so that every
+downstream artifact (DFDs, STRIDE/LINDDUN analysis, attack trees, MITRE
+ATT&CK mapping, IriusRisk reconciliation, the IAM/PAM/RBAC/JIT/JEA
+authorization graph) is generated **from this corpus**, not by
+re-interpreting the architecture documentation from scratch each time.
+
+```text
+docs/01-architecture/**/*.mmd, docs/specs/*.md, docs/02-decisions/*.md
+             │  (normalized once, by hand, evidence-checked)
+             ▼
+docs/03-threat-model/model/instances/*.yaml   <- THIS is the source of truth
+   (validated against schema/threat-model.schema.json)
+             │
+             ▼
+DFD L0-L3, STRIDE/LINDDUN, attack trees, MITRE mapping, IriusRisk, IAM/PAM
+```
+
+Mermaid becomes a **projection** of this model for DFDs, the same
+relationship `docs/01-architecture/traceability.md` already establishes
+between Specs and architecture diagrams.
+
+## Why this exists
+
+Without a normalized intermediate model, generating a DFD or an attack tree
+requires re-reading and re-interpreting 26 Mermaid files plus a dozen Specs
+and ADRs every time — a process with no determinism guarantee. Two
+generation passes over the same architecture could produce different trust
+boundaries, different flow lists, or a different IAM graph, and nothing
+would catch the drift. This corpus exists to make that reinterpretation
+happen exactly once, in a structured, schema-validated, evidence-checked
+form that every later phase reads instead of the raw architecture docs.
+
+## Layout
+
+- `schema/threat-model.schema.json` — versioned JSON Schema (draft
+  2020-12), the contract every instance file must satisfy.
+- `instances/<domain>.yaml` — one file per architecture domain, mirroring
+  `docs/01-architecture/<domain>/`: `context`, `network`, `identity`,
+  `governance`, `cicd`, `kubernetes`.
+
+## Element types
+
+`trust_zones`, `trust_boundaries`, `actors`, `identities`, `processes`,
+`data_stores`, `assets`, `data_flows` — the standard DFD/STRIDE element set,
+plus `identities` (distinct from `actors` — see
+[identity-reconciliation.md](../../01-architecture/identity-reconciliation.md)
+for why a GitHub identity, an OCI IAM principal, and a Kubernetes
+ServiceAccount are not assumed to be the same principal) and `assets` (for
+confidentiality/integrity/availability requirements independent of any
+single flow).
+
+## ID conventions
+
+- **Reuse, don't duplicate**: where a corpus element is a genuine 1:1 match
+  for an existing stable concept, its `id` **is** that concept's ID —
+  `trust_zones[].id` is always an `ARCH-ZONE-*` ID, and
+  `trust_boundaries[].id` is an `ARCH-OCI-*`/`ARCH-NET-*` ID where one
+  already exists (falling back to a new `TB-*` ID otherwise). This is a
+  hard requirement, not a convention to relax under time pressure — a
+  duplicate ID for the same concept is exactly the drift this corpus
+  exists to prevent.
+- **Mint + cite**: `actors`, `identities`, `processes`, `data_stores`,
+  `assets`, and `data_flows` don't generally have a pre-existing ARCH-* ID
+  (they're finer-grained than the architecture vocabulary), so they get a
+  new type-prefixed ID (`ACTOR-`, `IDENT-`, `PROC-`, `DS-`, `ASSET-`,
+  `FLOW-`) and cite any related `ARCH-*` concept through an `evidence`
+  entry (`source_type: arch-view`) instead.
+
+## Evidence discipline
+
+Every element requires `evidence: [...]` with at least one entry — the
+same rule `docs/01-architecture/traceability.md` enforces for diagrams,
+applied to this corpus. `evidence[].status` is one of:
+
+| Status | Meaning |
+| --- | --- |
+| `implemented` | Actually running (`infrastructure/` applied). None of this repo yet — it's greenfield. |
+| `specified` | An approved (Ready/Accepted) Spec or ADR covers it, not yet built. |
+| `planned` | Named in `roadmap.md`, no Spec yet. |
+| `candidate` | Plausible but not confirmed anywhere — flag, don't assert. |
+| `decision-pending` | Tied to an open SPIKE or an explicitly-marked open decision point in a view. |
+
+A `port`, `protocol`, or other field that is genuinely undecided in the
+architecture (e.g. Edge-zone ingress technology) is recorded as an
+explicit string describing the gap (`"undecided — ..."`), never a plausible
+guess. This mirrors `edge-zone.mmd`'s own practice of marking that decision
+open rather than inventing an ingress technology.
+
+## Validation
+
+```sh
+npm run validate:threat-model
+```
+
+Validates every `instances/*.yaml` against the schema, then checks
+corpus-wide referential integrity: no duplicate IDs across files, and every
+`*_ref` field resolves to a real corpus ID, a known `ARCH-*` concept (read
+live from `traceability.md`, not a separately-maintained copy that could
+drift), or the literal `EXTERNAL`. See the script's header comment
+(`scripts/validate-threat-model.mjs`) for its one documented limitation:
+ref resolution checks existence, not type.
+
+## Status
+
+`network.yaml` is the only populated instance so far — a proof of concept
+for the schema and tooling before scaling to the remaining five domains.
+See `docs/03-threat-model/README.md` for where this fits in the overall
+threat-modeling sequence.

--- a/docs/03-threat-model/model/instances/network.yaml
+++ b/docs/03-threat-model/model/instances/network.yaml
@@ -1,0 +1,441 @@
+domain: network
+model_version: 0.1.0
+generated_from:
+  - source_type: arch-view
+    ref: VIEW-NET-OVERVIEW
+    status: specified
+  - source_type: arch-view
+    ref: VIEW-NET-TRAFFIC
+    status: specified
+  - source_type: spec
+    ref: SPEC-NET-001.md
+    status: specified
+  - source_type: spec
+    ref: SPEC-NET-002.md
+    status: specified
+  - source_type: spec
+    ref: SPEC-NET-004.md
+    status: specified
+  - source_type: adr
+    ref: ADR-0003
+    status: specified
+  - source_type: adr
+    ref: ADR-0006
+    status: specified
+
+trust_zones:
+  - id: ARCH-ZONE-EDGE
+    name: Edge zone
+    description: Public-facing subnet — the only zone permitted a public IP.
+    network_cidr: 10.10.10.0/24
+    public_ip_allowed: true
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-001.md", status: specified }
+      - { source_type: adr, ref: ADR-0006, status: specified }
+
+  - id: ARCH-ZONE-MGMT
+    name: Management zone
+    description: Control-plane/administrative subnet — Kubernetes API, etcd, Ziti private router.
+    network_cidr: 10.10.20.0/24
+    public_ip_allowed: false
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-001.md", status: specified }
+      - { source_type: adr, ref: ADR-0006, status: specified }
+
+  - id: ARCH-ZONE-WORKLOAD
+    name: Workload zone
+    description: Talos worker subnet.
+    network_cidr: 10.10.30.0/24
+    public_ip_allowed: false
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-001.md", status: specified }
+      - { source_type: adr, ref: ADR-0006, status: specified }
+
+  - id: ARCH-ZONE-DATA
+    name: Data zone
+    description: Storage/backup subnet.
+    network_cidr: 10.10.40.0/24
+    public_ip_allowed: false
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-001.md", status: specified }
+      - { source_type: adr, ref: ADR-0006, status: specified }
+
+trust_boundaries:
+  - id: ARCH-OCI-TENANCY
+    name: OCI tenancy boundary
+    description: The OCI tenancy as the outermost structural/administrative boundary.
+    boundary_type: administrative-domain
+    separates: ["EXTERNAL", "ARCH-OCI-COMPARTMENT"]
+    evidence:
+      - { source_type: arch-view, ref: VIEW-NET-OVERVIEW, status: specified }
+
+  - id: ARCH-OCI-COMPARTMENT
+    name: Platform compartment boundary
+    description: Isolates platform resources from the tenancy root via compartment-scoped IAM policy.
+    boundary_type: administrative-domain
+    separates: ["ARCH-OCI-TENANCY", "ARCH-NET-VCN"]
+    evidence:
+      - { source_type: arch-view, ref: VIEW-NET-OVERVIEW, status: specified }
+      - { source_type: spec, ref: "SPEC-OCI-001.md", status: specified }
+
+  - id: ARCH-NET-VCN
+    name: VCN perimeter
+    description: The platform VCN (10.10.0.0/16) as a network security perimeter around all four trust zones.
+    boundary_type: network-perimeter
+    separates: ["ARCH-OCI-COMPARTMENT", "ARCH-ZONE-EDGE", "ARCH-ZONE-MGMT", "ARCH-ZONE-WORKLOAD", "ARCH-ZONE-DATA"]
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-001.md", status: specified }
+
+  - id: TB-INTERNET-EDGE
+    name: Internet-to-Edge boundary
+    description: The Internet Gateway — the only path from the public internet into the VCN, terminating in the Edge zone.
+    boundary_type: network-perimeter
+    separates: ["EXTERNAL", "ARCH-ZONE-EDGE"]
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
+      - { source_type: arch-view, ref: ARCH-GW-IGW, status: specified }
+
+  - id: TB-ZONE-ISOLATION
+    name: Inter-zone isolation boundary
+    description: NSG/Security-List-enforced isolation between the four trust zones — the control NSG's 6443 restriction (REQ-NET-019) is the security-critical instance of this boundary.
+    boundary_type: network-perimeter
+    separates: ["ARCH-ZONE-EDGE", "ARCH-ZONE-MGMT", "ARCH-ZONE-WORKLOAD", "ARCH-ZONE-DATA"]
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-018", status: specified }
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-020", status: specified }
+
+actors:
+  - id: ACTOR-ADMINISTRATOR
+    name: Platform administrator
+    actor_type: human
+    description: >-
+      The sole human actor with administrative access to the Kubernetes API.
+      Reaches it only via OpenZiti — never a direct network path (ADR-0003).
+    identity_refs: ["IDENT-ZITI-ADMIN"]
+    evidence:
+      - { source_type: adr, ref: ADR-0003, status: specified }
+      - { source_type: arch-view, ref: ARCH-FLOW-ADMIN, status: specified }
+
+identities:
+  - id: IDENT-ZITI-ADMIN
+    name: Administrator OpenZiti identity
+    system: openziti
+    class_ref: ARCH-ID-ZITI
+    principal_type: user
+    description: >-
+      The OpenZiti identity a dial/bind policy authorizes to reach the
+      Kubernetes API via the Ziti private router. OpenZiti application
+      configuration itself (enrollment, specific dial/bind policy content)
+      is out of scope for I03/SPEC-NET-004 — owned by I08, not yet at Spec
+      depth (roadmap.md).
+    evidence:
+      - { source_type: adr, ref: ADR-0003, status: specified }
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
+      - { source_type: roadmap, ref: "roadmap.md#I08", status: planned }
+
+processes:
+  - id: PROC-ZITI-PUBLIC-ROUTER
+    name: OpenZiti public edge router
+    description: >-
+      Internet-facing OpenZiti fabric ingress point in the Edge zone. Router
+      placement/existence is named by ADR-0003 and docs/arch/cloud-deployment.mmd;
+      OpenZiti-specific configuration is owned by I08, not yet Spec'd.
+    trust_zone_ref: ARCH-ZONE-EDGE
+    evidence:
+      - { source_type: adr, ref: ADR-0003, status: specified }
+      - { source_type: roadmap, ref: "roadmap.md#I08", status: planned }
+
+  - id: PROC-ZITI-PRIVATE-ROUTER
+    name: OpenZiti private router
+    description: >-
+      Management-zone OpenZiti router the public router's fabric hands
+      administrative traffic to before it reaches the Kubernetes API.
+    trust_zone_ref: ARCH-ZONE-MGMT
+    evidence:
+      - { source_type: adr, ref: ADR-0003, status: specified }
+      - { source_type: roadmap, ref: "roadmap.md#I08", status: planned }
+
+  - id: PROC-KUBE-APISERVER
+    name: kube-apiserver
+    description: >-
+      Kubernetes API server — Talos-hosted control-plane process in the
+      Management zone. This file specifies its network-layer placement and
+      ingress restriction only; the Kubernetes bootstrap itself is I05,
+      not yet at Spec depth.
+    trust_zone_ref: ARCH-ZONE-MGMT
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
+      - { source_type: arch-view, ref: ARCH-K8S-CONTROL, status: specified }
+      - { source_type: roadmap, ref: "roadmap.md#I05", status: planned }
+
+  - id: PROC-WORKER-NODE
+    name: Talos worker node
+    description: >-
+      Talos worker in the Workload zone. Must reach kube-apiserver on 6443
+      (kubelet, kube-proxy, and other node components) — the reason the
+      control NSG permits the worker NSG on that port (REQ-NET-019).
+    trust_zone_ref: ARCH-ZONE-WORKLOAD
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
+      - { source_type: arch-view, ref: ARCH-K8S-WORKER, status: specified }
+
+  - id: PROC-INTERNET-GATEWAY
+    name: Internet Gateway
+    description: Edge zone's sole internet-facing ingress point.
+    trust_zone_ref: ARCH-NET-VCN
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
+      - { source_type: arch-view, ref: ARCH-GW-IGW, status: specified }
+
+  - id: PROC-NAT-GATEWAY
+    name: NAT Gateway
+    description: Private egress for Management/Workload/Data zones.
+    trust_zone_ref: ARCH-NET-VCN
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
+      - { source_type: arch-view, ref: ARCH-GW-NAT, status: specified }
+
+  - id: PROC-SERVICE-GATEWAY
+    name: Service Gateway
+    description: Private OCI service access for all four zones (Object Storage, KMS, Logging, Monitoring).
+    trust_zone_ref: ARCH-NET-VCN
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
+      - { source_type: arch-view, ref: ARCH-GW-SGW, status: specified }
+
+assets:
+  - id: ASSET-K8S-API-ACCESS
+    name: Kubernetes API administrative access
+    asset_type: credential
+    confidentiality: high
+    integrity: high
+    availability: moderate
+    description: >-
+      The combination of Ziti dial/bind authorization plus whatever
+      Kubernetes-side credential is presented after the Ziti hop. REQ-NET-019
+      is the network-layer control protecting this asset; the credential
+      material itself (kubeconfig, OIDC token, etc.) is owned by I09/I10,
+      not yet Spec'd.
+    owner_refs: ["ACTOR-ADMINISTRATOR"]
+    evidence:
+      - { source_type: adr, ref: ADR-0003, status: specified }
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
+
+data_flows:
+  - id: FLOW-INTERNET-TO-IGW
+    name: Internet ingress to Internet Gateway
+    description: Public internet traffic entering via the Internet Gateway toward Edge-zone application ingress.
+    source_ref: EXTERNAL
+    destination_ref: PROC-INTERNET-GATEWAY
+    protocol: IP
+    port: "undecided — ingress technology/application ports not yet chosen (edge-zone.mmd marks this an open decision point; SPEC-NET-004 REQ-NET-020 scopes the ingress NSG to 'its documented application ports', not yet documented)"
+    direction: inbound
+    authentication: none
+    authorization: nsg-security-list
+    confidentiality_requirement: low
+    integrity_requirement: moderate
+    crosses_boundary_refs: ["TB-INTERNET-EDGE"]
+    traffic_class_ref: ARCH-FLOW-INGRESS
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-020", status: specified }
+      - { source_type: arch-view, ref: ARCH-FLOW-INGRESS, status: specified }
+
+  - id: FLOW-IGW-TO-EDGE-INGRESS
+    name: Internet Gateway to Edge application ingress
+    description: >-
+      Edge-zone application ingress. No specific ingress process (load
+      balancer, reverse proxy, etc.) is named yet — edge-zone.mmd marks the
+      ingress technology itself as an open decision point, so this flow
+      terminates at the zone rather than an invented process.
+    source_ref: PROC-INTERNET-GATEWAY
+    destination_ref: ARCH-ZONE-EDGE
+    protocol: IP
+    port: "undecided — see FLOW-INTERNET-TO-IGW"
+    direction: inbound
+    authentication: none
+    authorization: nsg-security-list
+    confidentiality_requirement: low
+    integrity_requirement: moderate
+    traffic_class_ref: ARCH-FLOW-INGRESS
+    evidence:
+      - { source_type: arch-view, ref: ARCH-FLOW-INGRESS, status: specified }
+      - { source_type: arch-view, ref: ARCH-ZONE-EDGE, status: decision-pending }
+
+  - id: FLOW-ADMIN-01-ADMIN-TO-PUBLIC-ROUTER
+    name: Administrator to Ziti public router
+    description: Administrator's Ziti client dials the public edge router.
+    source_ref: ACTOR-ADMINISTRATOR
+    destination_ref: PROC-ZITI-PUBLIC-ROUTER
+    protocol: TLS
+    port: 443
+    direction: inbound
+    authentication: mtls
+    authorization: openziti-policy
+    data_asset_refs: ["ASSET-K8S-API-ACCESS"]
+    confidentiality_requirement: high
+    integrity_requirement: high
+    crosses_boundary_refs: ["TB-INTERNET-EDGE"]
+    traffic_class_ref: ARCH-FLOW-ADMIN
+    evidence:
+      - { source_type: adr, ref: ADR-0003, status: specified }
+      - { source_type: arch-view, ref: ARCH-FLOW-ADMIN, status: specified }
+
+  - id: FLOW-ADMIN-02-FABRIC
+    name: Ziti public router to private router (fabric)
+    description: OpenZiti fabric carries the session from the public router to the private router, crossing from Edge into Management.
+    source_ref: PROC-ZITI-PUBLIC-ROUTER
+    destination_ref: PROC-ZITI-PRIVATE-ROUTER
+    protocol: TLS
+    port: "fabric-internal — not a fixed documented port"
+    direction: bidirectional
+    authentication: mtls
+    authorization: openziti-policy
+    data_asset_refs: ["ASSET-K8S-API-ACCESS"]
+    confidentiality_requirement: high
+    integrity_requirement: high
+    crosses_boundary_refs: ["TB-ZONE-ISOLATION"]
+    traffic_class_ref: ARCH-FLOW-ADMIN
+    evidence:
+      - { source_type: adr, ref: ADR-0003, status: specified }
+      - { source_type: arch-view, ref: ARCH-FLOW-ADMIN, status: specified }
+
+  - id: FLOW-ADMIN-03-PRIVATE-ROUTER-TO-API
+    name: Ziti private router to kube-apiserver
+    description: The only path to the Kubernetes API's administrative surface — REQ-NET-019's ziti-NSG allowance.
+    source_ref: PROC-ZITI-PRIVATE-ROUTER
+    destination_ref: PROC-KUBE-APISERVER
+    protocol: HTTPS
+    port: 6443
+    direction: outbound
+    authentication: mtls
+    authorization: nsg-security-list
+    data_asset_refs: ["ASSET-K8S-API-ACCESS"]
+    confidentiality_requirement: high
+    integrity_requirement: high
+    traffic_class_ref: ARCH-FLOW-ADMIN
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
+      - { source_type: adr, ref: ADR-0003, status: specified }
+
+  - id: FLOW-CONTROL-WORKER-TO-API
+    name: Worker node to kube-apiserver
+    description: >-
+      kubelet/kube-proxy on Talos workers reaching the API server — the
+      worker-NSG allowance in REQ-NET-019, the other legitimate 6443 source.
+    source_ref: PROC-WORKER-NODE
+    destination_ref: PROC-KUBE-APISERVER
+    protocol: HTTPS
+    port: 6443
+    direction: bidirectional
+    authentication: kubeconfig-cert
+    authorization: nsg-security-list
+    confidentiality_requirement: high
+    integrity_requirement: high
+    crosses_boundary_refs: ["TB-ZONE-ISOLATION"]
+    traffic_class_ref: ARCH-FLOW-CONTROL
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
+      - { source_type: arch-view, ref: ARCH-FLOW-CONTROL, status: specified }
+
+  - id: FLOW-EGRESS-WORKLOAD-TO-NAT
+    name: Workload-zone egress to NAT Gateway
+    description: >-
+      Representative of the EGRESS traffic class, which also covers
+      Management- and Data-zone nodes reaching the internet via the same
+      NAT Gateway (traffic-flows.mmd draws these as one class; modeled here
+      as the Workload-zone instance, the dominant case — e.g. pulling
+      container images).
+    source_ref: ARCH-ZONE-WORKLOAD
+    destination_ref: PROC-NAT-GATEWAY
+    protocol: IP
+    port: "any (outbound only)"
+    direction: outbound
+    authentication: none
+    authorization: nsg-security-list
+    confidentiality_requirement: low
+    integrity_requirement: low
+    traffic_class_ref: ARCH-FLOW-EGRESS
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
+      - { source_type: arch-view, ref: ARCH-FLOW-EGRESS, status: specified }
+
+  - id: FLOW-NAT-TO-INTERNET
+    name: NAT Gateway to internet
+    description: Egress traffic's final hop to the public internet.
+    source_ref: PROC-NAT-GATEWAY
+    destination_ref: EXTERNAL
+    protocol: IP
+    port: "any (outbound only)"
+    direction: outbound
+    authentication: none
+    authorization: nsg-security-list
+    confidentiality_requirement: low
+    integrity_requirement: low
+    crosses_boundary_refs: ["TB-INTERNET-EDGE"]
+    traffic_class_ref: ARCH-FLOW-EGRESS
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
+
+  - id: FLOW-SERVICE-ANY-ZONE-TO-SGW
+    name: Any zone to Service Gateway
+    description: >-
+      Representative of the SERVICE traffic class (any zone reaching OCI
+      services privately). Modeled as the Management-zone instance since
+      OCI Vault/KMS access (I11, not yet Spec'd) is its most security-relevant use.
+    source_ref: ARCH-ZONE-MGMT
+    destination_ref: PROC-SERVICE-GATEWAY
+    protocol: HTTPS
+    port: 443
+    direction: outbound
+    authentication: oci-signing-key
+    authorization: oci-iam-policy
+    confidentiality_requirement: moderate
+    integrity_requirement: moderate
+    traffic_class_ref: ARCH-FLOW-SERVICE
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
+      - { source_type: arch-view, ref: ARCH-FLOW-SERVICE, status: specified }
+
+  - id: FLOW-BACKUP-DATA-TO-SGW
+    name: Data-zone backup to Service Gateway
+    description: >-
+      Data-zone volumes to the (not yet Spec'd, I19/M9) backup endpoint via
+      the Service Gateway to OCI Object Storage.
+    source_ref: ARCH-ZONE-DATA
+    destination_ref: PROC-SERVICE-GATEWAY
+    protocol: HTTPS
+    port: 443
+    direction: outbound
+    authentication: oci-signing-key
+    authorization: oci-iam-policy
+    confidentiality_requirement: high
+    integrity_requirement: high
+    traffic_class_ref: ARCH-FLOW-BACKUP
+    evidence:
+      - { source_type: arch-view, ref: ARCH-FLOW-BACKUP, status: specified }
+      - { source_type: arch-view, ref: ARCH-SVC-BACKUP-BUCKET, status: planned }
+      - { source_type: roadmap, ref: "roadmap.md#I19", status: planned }
+
+  - id: FLOW-HYBRID-VCN-TO-DRG
+    name: VCN to DRG (reserved, inert)
+    description: >-
+      Reserved hybrid-connectivity path. The DRG is provisioned with an
+      empty route table and propagation disabled (ADR-0008) — this flow
+      does not carry traffic until I21, explicitly deferred past the MVP
+      boundary.
+    source_ref: ARCH-NET-VCN
+    destination_ref: EXTERNAL
+    protocol: unknown
+    port: "n/a — inert"
+    direction: outbound
+    authentication: none
+    authorization: none
+    confidentiality_requirement: none
+    integrity_requirement: none
+    traffic_class_ref: ARCH-FLOW-HYBRID
+    evidence:
+      - { source_type: adr, ref: ADR-0008, status: specified }
+      - { source_type: arch-view, ref: ARCH-FLOW-HYBRID, status: decision-pending }
+      - { source_type: roadmap, ref: "roadmap.md#I21", status: decision-pending }

--- a/docs/03-threat-model/model/schema/threat-model.schema.json
+++ b/docs/03-threat-model/model/schema/threat-model.schema.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://oracle-free-tier-platform.internal/schemas/threat-model/v1/threat-model.schema.json",
+  "title": "Threat-model normalized corpus (v1)",
+  "description": "One instance document per architecture domain (network, identity, governance, cicd, kubernetes, context). Every element requires >=1 evidence entry — this schema enforces the same 'no invented content' discipline as docs/01-architecture: an element with no Spec/ADR/ARCH-view/roadmap backing must be marked evidence.status=decision-pending or candidate, never asserted as fact.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["domain", "model_version", "generated_from"],
+  "properties": {
+    "domain": {
+      "type": "string",
+      "enum": ["context", "network", "identity", "governance", "cicd", "kubernetes"],
+      "description": "Mirrors the docs/01-architecture/<domain>/ directory this instance was derived from."
+    },
+    "model_version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$",
+      "description": "Semver for this instance file's content. Bump minor on additive changes, major on a breaking rename/removal of a stable ID."
+    },
+    "generated_from": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/evidence" },
+      "description": "Which architecture views/Specs/ADRs this file was normalized from, at the file level."
+    },
+    "trust_zones": { "type": "array", "items": { "$ref": "#/$defs/trustZone" }, "default": [] },
+    "trust_boundaries": { "type": "array", "items": { "$ref": "#/$defs/trustBoundary" }, "default": [] },
+    "actors": { "type": "array", "items": { "$ref": "#/$defs/actor" }, "default": [] },
+    "identities": { "type": "array", "items": { "$ref": "#/$defs/identity" }, "default": [] },
+    "processes": { "type": "array", "items": { "$ref": "#/$defs/process" }, "default": [] },
+    "data_stores": { "type": "array", "items": { "$ref": "#/$defs/dataStore" }, "default": [] },
+    "assets": { "type": "array", "items": { "$ref": "#/$defs/asset" }, "default": [] },
+    "data_flows": { "type": "array", "items": { "$ref": "#/$defs/dataFlow" }, "default": [] }
+  },
+  "$defs": {
+    "ciaLevel": {
+      "type": "string",
+      "enum": ["none", "low", "moderate", "high"]
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_type", "ref", "status"],
+      "properties": {
+        "source_type": {
+          "type": "string",
+          "enum": ["spec", "adr", "arch-view", "roadmap", "contributing", "security-md"]
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "e.g. 'SPEC-NET-004.md#REQ-NET-019', 'ADR-0003', 'ARCH-FLOW-ADMIN', 'roadmap.md#I05'."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["implemented", "specified", "planned", "candidate", "decision-pending"]
+        }
+      }
+    },
+    "trustZone": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "description", "public_ip_allowed", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^ARCH-ZONE-[A-Z0-9-]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "network_cidr": { "type": "string" },
+        "public_ip_allowed": { "type": "boolean" },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    },
+    "trustBoundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "description", "boundary_type", "separates", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^(ARCH-[A-Z0-9-]+|TB-[A-Z0-9-]+)$" },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "boundary_type": {
+          "type": "string",
+          "enum": ["network-perimeter", "identity-domain", "administrative-domain", "physical", "other"]
+        },
+        "separates": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "IDs (or the literal 'EXTERNAL' for outside-the-system) on each side of the boundary."
+        },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    },
+    "actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "actor_type", "description", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^ACTOR-[A-Z0-9-]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "actor_type": { "type": "string", "enum": ["human", "external-system", "automated-agent"] },
+        "description": { "type": "string", "minLength": 1 },
+        "identity_refs": { "type": "array", "items": { "type": "string", "pattern": "^IDENT-[A-Z0-9-]+$" }, "default": [] },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "system", "principal_type", "description", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^IDENT-[A-Z0-9-]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "system": {
+          "type": "string",
+          "enum": ["github", "oci-iam", "human-idp", "openziti", "kubernetes-rbac", "kubernetes-serviceaccount", "spiffe", "openbao", "flux", "other"]
+        },
+        "class_ref": { "type": "string", "pattern": "^ARCH-ID-[A-Z0-9-]+$", "description": "The ARCH-ID-* conceptual identity class this is an instance of, if one exists." },
+        "principal_type": { "type": "string", "enum": ["user", "service", "machine", "group", "role"] },
+        "maps_to": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["identity_ref", "mapping_mechanism", "same_principal"],
+            "properties": {
+              "identity_ref": { "type": "string", "pattern": "^IDENT-[A-Z0-9-]+$" },
+              "mapping_mechanism": { "type": "string", "minLength": 1, "description": "HOW they map — never leave implicit." },
+              "same_principal": { "type": "boolean", "description": "false = federated/related but deliberately NOT the same principal." }
+            }
+          },
+          "default": []
+        },
+        "description": { "type": "string", "minLength": 1 },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    },
+    "process": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "description", "trust_zone_ref", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^PROC-[A-Z0-9-]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "trust_zone_ref": { "type": "string", "description": "ARCH-ZONE-* id, or 'EXTERNAL' if outside all modeled zones." },
+        "owner_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    },
+    "dataStore": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "description", "trust_zone_ref", "data_classification", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^DS-[A-Z0-9-]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "trust_zone_ref": { "type": "string" },
+        "data_classification": { "type": "string", "enum": ["public", "internal", "confidential", "secret"] },
+        "asset_refs": { "type": "array", "items": { "type": "string", "pattern": "^ASSET-[A-Z0-9-]+$" }, "default": [] },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    },
+    "asset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "asset_type", "confidentiality", "integrity", "availability", "description", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^ASSET-[A-Z0-9-]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "asset_type": {
+          "type": "string",
+          "enum": ["data", "credential", "compute", "network-config", "container-image", "source-code", "other"]
+        },
+        "confidentiality": { "$ref": "#/$defs/ciaLevel" },
+        "integrity": { "$ref": "#/$defs/ciaLevel" },
+        "availability": { "$ref": "#/$defs/ciaLevel" },
+        "owner_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "description": { "type": "string", "minLength": 1 },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    },
+    "dataFlow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id", "name", "description", "source_ref", "destination_ref", "protocol", "direction",
+        "authentication", "authorization", "confidentiality_requirement", "integrity_requirement", "evidence"
+      ],
+      "properties": {
+        "id": { "type": "string", "pattern": "^FLOW-[A-Z0-9-]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "source_ref": { "type": "string", "minLength": 1 },
+        "destination_ref": { "type": "string", "minLength": 1 },
+        "protocol": { "type": "string", "minLength": 1 },
+        "port": { "anyOf": [{ "type": "integer", "minimum": 0, "maximum": 65535 }, { "type": "string" }] },
+        "direction": { "type": "string", "enum": ["inbound", "outbound", "bidirectional"] },
+        "authentication": {
+          "type": "string",
+          "enum": ["none", "mtls", "oidc-token", "ssh-key", "oci-signing-key", "spiffe-svid", "gpg-signature", "kubeconfig-cert", "other"]
+        },
+        "authorization": {
+          "type": "string",
+          "enum": ["none", "oci-iam-policy", "kubernetes-rbac", "nsg-security-list", "kyverno-policy", "openziti-policy", "github-branch-protection", "other"]
+        },
+        "data_asset_refs": { "type": "array", "items": { "type": "string", "pattern": "^ASSET-[A-Z0-9-]+$" }, "default": [] },
+        "confidentiality_requirement": { "$ref": "#/$defs/ciaLevel" },
+        "integrity_requirement": { "$ref": "#/$defs/ciaLevel" },
+        "crosses_boundary_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "traffic_class_ref": { "type": "string", "pattern": "^ARCH-FLOW-[A-Z0-9-]+$" },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,9 @@
     "": {
       "name": "oracle-free-tier-platform-docs",
       "devDependencies": {
-        "@mermaid-js/mermaid-cli": "11.16.0"
+        "@mermaid-js/mermaid-cli": "11.16.0",
+        "ajv": "8.20.0",
+        "js-yaml": "5.3.0"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -1023,6 +1025,23 @@
         }
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
@@ -1060,6 +1079,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
@@ -1830,6 +1856,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1942,6 +1992,36 @@
           "optional": true
         }
       }
+    },
+    "node_modules/js-yaml": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/katex": {
       "version": "0.16.47",
@@ -2230,6 +2310,16 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/robust-predicates": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "private": true,
   "description": "Tooling for validating docs/ architecture artifacts. No application code lives here.",
   "scripts": {
-    "validate:mermaid": "find docs -name '*.mmd' -print0 | xargs -0 -I{} mmdc -p docs/mermaid-puppeteer-config.json -i {} -o /tmp/mmdc-validate.svg"
+    "validate:mermaid": "find docs -name '*.mmd' -print0 | xargs -0 -I{} mmdc -p docs/mermaid-puppeteer-config.json -i {} -o /tmp/mmdc-validate.svg",
+    "validate:threat-model": "node scripts/validate-threat-model.mjs"
   },
   "devDependencies": {
-    "@mermaid-js/mermaid-cli": "11.16.0"
+    "@mermaid-js/mermaid-cli": "11.16.0",
+    "ajv": "8.20.0",
+    "js-yaml": "5.3.0"
   }
 }

--- a/scripts/validate-threat-model.mjs
+++ b/scripts/validate-threat-model.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Validates every docs/03-threat-model/model/instances/*.yaml file against
+// docs/03-threat-model/model/schema/threat-model.schema.json, then checks
+// corpus-wide referential integrity: no duplicate IDs across files, and
+// every *_ref field resolves to a real ID (a corpus element, a known
+// ARCH-* concept from traceability.md, or the literal 'EXTERNAL').
+//
+// Known limitation: ref resolution checks *existence*, not *type* —
+// e.g. a `trust_zone_ref` pointing at an ASSET-* id would pass this check
+// even though it's semantically wrong. Schema `pattern` constraints catch
+// the common case (most ref fields are typed by ID prefix); the free-form
+// ref fields (trust_zone_ref, source_ref, destination_ref, owner_refs,
+// separates) are existence-checked only.
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+let Ajv2020, load;
+try {
+  ({ default: Ajv2020 } = await import("ajv/dist/2020.js"));
+  ({ load } = await import("js-yaml"));
+} catch {
+  console.error("ERROR - ajv/js-yaml not installed. Run: npm ci");
+  process.exit(1);
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const MODEL_DIR = join(REPO_ROOT, "docs/03-threat-model/model");
+const INSTANCES_DIR = join(MODEL_DIR, "instances");
+const SCHEMA_PATH = join(MODEL_DIR, "schema/threat-model.schema.json");
+const TRACEABILITY_PATH = join(REPO_ROOT, "docs/01-architecture/traceability.md");
+
+const REF_ARRAY_FIELDS = [
+  "identity_refs", "maps_to", "owner_refs", "asset_refs",
+  "data_asset_refs", "crosses_boundary_refs", "separates",
+];
+const REF_SCALAR_FIELDS = ["trust_zone_ref", "source_ref", "destination_ref", "class_ref", "traffic_class_ref"];
+
+function loadArchIds() {
+  const text = readFileSync(TRACEABILITY_PATH, "utf8");
+  return new Set([...text.matchAll(/`(ARCH-[A-Z0-9-]+)`/g)].map((m) => m[1]));
+}
+
+function collectionKeys(doc) {
+  return ["trust_zones", "trust_boundaries", "actors", "identities", "processes", "data_stores", "assets", "data_flows"]
+    .filter((k) => Array.isArray(doc[k]));
+}
+
+function main() {
+  const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  const validate = ajv.compile(schema);
+
+  const archIds = loadArchIds();
+  const files = readdirSync(INSTANCES_DIR).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
+
+  if (files.length === 0) {
+    console.error(`ERROR - no instance files found under ${INSTANCES_DIR}`);
+    process.exit(1);
+  }
+
+  let failed = false;
+  const idOwner = new Map(); // id -> file it was first seen in
+  const allKnownIds = new Set(["EXTERNAL", ...archIds]);
+  const perFileDocs = [];
+
+  // Pass 1: schema validation + collect all IDs.
+  for (const file of files) {
+    const path = join(INSTANCES_DIR, file);
+    const doc = load(readFileSync(path, "utf8"));
+    perFileDocs.push({ file, doc });
+
+    const ok = validate(doc);
+    if (!ok) {
+      failed = true;
+      console.error(`FAILED (schema) - ${file}`);
+      for (const err of validate.errors) {
+        console.error(`  ${err.instancePath || "(root)"} ${err.message}`);
+      }
+      continue;
+    }
+
+    for (const key of collectionKeys(doc)) {
+      for (const item of doc[key]) {
+        if (idOwner.has(item.id)) {
+          failed = true;
+          console.error(`FAILED (duplicate id) - ${item.id} in ${file} already defined in ${idOwner.get(item.id)}`);
+        } else {
+          idOwner.set(item.id, file);
+          allKnownIds.add(item.id);
+        }
+      }
+    }
+    console.log(`PASS (schema) - ${file}`);
+  }
+
+  if (failed) {
+    console.error("\nSchema/duplicate-id errors found — skipping referential-integrity pass.");
+    process.exit(1);
+  }
+
+  // Pass 2: referential integrity, now that allKnownIds is complete across every file.
+  for (const { file, doc } of perFileDocs) {
+    for (const key of collectionKeys(doc)) {
+      for (const item of doc[key]) {
+        for (const field of REF_SCALAR_FIELDS) {
+          const val = item[field];
+          if (val && !allKnownIds.has(val)) {
+            failed = true;
+            console.error(`FAILED (dangling ref) - ${file}: ${item.id}.${field} -> '${val}' not found`);
+          }
+        }
+        for (const field of REF_ARRAY_FIELDS) {
+          const arr = item[field];
+          if (!Array.isArray(arr)) continue;
+          for (const entry of arr) {
+            const ref = typeof entry === "string" ? entry : entry.identity_ref;
+            if (ref && !allKnownIds.has(ref)) {
+              failed = true;
+              console.error(`FAILED (dangling ref) - ${file}: ${item.id}.${field}[] -> '${ref}' not found`);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (failed) {
+    console.error("\nReferential-integrity errors found.");
+    process.exit(1);
+  }
+
+  console.log(`\nAll ${files.length} instance file(s) valid. ${idOwner.size} corpus IDs, all references resolve.`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Phase 3A of the threat-modeling pipeline: `Architecture corpus -> normalized model -> DFD L0-L3 -> validation`, before STRIDE/attack trees/IriusRisk/IAM (later phases). This PR is the schema + tooling + **one domain** proof of concept, deliberately scoped as a review gate before scaling to the remaining five domains and generating DFDs.

**Why a normalized corpus at all**: without it, generating a DFD, attack tree, or IriusRisk model requires re-interpreting 26 Mermaid views + a dozen Specs/ADRs every time, with no determinism guarantee — two passes over the same architecture could silently diverge. This corpus makes that reinterpretation happen exactly once, schema-validated and evidence-checked, so Mermaid DFDs become a *projection* of this model rather than another independent source of truth (the same relationship `traceability.md` already established between Specs and architecture diagrams).

### Schema (`docs/03-threat-model/model/schema/threat-model.schema.json`)

Versioned JSON Schema (draft 2020-12) for `trust_zones`, `trust_boundaries`, `actors`, `identities`, `processes`, `data_stores`, `assets`, `data_flows`. Every element requires `evidence: [...]` with `status` one of `implemented|specified|planned|candidate|decision-pending` — the same no-invented-content discipline `traceability.md` enforces for diagrams, now formalized into the schema itself.

**ID convention**: `trust_zones`/`trust_boundaries` reuse existing `ARCH-*` IDs directly where a genuine 1:1 concept already exists — no parallel ID for the same thing. Everything else mints a new type-prefixed ID (`ACTOR-`/`IDENT-`/`PROC-`/`DS-`/`ASSET-`/`FLOW-`) and cites any related `ARCH-*` concept via an evidence entry.

### Network domain instance (`instances/network.yaml`)

4 trust zones, 5 trust boundaries, 1 actor, 1 identity, 7 processes, 1 asset, 11 data flows — extracted from `network-overview.mmd`, `traffic-flows.mmd`, `SPEC-NET-001/002/004`, `ADR-0003/0006/0008`. Genuinely undecided items (Edge-zone ingress technology/port) are recorded as explicit `"undecided — <why>"` strings, never a plausible guess — mirrors `edge-zone.mmd`'s own practice.

### Tooling (`scripts/validate-threat-model.mjs`)

Validates every instance file against the schema, then checks corpus-wide referential integrity: no duplicate IDs across files, every `*_ref` resolves to a real corpus ID, a live-read `ARCH-*` concept from `traceability.md` (not a separately-maintained copy that could drift), or the literal `EXTERNAL`. Verified against three deliberately broken copies (dangling ref, invalid enum, duplicate ID) to confirm it actually fails before trusting it to pass — not just a rubber stamp.

Wired into `npm run validate:threat-model`, a new `threat-model` job in `docs.yml`, and a pre-commit hook scoped to `docs/03-threat-model/model/`.

## Validation

- [x] `npm run validate:threat-model`: 1/1 instance valid, 30 corpus IDs, all references resolve
- [x] Negative-tested: dangling ref, invalid enum value, and duplicate ID were each independently confirmed to fail before being reverted
- [x] `pre-commit run --all-files`: all hooks passed
- [x] `npx markdownlint-cli2` (full repo-wide glob): 0 issues
- [x] Commit is DCO sign-off'd and GPG-signed (`git log --format=%G?` → `G`)

## Impact

- [x] Architecture decision changed (threat-model pipeline sequence now documented in `docs/03-threat-model/README.md`)
- [x] Threat model / trust boundaries / DFD / risk register affected (this **is** Phase 3A of that work)
- [ ] New infrastructure state boundary introduced
- [ ] Credential, secret, or access policy touched
- [x] README / docs updated

## Next (not in this PR)

Populate the remaining five domain instances (`identity`, `governance`, `cicd`, `kubernetes`, `context`), then generate DFD L0-L3 from the full corpus, then validate against all 26 architecture views before Phase 3B (STRIDE/LINDDUN, attack trees) begins.
