### PR TITLE
feat: threat-model corpus schema v2 — hardening pass before scaling domains

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,4 +59,5 @@ jobs:
         with:
           node-version: "22"
       - run: npm ci
+      - run: npm run test:threat-model
       - run: npm run validate:threat-model

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,13 @@ repos:
         files: '^docs/03-threat-model/model/'
         pass_filenames: false
 
+      - id: threat-model-validator-test
+        name: Threat-model validator self-test
+        entry: scripts/validate-threat-model.test.mjs
+        language: system
+        files: '^scripts/validate-threat-model(\.test)?\.mjs$'
+        pass_filenames: false
+
       - id: check-dco
         name: Developer Certificate of Origin (Signed-off-by)
         entry: .githooks/commit-msg

--- a/docs/03-threat-model/model/README.md
+++ b/docs/03-threat-model/model/README.md
@@ -18,94 +18,258 @@ docs/03-threat-model/model/instances/*.yaml   <- THIS is the source of truth
 DFD L0-L3, STRIDE/LINDDUN, attack trees, MITRE mapping, IriusRisk, IAM/PAM
 ```
 
-Mermaid becomes a **projection** of this model for DFDs, the same
-relationship `docs/01-architecture/traceability.md` already establishes
-between Specs and architecture diagrams.
+This corpus sits **above** DFD notation, not inside it. A `component` is an
+architecture-level fact ("this OCI Internet Gateway exists, here"); a DFD
+`process`/`data store`/`external entity` is a *projection* of that fact at
+a specific diagram level. Mermaid DFDs are themselves a further projection
+of this corpus, the same relationship `docs/01-architecture/traceability.md`
+already establishes between Specs and architecture diagrams.
 
-## Why this exists
+## v2 — schema-hardening pass (schema_version 2.0.0)
 
-Without a normalized intermediate model, generating a DFD or an attack tree
-requires re-reading and re-interpreting 26 Mermaid files plus a dozen Specs
-and ADRs every time — a process with no determinism guarantee. Two
-generation passes over the same architecture could produce different trust
-boundaries, different flow lists, or a different IAM graph, and nothing
-would catch the drift. This corpus exists to make that reinterpretation
-happen exactly once, in a structured, schema-validated, evidence-checked
-form that every later phase reads instead of the raw architecture docs.
+v1 was DFD-shaped: everything that wasn't a person or an identity was a
+`process`, `protocol`/`port` were flat strings, `authentication`/
+`authorization` were single enum values, and undecided details were
+recorded as human-readable strings inside otherwise-typed fields. That was
+fine for a proof of concept but too lossy for what this corpus must
+eventually drive: policies, credentials, and an IAM/PAM/RBAC/JIT/JEA graph.
+v2 is a breaking change (see "Versioning" below) made deliberately early,
+while only `network.yaml` existed, rather than after five more domains
+were built against v1.
 
-## Layout
+### BEFORE (v1) / AFTER (v2)
 
-- `schema/threat-model.schema.json` — versioned JSON Schema (draft
-  2020-12), the contract every instance file must satisfy.
-- `instances/<domain>.yaml` — one file per architecture domain, mirroring
-  `docs/01-architecture/<domain>/`: `context`, `network`, `identity`,
-  `governance`, `cicd`, `kubernetes`.
+**Component/resource** — infrastructure no longer masquerades as a DFD process:
+
+```yaml
+# BEFORE
+processes:
+  - id: PROC-INTERNET-GATEWAY
+    name: Internet Gateway
+    trust_zone_ref: ARCH-NET-VCN
+    evidence: [...]
+
+# AFTER
+components:
+  - id: COMP-INTERNET-GATEWAY
+    name: Internet Gateway
+    component_type: network-gateway
+    trust_zone_ref: ARCH-NET-VCN
+    state: specified
+    evidence: [...]
+```
+
+**Identity** — element `state` is now separate from evidence maturity:
+
+```yaml
+# BEFORE
+identities:
+  - id: IDENT-ZITI-ADMIN
+    system: openziti
+    evidence:
+      - { source_type: adr, ref: ADR-0003, status: specified }
+      - { source_type: roadmap, ref: "roadmap.md#I08", status: planned }
+    # no way to say what the IDENTITY's own state is —
+    # is it specified, or planned? ambiguous.
+
+# AFTER
+identities:
+  - id: IDENT-ZITI-ADMIN
+    system: openziti
+    state: planned   # <- curated, explicit, not derived from evidence
+    evidence:
+      - { source_type: adr, ref: ADR-0003, status: specified }
+      - { source_type: roadmap, ref: "roadmap.md#I08", status: planned }
+```
+
+**Credential** — a first-class entity, not folded into a generic asset:
+
+```yaml
+# BEFORE
+# (no such thing — asset_type: credential was as specific as it got)
+
+# AFTER
+credentials:
+  - id: CRED-K8S-API-CREDENTIAL
+    credential_type: other   # genuinely undecided — see gaps[]
+    subject_identity_ref: IDENT-ZITI-ADMIN
+    state: decision-pending
+    evidence: [...]
+```
+
+**Policy** — WHO, through WHICH identity, evaluated by WHICH engine, for WHICH action:
+
+```yaml
+# BEFORE
+# (no such thing — authorization: kubernetes-rbac was the entire model)
+
+# AFTER
+policies:
+  - id: POLICY-CONTROL-NSG-6443
+    policy_type: oci-nsg-rule
+    resource_refs: ["COMP-KUBE-APISERVER"]
+    actions: ["ingress:tcp:6443"]
+    scope_ref: COMP-CONTROL-NSG
+    effect: allow
+    state: specified
+    evidence: [...]
+```
+
+**Flow authentication/authorization** — structured, multi-mechanism, not a lossy single enum:
+
+```yaml
+# BEFORE
+authentication: mtls
+authorization: nsg-security-list
+
+# AFTER
+authentication:
+  required: true
+  mechanisms:
+    - { type: openziti-identity, identity_ref: IDENT-ZITI-ADMIN, authority_ref: COMP-ZITI-PUBLIC-ROUTER, state: planned }
+    - { type: mtls, state: planned }
+authorization:
+  required: true
+  mechanisms:
+    - { type: nsg-security-list, authority_ref: COMP-CONTROL-NSG, policy_refs: [POLICY-CONTROL-NSG-6443], state: specified }
+```
+
+**Gap/unknown** — a first-class record, not prose inside a typed field:
+
+```yaml
+# BEFORE
+data_flows:
+  - id: FLOW-INTERNET-TO-IGW
+    port: "undecided — ingress technology/application ports not yet chosen (...)"
+
+# AFTER
+data_flows:
+  - id: FLOW-INTERNET-TO-IGW
+    transport: { network_protocol: unknown, ports: [], state: decision-pending }
+    state: decision-pending
+gaps:
+  - id: GAP-NET-001
+    subject_ref: FLOW-INTERNET-TO-IGW
+    field: "transport.ports"
+    reason: "Edge-zone ingress technology has not been selected. No SPIKE currently tracks this decision."
+    blocking: false
+    evidence: [...]
+```
+
+**Trust boundary** — containment is no longer conflated with a two-sided crossing:
+
+```yaml
+# BEFORE
+trust_boundaries:
+  - id: ARCH-NET-VCN
+    separates: ["ARCH-OCI-COMPARTMENT", "ARCH-ZONE-EDGE", "ARCH-ZONE-MGMT", "ARCH-ZONE-WORKLOAD", "ARCH-ZONE-DATA"]
+    # this is containment (VCN CONTAINS 4 zones), not a crossing —
+    # a downstream attack-path generator could infer 5 false "boundary crossings" here
+
+# AFTER
+scopes:
+  - id: ARCH-NET-VCN
+    scope_type: network-perimeter
+    parent_ref: ARCH-OCI-COMPARTMENT   # <- containment lives here
+trust_zones:
+  - id: ARCH-ZONE-EDGE
+    parent_ref: ARCH-NET-VCN            # <- containment, not a boundary
+trust_boundaries:
+  - id: TB-INTERNET-EDGE
+    side_a_refs: ["EXTERNAL"]           # <- a genuine two-sided crossing
+    side_b_refs: ["ARCH-ZONE-EDGE"]
+```
+
+`TB-ZONE-ISOLATION` (a v1 boundary claiming all four zones were mutually
+"separated") was removed entirely rather than fixed — zone-to-zone
+crossings are already inferable from a flow's `source_ref`/`destination_ref`
+zone membership; a separate abstract boundary object added nothing and
+risked implying pairwise crossings that were never modeled precisely.
 
 ## Element types
 
-`trust_zones`, `trust_boundaries`, `actors`, `identities`, `processes`,
-`data_stores`, `assets`, `data_flows` — the standard DFD/STRIDE element set,
-plus `identities` (distinct from `actors` — see
+`scopes` (containment: tenancy → compartment → VCN, via `parent_ref`),
+`trust_zones` (also carry `parent_ref` into `scopes`), `trust_boundaries`
+(genuine two-sided crossings only: `side_a_refs`/`side_b_refs`), `actors`,
+`identities` (see
 [identity-reconciliation.md](../../01-architecture/identity-reconciliation.md)
 for why a GitHub identity, an OCI IAM principal, and a Kubernetes
-ServiceAccount are not assumed to be the same principal) and `assets` (for
-confidentiality/integrity/availability requirements independent of any
-single flow).
+ServiceAccount are not assumed to be the same principal), `credentials`,
+`components` (standing infrastructure/platform resources — see
+`component_type` enum in the schema), `processes` (reserved for
+DFD-projection-time process nodes; not populated directly in v2 — see the
+schema's own description on `processes[].description`), `data_stores`,
+`assets`, `data_flows`, `policies`, `controls`, `gaps`.
+
+## `state` vs `evidence[].status` — read this before editing any file
+
+These answer different questions and must never be conflated:
+
+- **`evidence[].status`**: what maturity does *this one source* assert?
+  Multiple evidence entries on the same element can (and often do) assert
+  different maturities — an ADR might be `specified` while the roadmap
+  initiative implementing it is only `planned`.
+- **`state`**: what is the element's own curated, effective state? Set
+  explicitly by whoever populates the corpus, **never derived
+  automatically** from the strongest or weakest evidence entry. A
+  `PROC-ZITI-PRIVATE-ROUTER`-style component can be `state: planned` even
+  while one of its evidence entries is `status: specified` — the ADR
+  decision is specified, but the component itself (its actual
+  configuration) is still only planned.
+
+Values: `implemented | specified | planned | candidate | decision-pending`
+(plus reserved-for-later `deprecated | retired`). `implemented` means
+actually running (`infrastructure/` applied) — nothing in this repo
+qualifies yet, it's greenfield. The validator enforces that any element
+claiming `state: implemented` has at least one evidence entry that also
+says `implemented` — state can't outrun what any source actually asserts.
 
 ## ID conventions
 
-- **Reuse, don't duplicate**: where a corpus element is a genuine 1:1 match
-  for an existing stable concept, its `id` **is** that concept's ID —
-  `trust_zones[].id` is always an `ARCH-ZONE-*` ID, and
-  `trust_boundaries[].id` is an `ARCH-OCI-*`/`ARCH-NET-*` ID where one
-  already exists (falling back to a new `TB-*` ID otherwise). This is a
-  hard requirement, not a convention to relax under time pressure — a
-  duplicate ID for the same concept is exactly the drift this corpus
-  exists to prevent.
-- **Mint + cite**: `actors`, `identities`, `processes`, `data_stores`,
-  `assets`, and `data_flows` don't generally have a pre-existing ARCH-* ID
-  (they're finer-grained than the architecture vocabulary), so they get a
-  new type-prefixed ID (`ACTOR-`, `IDENT-`, `PROC-`, `DS-`, `ASSET-`,
-  `FLOW-`) and cite any related `ARCH-*` concept through an `evidence`
-  entry (`source_type: arch-view`) instead.
+- **Reuse, don't duplicate**: where a corpus element is a genuine 1:1
+  match for an existing stable concept, its `id` **is** that concept's
+  ID — `trust_zones[].id` is always an `ARCH-ZONE-*` ID, `scopes[].id`
+  reuses `ARCH-OCI-*`/`ARCH-NET-*` where one exists. This is a hard
+  requirement — a duplicate ID for the same concept is exactly the drift
+  this corpus exists to prevent.
+- **Mint + cite**: everything else gets a new type-prefixed ID and cites
+  any related `ARCH-*` concept through an `evidence` entry instead:
+  `ACTOR-`, `IDENT-`, `CRED-`, `COMP-`, `PROC-`, `DS-`, `ASSET-`, `FLOW-`,
+  `POLICY-`, `CTRL-`, `GAP-`, `SCOPE-` (fallback for a scope with no
+  matching `ARCH-*` concept).
 
-## Evidence discipline
+## Versioning
 
-Every element requires `evidence: [...]` with at least one entry — the
-same rule `docs/01-architecture/traceability.md` enforces for diagrams,
-applied to this corpus. `evidence[].status` is one of:
-
-| Status | Meaning |
-| --- | --- |
-| `implemented` | Actually running (`infrastructure/` applied). None of this repo yet — it's greenfield. |
-| `specified` | An approved (Ready/Accepted) Spec or ADR covers it, not yet built. |
-| `planned` | Named in `roadmap.md`, no Spec yet. |
-| `candidate` | Plausible but not confirmed anywhere — flag, don't assert. |
-| `decision-pending` | Tied to an open SPIKE or an explicitly-marked open decision point in a view. |
-
-A `port`, `protocol`, or other field that is genuinely undecided in the
-architecture (e.g. Edge-zone ingress technology) is recorded as an
-explicit string describing the gap (`"undecided — ..."`), never a plausible
-guess. This mirrors `edge-zone.mmd`'s own practice of marking that decision
-open rather than inventing an ingress technology.
+`schema_version` (const, e.g. `"2.0.0"`) binds an instance file to the
+exact schema generation that validated it — independent of `model_version`
+(semver for the instance's own content). A schema change that isn't purely
+additive must bump `schema_version` and migrate every instance file before
+they can declare the new version; this repo makes that change immediately
+while only one instance exists rather than deferring it.
 
 ## Validation
 
 ```sh
-npm run validate:threat-model
+npm run test:threat-model       # validator self-test (fixtures, no real corpus data)
+npm run validate:threat-model   # schema + corpus-wide invariants against instances/*.yaml
 ```
 
-Validates every `instances/*.yaml` against the schema, then checks
-corpus-wide referential integrity: no duplicate IDs across files, and every
-`*_ref` field resolves to a real corpus ID, a known `ARCH-*` concept (read
-live from `traceability.md`, not a separately-maintained copy that could
-drift), or the literal `EXTERNAL`. See the script's header comment
-(`scripts/validate-threat-model.mjs`) for its one documented limitation:
-ref resolution checks existence, not type.
+`validate-threat-model.mjs` checks, beyond JSON Schema: no duplicate IDs
+across files; every `*_ref` resolves to a real corpus ID, a known `ARCH-*`
+concept read live from `traceability.md`, or `EXTERNAL`; no two identities'
+`maps_to` entries disagree about `same_principal` for the same pair; every
+`state: implemented` element has `>=1` evidence entry with
+`status: implemented`; every `state: decision-pending` element has a
+`gaps[]` entry naming it (top-level element state only — a nested
+`transport.state`/mechanism `state` of `decision-pending` is not required
+to have its own `gaps[]` entry, though adding one is still good practice).
+See the script's header comment for its one remaining documented
+limitation: ref resolution checks existence, not type.
 
 ## Status
 
-`network.yaml` is the only populated instance so far — a proof of concept
-for the schema and tooling before scaling to the remaining five domains.
-See `docs/03-threat-model/README.md` for where this fits in the overall
-threat-modeling sequence.
+`network.yaml` is the only populated instance — migrated to schema v2 as
+this hardening pass's proof of concept. Remaining domains (`identity`,
+`governance`, `cicd`, `kubernetes`, `context`) come next, once this schema
+is confirmed ready to scale. See `docs/03-threat-model/README.md` for
+where this fits in the overall threat-modeling sequence.

--- a/docs/03-threat-model/model/instances/network.yaml
+++ b/docs/03-threat-model/model/instances/network.yaml
@@ -1,27 +1,43 @@
 domain: network
-model_version: 0.1.0
+schema_version: 2.0.0
+model_version: 0.2.0
 generated_from:
-  - source_type: arch-view
-    ref: VIEW-NET-OVERVIEW
-    status: specified
-  - source_type: arch-view
-    ref: VIEW-NET-TRAFFIC
-    status: specified
-  - source_type: spec
-    ref: SPEC-NET-001.md
-    status: specified
-  - source_type: spec
-    ref: SPEC-NET-002.md
-    status: specified
-  - source_type: spec
-    ref: SPEC-NET-004.md
-    status: specified
-  - source_type: adr
-    ref: ADR-0003
-    status: specified
-  - source_type: adr
-    ref: ADR-0006
-    status: specified
+  - { source_type: arch-view, ref: VIEW-NET-OVERVIEW, status: specified }
+  - { source_type: arch-view, ref: VIEW-NET-TRAFFIC, status: specified }
+  - { source_type: spec, ref: "SPEC-NET-001.md", status: specified }
+  - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
+  - { source_type: spec, ref: "SPEC-NET-004.md", status: specified }
+  - { source_type: adr, ref: ADR-0003, status: specified }
+  - { source_type: adr, ref: ADR-0006, status: specified }
+  - { source_type: adr, ref: ADR-0008, status: specified }
+
+scopes:
+  - id: ARCH-OCI-TENANCY
+    name: OCI tenancy
+    description: The OCI tenancy as the outermost administrative containment scope.
+    scope_type: tenancy
+    state: specified
+    evidence:
+      - { source_type: arch-view, ref: VIEW-NET-OVERVIEW, status: specified }
+
+  - id: ARCH-OCI-COMPARTMENT
+    name: Platform compartment
+    description: Isolates platform resources from the tenancy root via compartment-scoped IAM policy.
+    scope_type: compartment
+    parent_ref: ARCH-OCI-TENANCY
+    state: specified
+    evidence:
+      - { source_type: arch-view, ref: VIEW-NET-OVERVIEW, status: specified }
+      - { source_type: spec, ref: "SPEC-OCI-001.md", status: specified }
+
+  - id: ARCH-NET-VCN
+    name: Platform VCN
+    description: The platform VCN (10.10.0.0/16), containing all four trust zones. Also a network security perimeter — see trust_boundaries for its actual crossing points, not this containment relationship.
+    scope_type: network-perimeter
+    parent_ref: ARCH-OCI-COMPARTMENT
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-001.md", status: specified }
 
 trust_zones:
   - id: ARCH-ZONE-EDGE
@@ -29,6 +45,8 @@ trust_zones:
     description: Public-facing subnet — the only zone permitted a public IP.
     network_cidr: 10.10.10.0/24
     public_ip_allowed: true
+    parent_ref: ARCH-NET-VCN
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-001.md", status: specified }
       - { source_type: adr, ref: ADR-0006, status: specified }
@@ -38,6 +56,8 @@ trust_zones:
     description: Control-plane/administrative subnet — Kubernetes API, etcd, Ziti private router.
     network_cidr: 10.10.20.0/24
     public_ip_allowed: false
+    parent_ref: ARCH-NET-VCN
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-001.md", status: specified }
       - { source_type: adr, ref: ADR-0006, status: specified }
@@ -47,6 +67,8 @@ trust_zones:
     description: Talos worker subnet.
     network_cidr: 10.10.30.0/24
     public_ip_allowed: false
+    parent_ref: ARCH-NET-VCN
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-001.md", status: specified }
       - { source_type: adr, ref: ADR-0006, status: specified }
@@ -56,54 +78,27 @@ trust_zones:
     description: Storage/backup subnet.
     network_cidr: 10.10.40.0/24
     public_ip_allowed: false
+    parent_ref: ARCH-NET-VCN
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-001.md", status: specified }
       - { source_type: adr, ref: ADR-0006, status: specified }
 
 trust_boundaries:
-  - id: ARCH-OCI-TENANCY
-    name: OCI tenancy boundary
-    description: The OCI tenancy as the outermost structural/administrative boundary.
-    boundary_type: administrative-domain
-    separates: ["EXTERNAL", "ARCH-OCI-COMPARTMENT"]
-    evidence:
-      - { source_type: arch-view, ref: VIEW-NET-OVERVIEW, status: specified }
-
-  - id: ARCH-OCI-COMPARTMENT
-    name: Platform compartment boundary
-    description: Isolates platform resources from the tenancy root via compartment-scoped IAM policy.
-    boundary_type: administrative-domain
-    separates: ["ARCH-OCI-TENANCY", "ARCH-NET-VCN"]
-    evidence:
-      - { source_type: arch-view, ref: VIEW-NET-OVERVIEW, status: specified }
-      - { source_type: spec, ref: "SPEC-OCI-001.md", status: specified }
-
-  - id: ARCH-NET-VCN
-    name: VCN perimeter
-    description: The platform VCN (10.10.0.0/16) as a network security perimeter around all four trust zones.
-    boundary_type: network-perimeter
-    separates: ["ARCH-OCI-COMPARTMENT", "ARCH-ZONE-EDGE", "ARCH-ZONE-MGMT", "ARCH-ZONE-WORKLOAD", "ARCH-ZONE-DATA"]
-    evidence:
-      - { source_type: spec, ref: "SPEC-NET-001.md", status: specified }
-
   - id: TB-INTERNET-EDGE
-    name: Internet-to-Edge boundary
-    description: The Internet Gateway — the only path from the public internet into the VCN, terminating in the Edge zone.
+    name: Internet-to-Edge boundary (Internet Gateway)
+    description: >-
+      The Internet Gateway — the only path from the public internet into the
+      VCN, terminating in the Edge zone. A genuine two-sided crossing point,
+      not a containment relationship (compare scopes[] for tenancy/
+      compartment/VCN containment, which is NOT modeled as a boundary here).
     boundary_type: network-perimeter
-    separates: ["EXTERNAL", "ARCH-ZONE-EDGE"]
+    side_a_refs: ["EXTERNAL"]
+    side_b_refs: ["ARCH-ZONE-EDGE"]
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
       - { source_type: arch-view, ref: ARCH-GW-IGW, status: specified }
-
-  - id: TB-ZONE-ISOLATION
-    name: Inter-zone isolation boundary
-    description: NSG/Security-List-enforced isolation between the four trust zones — the control NSG's 6443 restriction (REQ-NET-019) is the security-critical instance of this boundary.
-    boundary_type: network-perimeter
-    separates: ["ARCH-ZONE-EDGE", "ARCH-ZONE-MGMT", "ARCH-ZONE-WORKLOAD", "ARCH-ZONE-DATA"]
-    evidence:
-      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-018", status: specified }
-      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
-      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-020", status: specified }
 
 actors:
   - id: ACTOR-ADMINISTRATOR
@@ -113,6 +108,7 @@ actors:
       The sole human actor with administrative access to the Kubernetes API.
       Reaches it only via OpenZiti — never a direct network path (ADR-0003).
     identity_refs: ["IDENT-ZITI-ADMIN"]
+    state: specified
     evidence:
       - { source_type: adr, ref: ADR-0003, status: specified }
       - { source_type: arch-view, ref: ARCH-FLOW-ADMIN, status: specified }
@@ -127,116 +123,270 @@ identities:
       The OpenZiti identity a dial/bind policy authorizes to reach the
       Kubernetes API via the Ziti private router. OpenZiti application
       configuration itself (enrollment, specific dial/bind policy content)
-      is out of scope for I03/SPEC-NET-004 — owned by I08, not yet at Spec
-      depth (roadmap.md).
+      is owned by I08, not yet at Spec depth.
+    state: planned
     evidence:
       - { source_type: adr, ref: ADR-0003, status: specified }
       - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
       - { source_type: roadmap, ref: "roadmap.md#I08", status: planned }
 
-processes:
-  - id: PROC-ZITI-PUBLIC-ROUTER
-    name: OpenZiti public edge router
+credentials:
+  - id: CRED-ZITI-ADMIN-IDENTITY
+    name: Administrator's OpenZiti identity material
+    credential_type: openziti-identity-material
+    subject_identity_ref: IDENT-ZITI-ADMIN
+    state: planned
+    evidence:
+      - { source_type: adr, ref: ADR-0003, status: specified }
+      - { source_type: roadmap, ref: "roadmap.md#I08", status: planned }
+
+  - id: CRED-K8S-API-CREDENTIAL
+    name: Kubernetes-side administrative credential
+    credential_type: other
+    subject_identity_ref: IDENT-ZITI-ADMIN
     description: >-
-      Internet-facing OpenZiti fabric ingress point in the Edge zone. Router
-      placement/existence is named by ADR-0003 and docs/arch/cloud-deployment.mmd;
+      Whatever Kubernetes-side credential the administrator presents after
+      the Ziti hop — kubeconfig client cert, OIDC token, or something else,
+      genuinely undecided pending I09/I10's identity-provider choice.
+    state: decision-pending
+    evidence:
+      - { source_type: roadmap, ref: "roadmap.md#I10", status: planned }
+
+components:
+  - id: COMP-ZITI-PUBLIC-ROUTER
+    name: OpenZiti public edge router
+    component_type: network-control
+    description: >-
+      Internet-facing OpenZiti fabric ingress point in the Edge zone.
+      Placement/existence named by ADR-0003 and cloud-deployment.mmd;
       OpenZiti-specific configuration is owned by I08, not yet Spec'd.
     trust_zone_ref: ARCH-ZONE-EDGE
+    state: planned
     evidence:
       - { source_type: adr, ref: ADR-0003, status: specified }
       - { source_type: roadmap, ref: "roadmap.md#I08", status: planned }
 
-  - id: PROC-ZITI-PRIVATE-ROUTER
+  - id: COMP-ZITI-PRIVATE-ROUTER
     name: OpenZiti private router
-    description: >-
-      Management-zone OpenZiti router the public router's fabric hands
-      administrative traffic to before it reaches the Kubernetes API.
+    component_type: network-control
+    description: Management-zone OpenZiti router the public router's fabric hands administrative traffic to.
     trust_zone_ref: ARCH-ZONE-MGMT
+    state: planned
     evidence:
       - { source_type: adr, ref: ADR-0003, status: specified }
       - { source_type: roadmap, ref: "roadmap.md#I08", status: planned }
 
-  - id: PROC-KUBE-APISERVER
+  - id: COMP-KUBE-APISERVER
     name: kube-apiserver
+    component_type: control-plane
     description: >-
       Kubernetes API server — Talos-hosted control-plane process in the
-      Management zone. This file specifies its network-layer placement and
-      ingress restriction only; the Kubernetes bootstrap itself is I05,
-      not yet at Spec depth.
+      Management zone. Network-layer placement/ingress-restriction is
+      specified here; the Kubernetes bootstrap itself is I05, not yet at
+      Spec depth.
     trust_zone_ref: ARCH-ZONE-MGMT
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
       - { source_type: arch-view, ref: ARCH-K8S-CONTROL, status: specified }
       - { source_type: roadmap, ref: "roadmap.md#I05", status: planned }
 
-  - id: PROC-WORKER-NODE
+  - id: COMP-WORKER-NODE
     name: Talos worker node
+    component_type: compute
     description: >-
-      Talos worker in the Workload zone. Must reach kube-apiserver on 6443
-      (kubelet, kube-proxy, and other node components) — the reason the
-      control NSG permits the worker NSG on that port (REQ-NET-019).
+      Talos worker in the Workload zone. kubelet/kube-proxy must reach
+      kube-apiserver on 6443 — the reason the control NSG permits the
+      worker NSG on that port (REQ-NET-019).
     trust_zone_ref: ARCH-ZONE-WORKLOAD
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
       - { source_type: arch-view, ref: ARCH-K8S-WORKER, status: specified }
 
-  - id: PROC-INTERNET-GATEWAY
+  - id: COMP-INTERNET-GATEWAY
     name: Internet Gateway
+    component_type: network-gateway
     description: Edge zone's sole internet-facing ingress point.
     trust_zone_ref: ARCH-NET-VCN
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
       - { source_type: arch-view, ref: ARCH-GW-IGW, status: specified }
 
-  - id: PROC-NAT-GATEWAY
+  - id: COMP-NAT-GATEWAY
     name: NAT Gateway
+    component_type: network-gateway
     description: Private egress for Management/Workload/Data zones.
     trust_zone_ref: ARCH-NET-VCN
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
       - { source_type: arch-view, ref: ARCH-GW-NAT, status: specified }
 
-  - id: PROC-SERVICE-GATEWAY
+  - id: COMP-SERVICE-GATEWAY
     name: Service Gateway
-    description: Private OCI service access for all four zones (Object Storage, KMS, Logging, Monitoring).
+    component_type: network-gateway
+    description: Private OCI service access for all four zones.
     trust_zone_ref: ARCH-NET-VCN
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
       - { source_type: arch-view, ref: ARCH-GW-SGW, status: specified }
+
+  - id: COMP-ZITI-NSG
+    name: ziti NSG
+    component_type: security-control
+    description: One of the five purpose-built NSGs (REQ-NET-017) — Ziti routers' membership.
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-017", status: specified }
+
+  - id: COMP-INGRESS-NSG
+    name: ingress NSG
+    component_type: security-control
+    description: One of the five purpose-built NSGs (REQ-NET-017) — application ingress membership.
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-017", status: specified }
+
+  - id: COMP-CONTROL-NSG
+    name: control NSG
+    component_type: security-control
+    description: >-
+      One of the five purpose-built NSGs (REQ-NET-017) — protects
+      kube-apiserver. REQ-NET-019's 6443 restriction is enforced here.
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-017", status: specified }
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
+
+  - id: COMP-WORKER-NSG
+    name: worker NSG
+    component_type: security-control
+    description: One of the five purpose-built NSGs (REQ-NET-017) — Talos worker membership.
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-017", status: specified }
+
+  - id: COMP-STORAGE-NSG
+    name: storage NSG
+    component_type: security-control
+    description: One of the five purpose-built NSGs (REQ-NET-017) — data-zone VNIC membership.
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-017", status: specified }
 
 assets:
   - id: ASSET-K8S-API-ACCESS
     name: Kubernetes API administrative access
     asset_type: credential
-    confidentiality: high
-    integrity: high
-    availability: moderate
+    security_requirements:
+      confidentiality: high
+      integrity: high
+      availability: moderate
+      authenticity: high
     description: >-
       The combination of Ziti dial/bind authorization plus whatever
-      Kubernetes-side credential is presented after the Ziti hop. REQ-NET-019
-      is the network-layer control protecting this asset; the credential
-      material itself (kubeconfig, OIDC token, etc.) is owned by I09/I10,
-      not yet Spec'd.
+      Kubernetes-side credential is presented after the Ziti hop.
+      REQ-NET-019 is the network-layer control protecting this asset.
     owner_refs: ["ACTOR-ADMINISTRATOR"]
+    state: specified
     evidence:
       - { source_type: adr, ref: ADR-0003, status: specified }
       - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
+
+policies:
+  - id: POLICY-CONTROL-NSG-6443
+    name: control NSG — 6443 ingress restriction
+    policy_type: oci-nsg-rule
+    resource_refs: ["COMP-KUBE-APISERVER"]
+    actions: ["ingress:tcp:6443"]
+    scope_ref: COMP-CONTROL-NSG
+    effect: allow
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
+      - { source_type: adr, ref: ADR-0003, status: specified }
+
+controls:
+  - id: CTRL-DEFAULT-DENY-SECURITY-LIST
+    name: Per-zone default-deny Security List baseline
+    control_type: preventive
+    description: >-
+      Security Lists provide a default-deny ingress baseline per
+      trust-zone subnet; NSGs are the actual fine-grained enforcement
+      point (REQ-NET-016/018).
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-016", status: specified }
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-018", status: specified }
+
+  - id: CTRL-K8S-API-INGRESS-RESTRICTION
+    name: Kubernetes API ingress restriction to ziti+worker NSGs only
+    control_type: preventive
+    description: >-
+      The control NSG restricts 6443 ingress to only the ziti and worker
+      NSGs — the technical enforcement of ADR-0003's no-direct-public-path
+      guarantee, and SPEC-NET-004's single most security-critical
+      requirement.
+    implements_refs: ["POLICY-CONTROL-NSG-6443"]
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
+      - { source_type: adr, ref: ADR-0003, status: specified }
+
+gaps:
+  - id: GAP-NET-001
+    subject_ref: FLOW-INTERNET-TO-IGW
+    field: "transport.ports"
+    reason: >-
+      Edge-zone ingress technology has not been selected. No SPIKE
+      currently tracks this decision in roadmap.md's Open Spikes table —
+      a real planning gap, not just an unresolved value.
+    blocking: false
+    evidence:
+      - { source_type: arch-view, ref: ARCH-ZONE-EDGE, status: decision-pending }
+      - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-020", status: specified }
+
+  - id: GAP-NET-002
+    subject_ref: FLOW-IGW-TO-EDGE-INGRESS
+    field: "destination_ref specificity, transport.ports"
+    reason: >-
+      Same root cause as GAP-NET-001 — this flow terminates at the zone
+      rather than a named ingress component because none is chosen yet.
+    blocking: false
+    evidence:
+      - { source_type: arch-view, ref: ARCH-ZONE-EDGE, status: decision-pending }
+
+  - id: GAP-NET-003
+    subject_ref: CRED-K8S-API-CREDENTIAL
+    field: credential_type
+    reason: >-
+      The Kubernetes-side credential presented after the Ziti hop depends
+      on I09/I10 identity decisions, blocked on SPIKE-IDP-01 (self-hosted
+      vs external IdP).
+    blocking: true
+    resolution_ref: SPIKE-IDP-01
+    evidence:
+      - { source_type: roadmap, ref: "roadmap.md#SPIKE-IDP-01", status: decision-pending }
 
 data_flows:
   - id: FLOW-INTERNET-TO-IGW
     name: Internet ingress to Internet Gateway
     description: Public internet traffic entering via the Internet Gateway toward Edge-zone application ingress.
     source_ref: EXTERNAL
-    destination_ref: PROC-INTERNET-GATEWAY
-    protocol: IP
-    port: "undecided — ingress technology/application ports not yet chosen (edge-zone.mmd marks this an open decision point; SPEC-NET-004 REQ-NET-020 scopes the ingress NSG to 'its documented application ports', not yet documented)"
+    destination_ref: COMP-INTERNET-GATEWAY
+    transport: { network_protocol: unknown, ports: [], state: decision-pending }
     direction: inbound
-    authentication: none
-    authorization: nsg-security-list
-    confidentiality_requirement: low
-    integrity_requirement: moderate
+    authentication: { required: false, mechanisms: [{ type: none, state: specified }] }
+    authorization:
+      required: true
+      mechanisms: [{ type: nsg-security-list, authority_ref: COMP-INGRESS-NSG, state: specified }]
+    security_requirements: { confidentiality: low, integrity: moderate, availability: low }
     crosses_boundary_refs: ["TB-INTERNET-EDGE"]
     traffic_class_ref: ARCH-FLOW-INGRESS
+    state: decision-pending
     evidence:
       - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
       - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-020", status: specified }
@@ -245,20 +395,20 @@ data_flows:
   - id: FLOW-IGW-TO-EDGE-INGRESS
     name: Internet Gateway to Edge application ingress
     description: >-
-      Edge-zone application ingress. No specific ingress process (load
-      balancer, reverse proxy, etc.) is named yet — edge-zone.mmd marks the
-      ingress technology itself as an open decision point, so this flow
-      terminates at the zone rather than an invented process.
-    source_ref: PROC-INTERNET-GATEWAY
+      Edge-zone application ingress. No specific ingress component is
+      named yet — edge-zone.mmd marks the ingress technology itself as an
+      open decision point, so this flow terminates at the zone.
+    source_ref: COMP-INTERNET-GATEWAY
     destination_ref: ARCH-ZONE-EDGE
-    protocol: IP
-    port: "undecided — see FLOW-INTERNET-TO-IGW"
+    transport: { network_protocol: unknown, ports: [], state: decision-pending }
     direction: inbound
-    authentication: none
-    authorization: nsg-security-list
-    confidentiality_requirement: low
-    integrity_requirement: moderate
+    authentication: { required: false, mechanisms: [{ type: none, state: specified }] }
+    authorization:
+      required: true
+      mechanisms: [{ type: nsg-security-list, authority_ref: COMP-INGRESS-NSG, state: specified }]
+    security_requirements: { confidentiality: low, integrity: moderate, availability: low }
     traffic_class_ref: ARCH-FLOW-INGRESS
+    state: decision-pending
     evidence:
       - { source_type: arch-view, ref: ARCH-FLOW-INGRESS, status: specified }
       - { source_type: arch-view, ref: ARCH-ZONE-EDGE, status: decision-pending }
@@ -267,36 +417,41 @@ data_flows:
     name: Administrator to Ziti public router
     description: Administrator's Ziti client dials the public edge router.
     source_ref: ACTOR-ADMINISTRATOR
-    destination_ref: PROC-ZITI-PUBLIC-ROUTER
-    protocol: TLS
-    port: 443
+    destination_ref: COMP-ZITI-PUBLIC-ROUTER
+    transport: { network_protocol: tcp, application_protocol: tls, ports: [443], encrypted: true }
     direction: inbound
-    authentication: mtls
-    authorization: openziti-policy
+    authentication:
+      required: true
+      mechanisms:
+        - { type: openziti-identity, identity_ref: IDENT-ZITI-ADMIN, authority_ref: COMP-ZITI-PUBLIC-ROUTER, state: planned }
+        - { type: mtls, state: planned }
+    authorization:
+      required: true
+      mechanisms: [{ type: openziti-policy, authority_ref: COMP-ZITI-PUBLIC-ROUTER, state: planned }]
     data_asset_refs: ["ASSET-K8S-API-ACCESS"]
-    confidentiality_requirement: high
-    integrity_requirement: high
+    security_requirements: { confidentiality: high, integrity: high, availability: moderate }
     crosses_boundary_refs: ["TB-INTERNET-EDGE"]
     traffic_class_ref: ARCH-FLOW-ADMIN
+    state: planned
     evidence:
       - { source_type: adr, ref: ADR-0003, status: specified }
       - { source_type: arch-view, ref: ARCH-FLOW-ADMIN, status: specified }
 
   - id: FLOW-ADMIN-02-FABRIC
     name: Ziti public router to private router (fabric)
-    description: OpenZiti fabric carries the session from the public router to the private router, crossing from Edge into Management.
-    source_ref: PROC-ZITI-PUBLIC-ROUTER
-    destination_ref: PROC-ZITI-PRIVATE-ROUTER
-    protocol: TLS
-    port: "fabric-internal — not a fixed documented port"
+    description: OpenZiti fabric carries the session from the public router to the private router, Edge into Management.
+    source_ref: COMP-ZITI-PUBLIC-ROUTER
+    destination_ref: COMP-ZITI-PRIVATE-ROUTER
+    transport: { network_protocol: tcp, application_protocol: tls, ports: [], encrypted: true }
     direction: bidirectional
-    authentication: mtls
-    authorization: openziti-policy
+    authentication: { required: true, mechanisms: [{ type: mtls, state: planned }] }
+    authorization:
+      required: true
+      mechanisms: [{ type: openziti-policy, authority_ref: COMP-ZITI-PRIVATE-ROUTER, state: planned }]
     data_asset_refs: ["ASSET-K8S-API-ACCESS"]
-    confidentiality_requirement: high
-    integrity_requirement: high
-    crosses_boundary_refs: ["TB-ZONE-ISOLATION"]
+    security_requirements: { confidentiality: high, integrity: high, availability: moderate }
     traffic_class_ref: ARCH-FLOW-ADMIN
+    state: planned
     evidence:
       - { source_type: adr, ref: ADR-0003, status: specified }
       - { source_type: arch-view, ref: ARCH-FLOW-ADMIN, status: specified }
@@ -304,37 +459,38 @@ data_flows:
   - id: FLOW-ADMIN-03-PRIVATE-ROUTER-TO-API
     name: Ziti private router to kube-apiserver
     description: The only path to the Kubernetes API's administrative surface — REQ-NET-019's ziti-NSG allowance.
-    source_ref: PROC-ZITI-PRIVATE-ROUTER
-    destination_ref: PROC-KUBE-APISERVER
-    protocol: HTTPS
-    port: 6443
+    source_ref: COMP-ZITI-PRIVATE-ROUTER
+    destination_ref: COMP-KUBE-APISERVER
+    transport: { network_protocol: tcp, application_protocol: https, ports: [6443], encrypted: true }
     direction: outbound
-    authentication: mtls
-    authorization: nsg-security-list
+    authentication: { required: true, mechanisms: [{ type: mtls, state: specified }] }
+    authorization:
+      required: true
+      mechanisms: [{ type: nsg-security-list, authority_ref: COMP-CONTROL-NSG, policy_refs: ["POLICY-CONTROL-NSG-6443"], state: specified }]
     data_asset_refs: ["ASSET-K8S-API-ACCESS"]
-    confidentiality_requirement: high
-    integrity_requirement: high
+    data_semantics: ["control-plane-api-request"]
+    security_requirements: { confidentiality: high, integrity: high, availability: moderate }
     traffic_class_ref: ARCH-FLOW-ADMIN
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
       - { source_type: adr, ref: ADR-0003, status: specified }
 
   - id: FLOW-CONTROL-WORKER-TO-API
     name: Worker node to kube-apiserver
-    description: >-
-      kubelet/kube-proxy on Talos workers reaching the API server — the
-      worker-NSG allowance in REQ-NET-019, the other legitimate 6443 source.
-    source_ref: PROC-WORKER-NODE
-    destination_ref: PROC-KUBE-APISERVER
-    protocol: HTTPS
-    port: 6443
+    description: kubelet/kube-proxy reaching the API server — the worker-NSG allowance in REQ-NET-019.
+    source_ref: COMP-WORKER-NODE
+    destination_ref: COMP-KUBE-APISERVER
+    transport: { network_protocol: tcp, application_protocol: https, ports: [6443], encrypted: true }
     direction: bidirectional
-    authentication: kubeconfig-cert
-    authorization: nsg-security-list
-    confidentiality_requirement: high
-    integrity_requirement: high
-    crosses_boundary_refs: ["TB-ZONE-ISOLATION"]
+    authentication: { required: true, mechanisms: [{ type: kubeconfig-cert, state: specified }] }
+    authorization:
+      required: true
+      mechanisms: [{ type: nsg-security-list, authority_ref: COMP-CONTROL-NSG, policy_refs: ["POLICY-CONTROL-NSG-6443"], state: specified }]
+    data_semantics: ["control-plane-api-request"]
+    security_requirements: { confidentiality: high, integrity: high, availability: high }
     traffic_class_ref: ARCH-FLOW-CONTROL
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-019", status: specified }
       - { source_type: arch-view, ref: ARCH-FLOW-CONTROL, status: specified }
@@ -344,19 +500,18 @@ data_flows:
     description: >-
       Representative of the EGRESS traffic class, which also covers
       Management- and Data-zone nodes reaching the internet via the same
-      NAT Gateway (traffic-flows.mmd draws these as one class; modeled here
-      as the Workload-zone instance, the dominant case — e.g. pulling
-      container images).
+      NAT Gateway.
     source_ref: ARCH-ZONE-WORKLOAD
-    destination_ref: PROC-NAT-GATEWAY
-    protocol: IP
-    port: "any (outbound only)"
+    destination_ref: COMP-NAT-GATEWAY
+    transport: { network_protocol: unknown, ports: [] }
     direction: outbound
-    authentication: none
-    authorization: nsg-security-list
-    confidentiality_requirement: low
-    integrity_requirement: low
+    authentication: { required: false, mechanisms: [{ type: none, state: specified }] }
+    authorization:
+      required: true
+      mechanisms: [{ type: nsg-security-list, authority_ref: COMP-WORKER-NSG, state: specified }]
+    security_requirements: { confidentiality: low, integrity: low, availability: low }
     traffic_class_ref: ARCH-FLOW-EGRESS
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
       - { source_type: arch-view, ref: ARCH-FLOW-EGRESS, status: specified }
@@ -364,55 +519,50 @@ data_flows:
   - id: FLOW-NAT-TO-INTERNET
     name: NAT Gateway to internet
     description: Egress traffic's final hop to the public internet.
-    source_ref: PROC-NAT-GATEWAY
+    source_ref: COMP-NAT-GATEWAY
     destination_ref: EXTERNAL
-    protocol: IP
-    port: "any (outbound only)"
+    transport: { network_protocol: unknown, ports: [] }
     direction: outbound
-    authentication: none
-    authorization: nsg-security-list
-    confidentiality_requirement: low
-    integrity_requirement: low
-    crosses_boundary_refs: ["TB-INTERNET-EDGE"]
+    authentication: { required: false, mechanisms: [{ type: none, state: specified }] }
+    authorization: { required: false, mechanisms: [] }
+    security_requirements: { confidentiality: low, integrity: low, availability: low }
     traffic_class_ref: ARCH-FLOW-EGRESS
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
 
   - id: FLOW-SERVICE-ANY-ZONE-TO-SGW
     name: Any zone to Service Gateway
     description: >-
-      Representative of the SERVICE traffic class (any zone reaching OCI
-      services privately). Modeled as the Management-zone instance since
-      OCI Vault/KMS access (I11, not yet Spec'd) is its most security-relevant use.
+      Representative of the SERVICE traffic class. Modeled as the
+      Management-zone instance since OCI Vault/KMS access (I11, not yet
+      Spec'd) is its most security-relevant use.
     source_ref: ARCH-ZONE-MGMT
-    destination_ref: PROC-SERVICE-GATEWAY
-    protocol: HTTPS
-    port: 443
+    destination_ref: COMP-SERVICE-GATEWAY
+    transport: { network_protocol: tcp, application_protocol: https, ports: [443], encrypted: true }
     direction: outbound
-    authentication: oci-signing-key
-    authorization: oci-iam-policy
-    confidentiality_requirement: moderate
-    integrity_requirement: moderate
+    authentication: { required: true, mechanisms: [{ type: oci-signing-key, state: specified }] }
+    authorization: { required: true, mechanisms: [{ type: oci-iam-policy, state: specified }] }
+    security_requirements: { confidentiality: moderate, integrity: moderate, availability: moderate }
     traffic_class_ref: ARCH-FLOW-SERVICE
+    state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
       - { source_type: arch-view, ref: ARCH-FLOW-SERVICE, status: specified }
 
   - id: FLOW-BACKUP-DATA-TO-SGW
     name: Data-zone backup to Service Gateway
-    description: >-
-      Data-zone volumes to the (not yet Spec'd, I19/M9) backup endpoint via
-      the Service Gateway to OCI Object Storage.
+    description: Data-zone volumes to the (not yet Spec'd, I19/M9) backup endpoint via the Service Gateway to OCI Object Storage.
     source_ref: ARCH-ZONE-DATA
-    destination_ref: PROC-SERVICE-GATEWAY
-    protocol: HTTPS
-    port: 443
+    destination_ref: COMP-SERVICE-GATEWAY
+    transport: { network_protocol: tcp, application_protocol: https, ports: [443], encrypted: true }
     direction: outbound
-    authentication: oci-signing-key
-    authorization: oci-iam-policy
-    confidentiality_requirement: high
-    integrity_requirement: high
+    authentication: { required: true, mechanisms: [{ type: oci-signing-key, state: planned }] }
+    authorization: { required: true, mechanisms: [{ type: oci-iam-policy, state: planned }] }
+    data_semantics: ["backup-data"]
+    security_requirements: { confidentiality: high, integrity: high, availability: moderate }
     traffic_class_ref: ARCH-FLOW-BACKUP
+    state: planned
     evidence:
       - { source_type: arch-view, ref: ARCH-FLOW-BACKUP, status: specified }
       - { source_type: arch-view, ref: ARCH-SVC-BACKUP-BUCKET, status: planned }
@@ -422,20 +572,18 @@ data_flows:
     name: VCN to DRG (reserved, inert)
     description: >-
       Reserved hybrid-connectivity path. The DRG is provisioned with an
-      empty route table and propagation disabled (ADR-0008) — this flow
-      does not carry traffic until I21, explicitly deferred past the MVP
-      boundary.
+      empty route table and propagation disabled (ADR-0008) — a settled
+      decision to stay inert until I21, not an open question.
     source_ref: ARCH-NET-VCN
     destination_ref: EXTERNAL
-    protocol: unknown
-    port: "n/a — inert"
+    transport: { network_protocol: unknown, ports: [] }
     direction: outbound
-    authentication: none
-    authorization: none
-    confidentiality_requirement: none
-    integrity_requirement: none
+    authentication: { required: false, mechanisms: [] }
+    authorization: { required: false, mechanisms: [] }
+    security_requirements: { confidentiality: none, integrity: none, availability: none }
     traffic_class_ref: ARCH-FLOW-HYBRID
+    state: planned
     evidence:
       - { source_type: adr, ref: ADR-0008, status: specified }
-      - { source_type: arch-view, ref: ARCH-FLOW-HYBRID, status: decision-pending }
-      - { source_type: roadmap, ref: "roadmap.md#I21", status: decision-pending }
+      - { source_type: arch-view, ref: ARCH-FLOW-HYBRID, status: specified }
+      - { source_type: roadmap, ref: "roadmap.md#I21", status: planned }

--- a/docs/03-threat-model/model/schema/threat-model.schema.json
+++ b/docs/03-threat-model/model/schema/threat-model.schema.json
@@ -92,8 +92,8 @@
     },
     "locationRef": {
       "type": "string",
-      "pattern": "^(ARCH-[A-Z0-9-]+|EXTERNAL)$",
-      "description": "A trust-zone or scope location: an ARCH-ZONE-*/ARCH-NET-*/ARCH-OCI-* concept, or EXTERNAL."
+      "pattern": "^(ARCH-[A-Z0-9-]+|SCOPE-[A-Z0-9-]+|EXTERNAL)$",
+      "description": "A trust-zone or scope location: an ARCH-ZONE-*/ARCH-NET-*/ARCH-OCI-* concept, a SCOPE-* fallback (a scope with no matching ARCH-* concept), or EXTERNAL."
     },
     "identityRef": { "type": "string", "pattern": "^IDENT-[A-Z0-9-]+$" },
     "principalRef": { "type": "string", "pattern": "^(IDENT-[A-Z0-9-]+|ACTOR-[A-Z0-9-]+)$" },

--- a/docs/03-threat-model/model/schema/threat-model.schema.json
+++ b/docs/03-threat-model/model/schema/threat-model.schema.json
@@ -1,21 +1,25 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://oracle-free-tier-platform.internal/schemas/threat-model/v1/threat-model.schema.json",
-  "title": "Threat-model normalized corpus (v1)",
-  "description": "One instance document per architecture domain (network, identity, governance, cicd, kubernetes, context). Every element requires >=1 evidence entry — this schema enforces the same 'no invented content' discipline as docs/01-architecture: an element with no Spec/ADR/ARCH-view/roadmap backing must be marked evidence.status=decision-pending or candidate, never asserted as fact.",
+  "$id": "https://oracle-free-tier-platform.internal/schemas/threat-model/v2/threat-model.schema.json",
+  "title": "Threat-model normalized corpus (v2)",
+  "description": "One instance document per architecture domain (network, identity, governance, cicd, kubernetes, context). This corpus sits ABOVE DFD notation — components/policies/controls/credentials are architecture-level facts, not DFD process/data-store nodes; a DFD generator projects from this corpus, it does not author it. Every element requires >=1 evidence entry AND a top-level `state` (see the distinction documented on each: `evidence[].status` is what one source asserts, `state` is the curated effective state of the element itself, never derived implicitly from evidence).",
   "type": "object",
   "additionalProperties": false,
-  "required": ["domain", "model_version", "generated_from"],
+  "required": ["domain", "schema_version", "model_version", "generated_from"],
   "properties": {
     "domain": {
       "type": "string",
       "enum": ["context", "network", "identity", "governance", "cicd", "kubernetes"],
       "description": "Mirrors the docs/01-architecture/<domain>/ directory this instance was derived from."
     },
+    "schema_version": {
+      "const": "2.0.0",
+      "description": "Binds this instance to the exact schema generation that validated it. Bump when the schema changes; every instance file must be re-validated (and, for a breaking change, migrated) before it can declare a new schema_version."
+    },
     "model_version": {
       "type": "string",
       "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$",
-      "description": "Semver for this instance file's content. Bump minor on additive changes, major on a breaking rename/removal of a stable ID."
+      "description": "Semver for this instance file's content (independent of schema_version). Bump minor on additive changes, major on a breaking rename/removal of a stable ID."
     },
     "generated_from": {
       "type": "array",
@@ -23,19 +27,42 @@
       "items": { "$ref": "#/$defs/evidence" },
       "description": "Which architecture views/Specs/ADRs this file was normalized from, at the file level."
     },
+    "scopes": { "type": "array", "items": { "$ref": "#/$defs/scope" }, "default": [] },
     "trust_zones": { "type": "array", "items": { "$ref": "#/$defs/trustZone" }, "default": [] },
     "trust_boundaries": { "type": "array", "items": { "$ref": "#/$defs/trustBoundary" }, "default": [] },
     "actors": { "type": "array", "items": { "$ref": "#/$defs/actor" }, "default": [] },
     "identities": { "type": "array", "items": { "$ref": "#/$defs/identity" }, "default": [] },
+    "credentials": { "type": "array", "items": { "$ref": "#/$defs/credential" }, "default": [] },
+    "components": { "type": "array", "items": { "$ref": "#/$defs/component" }, "default": [] },
     "processes": { "type": "array", "items": { "$ref": "#/$defs/process" }, "default": [] },
     "data_stores": { "type": "array", "items": { "$ref": "#/$defs/dataStore" }, "default": [] },
     "assets": { "type": "array", "items": { "$ref": "#/$defs/asset" }, "default": [] },
-    "data_flows": { "type": "array", "items": { "$ref": "#/$defs/dataFlow" }, "default": [] }
+    "data_flows": { "type": "array", "items": { "$ref": "#/$defs/dataFlow" }, "default": [] },
+    "policies": { "type": "array", "items": { "$ref": "#/$defs/policy" }, "default": [] },
+    "controls": { "type": "array", "items": { "$ref": "#/$defs/control" }, "default": [] },
+    "gaps": { "type": "array", "items": { "$ref": "#/$defs/gap" }, "default": [] }
   },
   "$defs": {
+    "state": {
+      "type": "string",
+      "enum": ["implemented", "specified", "planned", "candidate", "decision-pending", "deprecated", "retired"],
+      "description": "The curated, deterministic effective state of THIS element — never derived implicitly from the strongest/weakest evidence.status below. A process can be state=planned even while one of its evidence entries has status=specified: evidence answers 'what maturity does this source assert', state answers 'what is this element's actual current state'. A human (or a reviewed generation pass) sets state explicitly."
+    },
     "ciaLevel": {
       "type": "string",
       "enum": ["none", "low", "moderate", "high"]
+    },
+    "securityRequirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["confidentiality", "integrity", "availability"],
+      "properties": {
+        "confidentiality": { "$ref": "#/$defs/ciaLevel" },
+        "integrity": { "$ref": "#/$defs/ciaLevel" },
+        "availability": { "$ref": "#/$defs/ciaLevel" },
+        "authenticity": { "$ref": "#/$defs/ciaLevel", "description": "Optional — proof of source/identity (e.g. signed commits, SLSA provenance, SPIFFE identity). Not CIA; a distinct requirement dimension." },
+        "non_repudiation": { "$ref": "#/$defs/ciaLevel", "description": "Optional — proof an action cannot be denied after the fact (e.g. audit events)." }
+      }
     },
     "evidence": {
       "type": "object",
@@ -53,27 +80,115 @@
         },
         "status": {
           "type": "string",
-          "enum": ["implemented", "specified", "planned", "candidate", "decision-pending"]
+          "enum": ["implemented", "specified", "planned", "candidate", "decision-pending"],
+          "description": "What maturity THIS SOURCE asserts — not the element's own state (see $defs/state)."
         }
+      }
+    },
+    "endpointRef": {
+      "type": "string",
+      "pattern": "^(ACTOR-[A-Z0-9-]+|COMP-[A-Z0-9-]+|PROC-[A-Z0-9-]+|DS-[A-Z0-9-]+|ARCH-[A-Z0-9-]+|EXTERNAL)$",
+      "description": "A reference to anything that can originate or terminate a data flow: an actor, component, process, data store, an ARCH-* zone/scope/gateway concept, or EXTERNAL."
+    },
+    "locationRef": {
+      "type": "string",
+      "pattern": "^(ARCH-[A-Z0-9-]+|EXTERNAL)$",
+      "description": "A trust-zone or scope location: an ARCH-ZONE-*/ARCH-NET-*/ARCH-OCI-* concept, or EXTERNAL."
+    },
+    "identityRef": { "type": "string", "pattern": "^IDENT-[A-Z0-9-]+$" },
+    "principalRef": { "type": "string", "pattern": "^(IDENT-[A-Z0-9-]+|ACTOR-[A-Z0-9-]+)$" },
+    "authnMechanism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "state"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["none", "openziti-identity", "oidc-token", "mtls", "spiffe-svid", "ssh-key", "oci-signing-key", "gpg-signature", "kubeconfig-cert", "other"]
+        },
+        "identity_ref": { "$ref": "#/$defs/identityRef" },
+        "authority_ref": { "type": "string", "minLength": 1, "description": "The component/concept that evaluates or issues this mechanism, e.g. a COMP-* or ARCH-* id." },
+        "state": { "$ref": "#/$defs/state" }
+      }
+    },
+    "authentication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "mechanisms"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "mechanisms": { "type": "array", "items": { "$ref": "#/$defs/authnMechanism" }, "default": [] }
+      }
+    },
+    "authzMechanism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "state"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["none", "oci-iam-policy", "kubernetes-rbac", "nsg-security-list", "kyverno-policy", "openziti-policy", "github-branch-protection", "other"]
+        },
+        "authority_ref": { "type": "string", "minLength": 1 },
+        "policy_refs": { "type": "array", "items": { "type": "string", "pattern": "^POLICY-[A-Z0-9-]+$" }, "default": [] },
+        "principal_refs": { "type": "array", "items": { "$ref": "#/$defs/principalRef" }, "default": [] },
+        "state": { "$ref": "#/$defs/state" }
+      }
+    },
+    "authorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "mechanisms"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "mechanisms": { "type": "array", "items": { "$ref": "#/$defs/authzMechanism" }, "default": [] }
+      }
+    },
+    "transport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["network_protocol"],
+      "properties": {
+        "network_protocol": { "type": "string", "enum": ["tcp", "udp", "icmp", "other", "unknown"] },
+        "application_protocol": { "type": "string", "enum": ["http", "https", "grpc", "dns", "tls", "mtls", "quic", "ssh", "other", "unknown"] },
+        "ports": { "type": "array", "items": { "type": "integer", "minimum": 0, "maximum": 65535 }, "default": [] },
+        "encrypted": { "type": "boolean" },
+        "state": { "$ref": "#/$defs/state", "description": "Set when the transport details themselves are undecided (pair with a gaps[] entry)." }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "description", "scope_type", "state", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^(ARCH-OCI-[A-Z0-9-]+|ARCH-NET-[A-Z0-9-]+|SCOPE-[A-Z0-9-]+)$" },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "scope_type": { "type": "string", "enum": ["tenancy", "compartment", "network-perimeter", "other"] },
+        "parent_ref": { "type": "string", "description": "Containment parent — omit for the outermost scope." },
+        "state": { "$ref": "#/$defs/state" },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
       }
     },
     "trustZone": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "name", "description", "public_ip_allowed", "evidence"],
+      "required": ["id", "name", "description", "public_ip_allowed", "state", "evidence"],
       "properties": {
         "id": { "type": "string", "pattern": "^ARCH-ZONE-[A-Z0-9-]+$" },
         "name": { "type": "string", "minLength": 1 },
         "description": { "type": "string", "minLength": 1 },
         "network_cidr": { "type": "string" },
         "public_ip_allowed": { "type": "boolean" },
+        "parent_ref": { "type": "string", "description": "Containment parent (a scopes[] id) — this is NOT a trust_boundary crossing, it's containment." },
+        "state": { "$ref": "#/$defs/state" },
         "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
       }
     },
     "trustBoundary": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "name", "description", "boundary_type", "separates", "evidence"],
+      "required": ["id", "name", "description", "boundary_type", "side_a_refs", "side_b_refs", "state", "evidence"],
       "properties": {
         "id": { "type": "string", "pattern": "^(ARCH-[A-Z0-9-]+|TB-[A-Z0-9-]+)$" },
         "name": { "type": "string", "minLength": 1 },
@@ -82,34 +197,35 @@
           "type": "string",
           "enum": ["network-perimeter", "identity-domain", "administrative-domain", "physical", "other"]
         },
-        "separates": {
-          "type": "array",
-          "minItems": 2,
-          "items": { "type": "string", "minLength": 1 },
-          "description": "IDs (or the literal 'EXTERNAL' for outside-the-system) on each side of the boundary."
+        "side_a_refs": {
+          "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 },
+          "description": "One side of a genuine two-sided crossing point. Containment (tenancy/compartment/VCN/zone nesting) belongs in scopes[]/parent_ref, not here — a trust_boundary is a place something crosses, not a container."
         },
+        "side_b_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "state": { "$ref": "#/$defs/state" },
         "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
       }
     },
     "actor": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "name", "actor_type", "description", "evidence"],
+      "required": ["id", "name", "actor_type", "description", "state", "evidence"],
       "properties": {
         "id": { "type": "string", "pattern": "^ACTOR-[A-Z0-9-]+$" },
         "name": { "type": "string", "minLength": 1 },
         "actor_type": { "type": "string", "enum": ["human", "external-system", "automated-agent"] },
         "description": { "type": "string", "minLength": 1 },
-        "identity_refs": { "type": "array", "items": { "type": "string", "pattern": "^IDENT-[A-Z0-9-]+$" }, "default": [] },
+        "identity_refs": { "type": "array", "items": { "$ref": "#/$defs/identityRef" }, "default": [] },
+        "state": { "$ref": "#/$defs/state" },
         "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
       }
     },
     "identity": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "name", "system", "principal_type", "description", "evidence"],
+      "required": ["id", "name", "system", "principal_type", "description", "state", "evidence"],
       "properties": {
-        "id": { "type": "string", "pattern": "^IDENT-[A-Z0-9-]+$" },
+        "id": { "$ref": "#/$defs/identityRef" },
         "name": { "type": "string", "minLength": 1 },
         "system": {
           "type": "string",
@@ -124,48 +240,105 @@
             "additionalProperties": false,
             "required": ["identity_ref", "mapping_mechanism", "same_principal"],
             "properties": {
-              "identity_ref": { "type": "string", "pattern": "^IDENT-[A-Z0-9-]+$" },
+              "identity_ref": { "$ref": "#/$defs/identityRef" },
               "mapping_mechanism": { "type": "string", "minLength": 1, "description": "HOW they map — never leave implicit." },
-              "same_principal": { "type": "boolean", "description": "false = federated/related but deliberately NOT the same principal." }
+              "same_principal": { "type": "boolean", "description": "false = federated/related but deliberately NOT the same principal. Must be consistent if the target identity also declares a mapping back to this one." }
             }
           },
           "default": []
         },
         "description": { "type": "string", "minLength": 1 },
+        "state": { "$ref": "#/$defs/state" },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    },
+    "credential": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "credential_type", "state", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^CRED-[A-Z0-9-]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "credential_type": {
+          "type": "string",
+          "enum": ["oidc-token", "spiffe-svid", "kubeconfig-cert", "github-oidc-token", "oci-signing-key", "openziti-identity-material", "openbao-token", "kubernetes-serviceaccount-token", "gpg-key", "ssh-key", "other"]
+        },
+        "issuer_ref": { "type": "string" },
+        "subject_identity_ref": { "$ref": "#/$defs/identityRef" },
+        "audience": { "type": "string" },
+        "lifetime": { "type": "string" },
+        "rotation": { "type": "string" },
+        "storage_ref": { "type": "string" },
+        "description": { "type": "string" },
+        "state": { "$ref": "#/$defs/state" },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    },
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "component_type", "description", "state", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^COMP-[A-Z0-9-]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "component_type": {
+          "type": "string",
+          "enum": ["compute", "network-gateway", "network-control", "control-plane", "service", "controller", "storage", "security-control", "ci-runner", "registry", "other"]
+        },
+        "trust_zone_ref": { "$ref": "#/$defs/locationRef" },
+        "identity_refs": { "type": "array", "items": { "$ref": "#/$defs/identityRef" }, "default": [] },
+        "owner_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "technical_owner_ref": { "type": "string" },
+        "security_owner_ref": { "type": "string" },
+        "data_owner_ref": { "type": "string" },
+        "description": { "type": "string", "minLength": 1 },
+        "state": { "$ref": "#/$defs/state" },
         "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
       }
     },
     "process": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "name", "description", "trust_zone_ref", "evidence"],
+      "required": ["id", "name", "description", "trust_zone_ref", "state", "evidence"],
       "properties": {
         "id": { "type": "string", "pattern": "^PROC-[A-Z0-9-]+$" },
         "name": { "type": "string", "minLength": 1 },
-        "description": { "type": "string", "minLength": 1 },
-        "trust_zone_ref": { "type": "string", "description": "ARCH-ZONE-* id, or 'EXTERNAL' if outside all modeled zones." },
+        "description": {
+          "type": "string", "minLength": 1,
+          "description": "processes[] is for DFD-projection-time process nodes — a data-transformation step that doesn't correspond 1:1 to a deployed resource. Standing infrastructure/platform resources belong in components[] instead (see model/README.md)."
+        },
+        "trust_zone_ref": { "$ref": "#/$defs/locationRef" },
         "owner_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "technical_owner_ref": { "type": "string" },
+        "security_owner_ref": { "type": "string" },
+        "data_owner_ref": { "type": "string" },
+        "state": { "$ref": "#/$defs/state" },
         "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
       }
     },
     "dataStore": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "name", "description", "trust_zone_ref", "data_classification", "evidence"],
+      "required": ["id", "name", "description", "trust_zone_ref", "data_classification", "state", "evidence"],
       "properties": {
         "id": { "type": "string", "pattern": "^DS-[A-Z0-9-]+$" },
         "name": { "type": "string", "minLength": 1 },
         "description": { "type": "string", "minLength": 1 },
-        "trust_zone_ref": { "type": "string" },
+        "trust_zone_ref": { "$ref": "#/$defs/locationRef" },
         "data_classification": { "type": "string", "enum": ["public", "internal", "confidential", "secret"] },
         "asset_refs": { "type": "array", "items": { "type": "string", "pattern": "^ASSET-[A-Z0-9-]+$" }, "default": [] },
+        "owner_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "technical_owner_ref": { "type": "string" },
+        "security_owner_ref": { "type": "string" },
+        "data_owner_ref": { "type": "string" },
+        "state": { "$ref": "#/$defs/state" },
         "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
       }
     },
     "asset": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "name", "asset_type", "confidentiality", "integrity", "availability", "description", "evidence"],
+      "required": ["id", "name", "asset_type", "security_requirements", "description", "state", "evidence"],
       "properties": {
         "id": { "type": "string", "pattern": "^ASSET-[A-Z0-9-]+$" },
         "name": { "type": "string", "minLength": 1 },
@@ -173,11 +346,13 @@
           "type": "string",
           "enum": ["data", "credential", "compute", "network-config", "container-image", "source-code", "other"]
         },
-        "confidentiality": { "$ref": "#/$defs/ciaLevel" },
-        "integrity": { "$ref": "#/$defs/ciaLevel" },
-        "availability": { "$ref": "#/$defs/ciaLevel" },
+        "security_requirements": { "$ref": "#/$defs/securityRequirements" },
         "owner_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "technical_owner_ref": { "type": "string" },
+        "security_owner_ref": { "type": "string" },
+        "data_owner_ref": { "type": "string" },
         "description": { "type": "string", "minLength": 1 },
+        "state": { "$ref": "#/$defs/state" },
         "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
       }
     },
@@ -185,31 +360,81 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "id", "name", "description", "source_ref", "destination_ref", "protocol", "direction",
-        "authentication", "authorization", "confidentiality_requirement", "integrity_requirement", "evidence"
+        "id", "name", "description", "source_ref", "destination_ref", "transport", "direction",
+        "authentication", "authorization", "security_requirements", "state", "evidence"
       ],
       "properties": {
         "id": { "type": "string", "pattern": "^FLOW-[A-Z0-9-]+$" },
         "name": { "type": "string", "minLength": 1 },
         "description": { "type": "string", "minLength": 1 },
-        "source_ref": { "type": "string", "minLength": 1 },
-        "destination_ref": { "type": "string", "minLength": 1 },
-        "protocol": { "type": "string", "minLength": 1 },
-        "port": { "anyOf": [{ "type": "integer", "minimum": 0, "maximum": 65535 }, { "type": "string" }] },
+        "source_ref": { "$ref": "#/$defs/endpointRef" },
+        "destination_ref": { "$ref": "#/$defs/endpointRef" },
+        "transport": { "$ref": "#/$defs/transport" },
         "direction": { "type": "string", "enum": ["inbound", "outbound", "bidirectional"] },
-        "authentication": {
-          "type": "string",
-          "enum": ["none", "mtls", "oidc-token", "ssh-key", "oci-signing-key", "spiffe-svid", "gpg-signature", "kubeconfig-cert", "other"]
-        },
-        "authorization": {
-          "type": "string",
-          "enum": ["none", "oci-iam-policy", "kubernetes-rbac", "nsg-security-list", "kyverno-policy", "openziti-policy", "github-branch-protection", "other"]
-        },
+        "authentication": { "$ref": "#/$defs/authentication" },
+        "authorization": { "$ref": "#/$defs/authorization" },
         "data_asset_refs": { "type": "array", "items": { "type": "string", "pattern": "^ASSET-[A-Z0-9-]+$" }, "default": [] },
-        "confidentiality_requirement": { "$ref": "#/$defs/ciaLevel" },
-        "integrity_requirement": { "$ref": "#/$defs/ciaLevel" },
+        "data_semantics": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string",
+            "enum": ["control-plane-api-request", "credential-token", "cluster-state", "container-image", "sbom", "secret", "telemetry", "backup-data", "source-code", "other"]
+          },
+          "description": "Categorical tag for what crosses this flow when data_asset_refs is empty or insufficiently specific. Avoid duplicating what an asset ref already states."
+        },
+        "security_requirements": { "$ref": "#/$defs/securityRequirements" },
         "crosses_boundary_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
         "traffic_class_ref": { "type": "string", "pattern": "^ARCH-FLOW-[A-Z0-9-]+$" },
+        "state": { "$ref": "#/$defs/state" },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "policy_type", "effect", "state", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^POLICY-[A-Z0-9-]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "policy_type": {
+          "type": "string",
+          "enum": ["oci-iam-policy", "oci-nsg-rule", "oci-security-list", "kubernetes-role", "kubernetes-clusterrole", "kubernetes-rolebinding", "kubernetes-clusterrolebinding", "openziti-service-policy", "openbao-policy", "cilium-networkpolicy", "kyverno-policy", "github-permissions", "github-branch-protection", "other"]
+        },
+        "principal_refs": { "type": "array", "items": { "$ref": "#/$defs/principalRef" }, "default": [] },
+        "resource_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "actions": { "type": "array", "items": { "type": "string" }, "default": [], "description": "May be empty when state=decision-pending — do not guess least-privilege scope ahead of the owning Spec." },
+        "scope_ref": { "type": "string" },
+        "effect": { "type": "string", "enum": ["allow", "deny", "unspecified"] },
+        "state": { "$ref": "#/$defs/state" },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    },
+    "control": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "control_type", "description", "state", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^CTRL-[A-Z0-9-]+$" },
+        "name": { "type": "string", "minLength": 1 },
+        "control_type": { "type": "string", "enum": ["preventive", "detective", "corrective", "deterrent", "compensating"] },
+        "description": { "type": "string", "minLength": 1 },
+        "implements_refs": { "type": "array", "items": { "type": "string" }, "default": [], "description": "Policy/component refs this control realizes." },
+        "state": { "$ref": "#/$defs/state" },
+        "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
+      }
+    },
+    "gap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "subject_ref", "field", "reason", "blocking", "evidence"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^GAP-[A-Z0-9-]+$" },
+        "subject_ref": { "type": "string", "minLength": 1, "description": "The corpus element id this gap is about." },
+        "field": { "type": "string", "minLength": 1, "description": "Which field on the subject is undecided, e.g. 'transport.ports'." },
+        "reason": { "type": "string", "minLength": 1 },
+        "blocking": { "type": "boolean" },
+        "resolution_ref": { "type": "string", "description": "e.g. a SPIKE-* id that will resolve this." },
         "evidence": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidence" } }
       }
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Tooling for validating docs/ architecture artifacts. No application code lives here.",
   "scripts": {
     "validate:mermaid": "find docs -name '*.mmd' -print0 | xargs -0 -I{} mmdc -p docs/mermaid-puppeteer-config.json -i {} -o /tmp/mmdc-validate.svg",
-    "validate:threat-model": "node scripts/validate-threat-model.mjs"
+    "validate:threat-model": "node scripts/validate-threat-model.mjs",
+    "test:threat-model": "node scripts/validate-threat-model.test.mjs"
   },
   "devDependencies": {
     "@mermaid-js/mermaid-cli": "11.16.0",

--- a/scripts/validate-threat-model.mjs
+++ b/scripts/validate-threat-model.mjs
@@ -57,7 +57,7 @@ const COLLECTION_KEYS = [
 // Top-level scalar fields on any collection item that must resolve to a known ID.
 const REF_SCALAR_FIELDS = [
   "trust_zone_ref", "source_ref", "destination_ref", "class_ref", "traffic_class_ref",
-  "parent_ref", "subject_ref", "subject_identity_ref",
+  "parent_ref", "subject_ref", "subject_identity_ref", "scope_ref",
   "technical_owner_ref", "security_owner_ref", "data_owner_ref",
 ];
 // Top-level array fields (of plain string refs) that must resolve.

--- a/scripts/validate-threat-model.mjs
+++ b/scripts/validate-threat-model.mjs
@@ -1,16 +1,30 @@
 #!/usr/bin/env node
 // Validates every docs/03-threat-model/model/instances/*.yaml file against
 // docs/03-threat-model/model/schema/threat-model.schema.json, then checks
-// corpus-wide referential integrity: no duplicate IDs across files, and
-// every *_ref field resolves to a real ID (a corpus element, a known
-// ARCH-* concept from traceability.md, or the literal 'EXTERNAL').
+// corpus-wide invariants beyond what JSON Schema alone can express:
 //
-// Known limitation: ref resolution checks *existence*, not *type* —
+//   1. No duplicate IDs across files.
+//   2. Every *_ref field resolves to a real ID (a corpus element, a known
+//      ARCH-* concept read live from traceability.md — not a separately
+//      maintained copy that could drift — or the literal 'EXTERNAL').
+//   3. No two identities' maps_to entries disagree about same_principal
+//      for the same pair.
+//   4. Every element with state=implemented has >=1 evidence entry with
+//      status=implemented — an element's curated state can't outrun what
+//      any of its sources actually assert.
+//   5. Every element with state=decision-pending has >=1 gaps[] entry
+//      whose subject_ref names it (scoped to top-level element state
+//      only, not nested authn/authz-mechanism/transport state — see
+//      README for why that's a deliberate v2 scope limit, not an
+//      oversight).
+//
+// Known limitation: ref resolution (#2) checks *existence*, not *type* —
 // e.g. a `trust_zone_ref` pointing at an ASSET-* id would pass this check
 // even though it's semantically wrong. Schema `pattern` constraints catch
-// the common case (most ref fields are typed by ID prefix); the free-form
-// ref fields (trust_zone_ref, source_ref, destination_ref, owner_refs,
-// separates) are existence-checked only.
+// the common case; policy.resource_refs and credential issuer_ref/
+// storage_ref are intentionally NOT existence-checked, since they may
+// legitimately name something outside this corpus (an OCI resource path,
+// an external system) rather than another corpus element.
 import { readFileSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -27,15 +41,30 @@ try {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, "..");
 const MODEL_DIR = join(REPO_ROOT, "docs/03-threat-model/model");
-const INSTANCES_DIR = join(MODEL_DIR, "instances");
-const SCHEMA_PATH = join(MODEL_DIR, "schema/threat-model.schema.json");
-const TRACEABILITY_PATH = join(REPO_ROOT, "docs/01-architecture/traceability.md");
 
-const REF_ARRAY_FIELDS = [
-  "identity_refs", "maps_to", "owner_refs", "asset_refs",
-  "data_asset_refs", "crosses_boundary_refs", "separates",
+// Overridable for testing against fixture corpora (see check-gpg-signing.sh
+// for the equivalent pattern used elsewhere in this repo: isolate, don't
+// mock the logic under test).
+const INSTANCES_DIR = process.env.THREAT_MODEL_INSTANCES_DIR || join(MODEL_DIR, "instances");
+const SCHEMA_PATH = process.env.THREAT_MODEL_SCHEMA_PATH || join(MODEL_DIR, "schema/threat-model.schema.json");
+const TRACEABILITY_PATH = process.env.THREAT_MODEL_TRACEABILITY_PATH || join(REPO_ROOT, "docs/01-architecture/traceability.md");
+
+const COLLECTION_KEYS = [
+  "scopes", "trust_zones", "trust_boundaries", "actors", "identities", "credentials",
+  "components", "processes", "data_stores", "assets", "data_flows", "policies", "controls", "gaps",
 ];
-const REF_SCALAR_FIELDS = ["trust_zone_ref", "source_ref", "destination_ref", "class_ref", "traffic_class_ref"];
+
+// Top-level scalar fields on any collection item that must resolve to a known ID.
+const REF_SCALAR_FIELDS = [
+  "trust_zone_ref", "source_ref", "destination_ref", "class_ref", "traffic_class_ref",
+  "parent_ref", "subject_ref", "subject_identity_ref",
+  "technical_owner_ref", "security_owner_ref", "data_owner_ref",
+];
+// Top-level array fields (of plain string refs) that must resolve.
+const REF_ARRAY_FIELDS = [
+  "identity_refs", "owner_refs", "asset_refs", "data_asset_refs", "crosses_boundary_refs",
+  "side_a_refs", "side_b_refs", "implements_refs", "principal_refs",
+];
 
 function loadArchIds() {
   const text = readFileSync(TRACEABILITY_PATH, "utf8");
@@ -43,11 +72,32 @@ function loadArchIds() {
 }
 
 function collectionKeys(doc) {
-  return ["trust_zones", "trust_boundaries", "actors", "identities", "processes", "data_stores", "assets", "data_flows"]
-    .filter((k) => Array.isArray(doc[k]));
+  return COLLECTION_KEYS.filter((k) => Array.isArray(doc[k]));
 }
 
-function main() {
+function checkRef(file, item, label, ref, allKnownIds, errors) {
+  if (ref && !allKnownIds.has(ref)) {
+    errors.push(`FAILED (dangling ref) - ${file}: ${item.id}.${label} -> '${ref}' not found`);
+  }
+}
+
+function checkMechanisms(file, item, fieldName, mechanisms, allKnownIds, errors) {
+  if (!Array.isArray(mechanisms)) return;
+  mechanisms.forEach((m, i) => {
+    checkRef(file, item, `${fieldName}.mechanisms[${i}].identity_ref`, m.identity_ref, allKnownIds, errors);
+    for (const ref of m.policy_refs || []) {
+      checkRef(file, item, `${fieldName}.mechanisms[${i}].policy_refs[]`, ref, allKnownIds, errors);
+    }
+    for (const ref of m.principal_refs || []) {
+      checkRef(file, item, `${fieldName}.mechanisms[${i}].principal_refs[]`, ref, allKnownIds, errors);
+    }
+    // authority_ref is intentionally not existence-checked: it may name an
+    // ARCH-* concept, a component, or (per the schema's own description)
+    // something not yet minted as a corpus element.
+  });
+}
+
+async function main() {
   const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
   const ajv = new Ajv2020({ allErrors: true, strict: true });
   const validate = ajv.compile(schema);
@@ -60,8 +110,9 @@ function main() {
     process.exit(1);
   }
 
-  let failed = false;
+  const errors = [];
   const idOwner = new Map(); // id -> file it was first seen in
+  const idToItem = new Map(); // id -> item, for the same_principal/state checks
   const allKnownIds = new Set(["EXTERNAL", ...archIds]);
   const perFileDocs = [];
 
@@ -73,10 +124,9 @@ function main() {
 
     const ok = validate(doc);
     if (!ok) {
-      failed = true;
-      console.error(`FAILED (schema) - ${file}`);
+      errors.push(`FAILED (schema) - ${file}`);
       for (const err of validate.errors) {
-        console.error(`  ${err.instancePath || "(root)"} ${err.message}`);
+        errors.push(`  ${err.instancePath || "(root)"} ${err.message}`);
       }
       continue;
     }
@@ -84,10 +134,10 @@ function main() {
     for (const key of collectionKeys(doc)) {
       for (const item of doc[key]) {
         if (idOwner.has(item.id)) {
-          failed = true;
-          console.error(`FAILED (duplicate id) - ${item.id} in ${file} already defined in ${idOwner.get(item.id)}`);
+          errors.push(`FAILED (duplicate id) - ${item.id} in ${file} already defined in ${idOwner.get(item.id)}`);
         } else {
           idOwner.set(item.id, file);
+          idToItem.set(item.id, item);
           allKnownIds.add(item.id);
         }
       }
@@ -95,8 +145,9 @@ function main() {
     console.log(`PASS (schema) - ${file}`);
   }
 
-  if (failed) {
-    console.error("\nSchema/duplicate-id errors found — skipping referential-integrity pass.");
+  if (errors.length > 0) {
+    console.error(errors.join("\n"));
+    console.error("\nSchema/duplicate-id errors found — skipping remaining checks.");
     process.exit(1);
   }
 
@@ -105,33 +156,74 @@ function main() {
     for (const key of collectionKeys(doc)) {
       for (const item of doc[key]) {
         for (const field of REF_SCALAR_FIELDS) {
-          const val = item[field];
-          if (val && !allKnownIds.has(val)) {
-            failed = true;
-            console.error(`FAILED (dangling ref) - ${file}: ${item.id}.${field} -> '${val}' not found`);
-          }
+          checkRef(file, item, field, item[field], allKnownIds, errors);
         }
         for (const field of REF_ARRAY_FIELDS) {
-          const arr = item[field];
-          if (!Array.isArray(arr)) continue;
-          for (const entry of arr) {
-            const ref = typeof entry === "string" ? entry : entry.identity_ref;
-            if (ref && !allKnownIds.has(ref)) {
-              failed = true;
-              console.error(`FAILED (dangling ref) - ${file}: ${item.id}.${field}[] -> '${ref}' not found`);
-            }
+          for (const ref of item[field] || []) checkRef(file, item, `${field}[]`, ref, allKnownIds, errors);
+        }
+        for (const entry of item.maps_to || []) {
+          checkRef(file, item, "maps_to[].identity_ref", entry.identity_ref, allKnownIds, errors);
+        }
+        if (item.authentication) checkMechanisms(file, item, "authentication", item.authentication.mechanisms, allKnownIds, errors);
+        if (item.authorization) checkMechanisms(file, item, "authorization", item.authorization.mechanisms, allKnownIds, errors);
+      }
+    }
+  }
+
+  // Pass 3: same_principal consistency — if A says (B, same_principal=X) and
+  // B also says (A, same_principal=Y), X must equal Y.
+  for (const { file, doc } of perFileDocs) {
+    for (const identity of doc.identities || []) {
+      for (const entry of identity.maps_to || []) {
+        const target = idToItem.get(entry.identity_ref);
+        if (!target || !Array.isArray(target.maps_to)) continue;
+        const reverse = target.maps_to.find((e) => e.identity_ref === identity.id);
+        if (reverse && reverse.same_principal !== entry.same_principal) {
+          errors.push(
+            `FAILED (contradictory same_principal) - ${file}: ${identity.id} says same_principal=${entry.same_principal} ` +
+              `for ${entry.identity_ref}, but ${entry.identity_ref} says same_principal=${reverse.same_principal} for ${identity.id}`
+          );
+        }
+      }
+    }
+  }
+
+  // Pass 4: state=implemented requires >=1 evidence entry with status=implemented.
+  for (const { file, doc } of perFileDocs) {
+    for (const key of collectionKeys(doc)) {
+      for (const item of doc[key]) {
+        if (item.state === "implemented") {
+          const hasImplementedEvidence = (item.evidence || []).some((e) => e.status === "implemented");
+          if (!hasImplementedEvidence) {
+            errors.push(`FAILED (unsupported implemented) - ${file}: ${item.id} has state=implemented but no evidence entry has status=implemented`);
           }
         }
       }
     }
   }
 
-  if (failed) {
-    console.error("\nReferential-integrity errors found.");
+  // Pass 5: state=decision-pending requires a gaps[] entry naming this element.
+  const gapSubjects = new Set();
+  for (const { doc } of perFileDocs) {
+    for (const gap of doc.gaps || []) gapSubjects.add(gap.subject_ref);
+  }
+  for (const { file, doc } of perFileDocs) {
+    for (const key of collectionKeys(doc)) {
+      if (key === "gaps") continue;
+      for (const item of doc[key]) {
+        if (item.state === "decision-pending" && !gapSubjects.has(item.id)) {
+          errors.push(`FAILED (undocumented decision-pending) - ${file}: ${item.id} has state=decision-pending but no gaps[] entry has subject_ref='${item.id}'`);
+        }
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(errors.join("\n"));
     process.exit(1);
   }
 
-  console.log(`\nAll ${files.length} instance file(s) valid. ${idOwner.size} corpus IDs, all references resolve.`);
+  console.log(`\nAll ${files.length} instance file(s) valid. ${idOwner.size} corpus IDs, all invariants hold.`);
 }
 
 main();

--- a/scripts/validate-threat-model.test.mjs
+++ b/scripts/validate-threat-model.test.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+// Deterministic tests for validate-threat-model.mjs. Each case writes a
+// small, self-contained fixture instance file (no ARCH-* refs, so these
+// don't depend on traceability.md's exact content) to an isolated temp
+// directory, runs the validator as a subprocess against it via the
+// THREAT_MODEL_INSTANCES_DIR/SCHEMA_PATH/TRACEABILITY_PATH env overrides,
+// and asserts the exit code. Mirrors check-gpg-signing.test.sh's pattern:
+// isolate, don't mock the logic under test.
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const VALIDATOR = join(__dirname, "validate-threat-model.mjs");
+const SCHEMA_PATH = join(REPO_ROOT, "docs/03-threat-model/model/schema/threat-model.schema.json");
+// Fixtures deliberately avoid ARCH-* refs, but the validator always reads
+// this file — point it at the real one so 'EXTERNAL' + no ARCH-* usage
+// still resolves correctly regardless of its content.
+const TRACEABILITY_PATH = join(REPO_ROOT, "docs/01-architecture/traceability.md");
+
+let PASS = 0, FAIL = 0;
+
+const BASE_ACTOR = `
+  - id: ACTOR-TEST
+    name: Test actor
+    actor_type: human
+    description: fixture
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-TEST.md", status: specified }`;
+
+function fixtureHeader(extra = "") {
+  return `domain: network
+schema_version: 2.0.0
+model_version: 0.1.0
+generated_from:
+  - { source_type: spec, ref: "SPEC-TEST.md", status: specified }
+${extra}
+`;
+}
+
+function runCase(name, expectedExit, yamlContent) {
+  const dir = mkdtempSync(join(tmpdir(), "threat-model-test-"));
+  const instancesDir = join(dir, "instances");
+  mkdirSync(instancesDir);
+  writeFileSync(join(instancesDir, "network.yaml"), yamlContent);
+
+  const result = spawnSync("node", [VALIDATOR], {
+    env: {
+      ...process.env,
+      THREAT_MODEL_INSTANCES_DIR: instancesDir,
+      THREAT_MODEL_SCHEMA_PATH: SCHEMA_PATH,
+      THREAT_MODEL_TRACEABILITY_PATH: TRACEABILITY_PATH,
+    },
+    encoding: "utf8",
+  });
+
+  rmSync(dir, { recursive: true, force: true });
+
+  if (result.status === expectedExit) {
+    console.log(`PASS: ${name}`);
+    PASS++;
+  } else {
+    console.error(`FAIL: ${name} (expected exit ${expectedExit}, got ${result.status})`);
+    console.error(result.stdout, result.stderr);
+    FAIL++;
+  }
+}
+
+// 1. Valid minimal corpus -> passes.
+runCase("valid minimal corpus", 0, fixtureHeader(`actors:${BASE_ACTOR}`));
+
+// 2. Dangling ref -> fails.
+runCase(
+  "dangling ref",
+  1,
+  fixtureHeader(`actors:
+  - id: ACTOR-TEST
+    name: Test actor
+    actor_type: human
+    description: fixture
+    identity_refs: ["IDENT-DOES-NOT-EXIST"]
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-TEST.md", status: specified }`)
+);
+
+// 3. Duplicate ID -> fails.
+runCase(
+  "duplicate id",
+  1,
+  fixtureHeader(`actors:${BASE_ACTOR}${BASE_ACTOR}`)
+);
+
+// 4. Invalid enum value -> schema failure.
+runCase(
+  "invalid enum value",
+  1,
+  fixtureHeader(`actors:
+  - id: ACTOR-TEST
+    name: Test actor
+    actor_type: not-a-real-type
+    description: fixture
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-TEST.md", status: specified }`)
+);
+
+// 5. Contradictory same_principal -> fails.
+runCase(
+  "contradictory same_principal",
+  1,
+  fixtureHeader(`identities:
+  - id: IDENT-A
+    name: Identity A
+    system: github
+    principal_type: user
+    description: fixture
+    maps_to:
+      - { identity_ref: IDENT-B, mapping_mechanism: test, same_principal: true }
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-TEST.md", status: specified }
+  - id: IDENT-B
+    name: Identity B
+    system: oci-iam
+    principal_type: user
+    description: fixture
+    maps_to:
+      - { identity_ref: IDENT-A, mapping_mechanism: test, same_principal: false }
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-TEST.md", status: specified }`)
+);
+
+// 6. Consistent same_principal (both true) -> passes.
+runCase(
+  "consistent same_principal",
+  0,
+  fixtureHeader(`identities:
+  - id: IDENT-A
+    name: Identity A
+    system: github
+    principal_type: user
+    description: fixture
+    maps_to:
+      - { identity_ref: IDENT-B, mapping_mechanism: test, same_principal: true }
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-TEST.md", status: specified }
+  - id: IDENT-B
+    name: Identity B
+    system: oci-iam
+    principal_type: user
+    description: fixture
+    maps_to:
+      - { identity_ref: IDENT-A, mapping_mechanism: test, same_principal: true }
+    state: specified
+    evidence:
+      - { source_type: spec, ref: "SPEC-TEST.md", status: specified }`)
+);
+
+// 7. state=implemented with only planned evidence -> fails.
+runCase(
+  "implemented without implemented evidence",
+  1,
+  fixtureHeader(`actors:
+  - id: ACTOR-TEST
+    name: Test actor
+    actor_type: human
+    description: fixture
+    state: implemented
+    evidence:
+      - { source_type: spec, ref: "SPEC-TEST.md", status: planned }`)
+);
+
+// 8. state=implemented WITH implemented evidence -> passes.
+runCase(
+  "implemented with implemented evidence",
+  0,
+  fixtureHeader(`actors:
+  - id: ACTOR-TEST
+    name: Test actor
+    actor_type: human
+    description: fixture
+    state: implemented
+    evidence:
+      - { source_type: spec, ref: "SPEC-TEST.md", status: implemented }`)
+);
+
+// 9. state=decision-pending with no gaps[] entry -> fails.
+runCase(
+  "decision-pending without gap",
+  1,
+  fixtureHeader(`actors:
+  - id: ACTOR-TEST
+    name: Test actor
+    actor_type: human
+    description: fixture
+    state: decision-pending
+    evidence:
+      - { source_type: spec, ref: "SPEC-TEST.md", status: decision-pending }`)
+);
+
+// 10. state=decision-pending WITH a matching gaps[] entry -> passes.
+runCase(
+  "decision-pending with gap",
+  0,
+  fixtureHeader(`actors:
+  - id: ACTOR-TEST
+    name: Test actor
+    actor_type: human
+    description: fixture
+    state: decision-pending
+    evidence:
+      - { source_type: spec, ref: "SPEC-TEST.md", status: decision-pending }
+gaps:
+  - id: GAP-TEST-001
+    subject_ref: ACTOR-TEST
+    field: some-field
+    reason: fixture reason
+    blocking: false
+    evidence:
+      - { source_type: spec, ref: "SPEC-TEST.md", status: decision-pending }`)
+);
+
+console.log(`\n${PASS} passed, ${FAIL} failed`);
+process.exit(FAIL === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Schema-hardening pass on the threat-model normalized corpus (PR #35), addressing a full review before scaling to the remaining five domains. Breaking change (`schema_version` 0.1.0 → 2.0.0), made deliberately now while only `network.yaml` exists.

v1 was too DFD-shaped for what this corpus must eventually drive: policies, credentials, and an IAM/PAM/RBAC/JIT/JEA authorization graph. Full BEFORE/AFTER examples for every change are in [`model/README.md`](docs/03-threat-model/model/README.md#v2--schema-hardening-pass-schema_version-200).

### Structural changes

- **Element-level `state`**, separate from `evidence[].status` — evidence answers "what maturity does this source assert", `state` answers "what is this element's actual state", curated explicitly and never derived. Validator enforces `state=implemented` requires ≥1 evidence entry with `status=implemented`.
- **`components[]`**: standing infrastructure (gateways, control planes, NSGs) no longer masquerades as a DFD `process`. `processes[]` is now reserved for DFD-projection-time nodes this corpus sits above.
- **`policies[]`** and **`controls[]`**: first-class WHO/identity/engine/policy/action/scope facts — still not threats/risk, that stays deferred.
- **`credentials[]`**: distinct from generic `asset_type: credential` — `credential_type`, `issuer_ref`, `subject_identity_ref`, `audience`, `lifetime`, `rotation`, `storage_ref`.
- **Structured `authentication`/`authorization`**: `{required, mechanisms: [...]}` instead of a single lossy enum — a flow can now represent multiple mechanisms across hops.
- **`transport` object** replaces flat `protocol`/`port` strings.
- **`security_requirements`** (CIA + optional `authenticity`/`non_repudiation`) replaces flat CIA fields.
- **`gaps[]`**: `subject_ref`/`field`/`reason`/`blocking`/`resolution_ref` — replaces prose like `port: "undecided — ..."` baked into typed fields. Validator enforces every `state=decision-pending` element has a `gaps[]` entry naming it.
- **`scopes[]`** (containment via `parent_ref`) fixes a real bug flagged in review: v1's `ARCH-NET-VCN` trust boundary listed the compartment plus all four zones under `separates`, conflating containment with a crossing — exactly the shape that risks a downstream attack-path generator inferring false boundary crossings. `trust_boundaries` now require `side_a_refs`/`side_b_refs` (a genuine two-sided crossing only); the v1 N-way `TB-ZONE-ISOLATION` boundary was removed entirely — zone-to-zone crossings are already inferable from a flow's source/destination zone membership.
- `endpointRef`/`locationRef` JSON Schema patterns now type `source_ref`/`destination_ref`/`trust_zone_ref` directly, not left to the custom validator alone.

### Validator hardening

Referential-integrity checks extended to every new collection and nested authn/authz mechanism refs; new same_principal-consistency check (two identities can't disagree about whether they're the same principal); the two new `state`-based invariants above. Paths made env-overridable specifically so the validator is testable in isolation.

### New: `scripts/validate-threat-model.test.mjs`

10 deterministic fixture cases run as subprocesses against isolated temp instance directories, proving the validator's invariants actually fire (not just the schema-level ones already proven manually in #35): valid corpus, dangling ref, duplicate id, bad enum, contradictory `same_principal` ×2, implemented with/without implemented evidence, decision-pending with/without a gap. Wired into `npm run test:threat-model`, CI, and pre-commit.

### `network.yaml` migration

Full migration, no architectural meaning lost: same 7 traffic classes, same REQ-NET-019 enforcement chain, same explicit undecided-not-invented discipline for Edge ingress — now as a proper `gaps[]` entry noting no SPIKE currently tracks that decision (a real, previously-implicit finding). 4 scopes, 4 trust zones, 1 trust boundary (down from 5 — the other 4 were containment, not genuine crossings), 1 actor, 1 identity, 2 credentials, 12 components (including all 5 REQ-NET-017 NSGs), 1 asset, 1 policy, 2 controls, 3 gaps, 11 data flows.

## Validation

- [x] `npm run test:threat-model`: 10/10 passed
- [x] `npm run validate:threat-model`: 1/1 instance valid, 42 corpus IDs, all invariants hold
- [x] `pre-commit run --all-files`: all hooks passed
- [x] `npx markdownlint-cli2` (full repo-wide glob): 0 issues
- [x] Commit is DCO sign-off'd and GPG-signed (`git log --format=%G?` → `G`)

## Impact

- [x] Architecture decision changed (threat-model corpus schema, breaking)
- [x] Threat model / trust boundaries / DFD / risk register affected (this is the schema DFDs will be generated from)
- [ ] New infrastructure state boundary introduced
- [ ] Credential, secret, or access policy touched
- [x] README / docs updated

## Not in this PR

Still not scaling to the remaining five domains (`identity`, `governance`, `cicd`, `kubernetes`, `context`) — that's the next review gate.
