### PR TITLE
feat: IaC foundation conventions, state DAG, and Terragrunt skeleton (PR A)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: davidanson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
         with:
           config: .markdownlint-cli2.yaml
-          globs: "docs/**/*.md README.md SECURITY.md CONTRIBUTING.md AGENTS.md .github/**/*.md"
+          globs: "docs/**/*.md README.md SECURITY.md CONTRIBUTING.md AGENTS.md infrastructure/**/*.md .github/**/*.md"
           no-ignore: true
 
   mermaid:

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -14,4 +14,5 @@ globs:
   - "docs/**/*.md"
   - "*.md"
   - ".github/**/*.md"
+  - "infrastructure/**/*.md"
 no-ignore: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,13 @@ repos:
         files: '^scripts/validate-threat-model(\.test)?\.mjs$'
         pass_filenames: false
 
+      - id: terragrunt-hclfmt
+        name: Terragrunt HCL format check
+        entry: bash -c 'cd infrastructure/live && terragrunt hcl fmt --check'
+        language: system
+        files: '^infrastructure/live/.*\.hcl$'
+        pass_filenames: false
+
       - id: check-dco
         name: Developer Certificate of Origin (Signed-off-by)
         entry: .githooks/commit-msg

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,17 @@ never any other source (`SPEC-NET-004.md` REQ-NET-019).
 - `scripts/check-gpg-signing.test.sh`: deterministic config-only tests for
   the above (isolated from your real `~/.gitconfig`; no real signing key
   needed). Runs automatically via pre-commit when either file changes.
+- `npm run validate:threat-model`: schema + corpus-wide referential
+  integrity for `docs/03-threat-model/model/instances/*.yaml`.
+- `npm run test:threat-model`: the validator's own fixture-based
+  self-test (no real corpus data). Run this before
+  `validate:threat-model` when you've touched the validator itself.
+- `terragrunt hcl fmt --check` / `terragrunt hcl validate` (run from
+  `infrastructure/live/`): format-check and semantic-validate every
+  Terragrunt HCL file — works even before any per-unit `terragrunt.hcl`
+  exists, since it validates the shared `root.hcl`/`common/*.hcl`
+  composition layer directly. See `infrastructure/README.md` for the
+  state-unit layout these compose.
 - `tofu fmt -recursive infrastructure`, `tflint --recursive`,
   `checkov -d infrastructure`, and — critically — validate each
   configuration directory individually, never from the repo root, once

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,10 @@ source of truth for what is deployed. Treat every change as a reviewable unit.
 
 ## Ownership model
 
-- **OpenTofu** owns OCI infrastructure.
+- **OpenTofu** owns OCI resource logic (`infrastructure/modules/`);
+  **Terragrunt** owns environment composition and state boundaries
+  (`infrastructure/live/`) — see `infrastructure/README.md` for the
+  state-unit DAG.
 - **Talos** owns node configuration.
 - **Flux** owns Kubernetes desired state. GitHub Actions never deploy.
 - **Cilium / SPIRE / OpenBao / ESO / Kyverno** own their respective control planes.
@@ -47,6 +50,8 @@ Run before pushing:
 scripts/check-gpg-signing.sh
 pre-commit run --all-files
 npm run validate:mermaid              # if any docs/**/*.mmd changed
+npm run validate:threat-model         # if docs/03-threat-model/model/** changed
+terragrunt hcl fmt --check            # from infrastructure/live/, if any *.hcl changed
 tofu fmt -recursive infrastructure
 tflint --recursive
 checkov -d infrastructure

--- a/infrastructure/.tflint.hcl
+++ b/infrastructure/.tflint.hcl
@@ -1,4 +1,6 @@
 plugin "terraform" {
   enabled = true
   preset  = "recommended"
+  version = "0.15.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-terraform"
 }

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,297 @@
+# Infrastructure
+
+Status: **design stage** — this document defines the conventions,
+traceability, and state architecture that every module/live unit under
+this directory must follow. No OCI resources have been applied yet. See
+[docs/01-architecture/foundation.md](../docs/01-architecture/foundation.md)
+for the as-built compartment/IAM/state-backend documentation once
+`SPEC-OCI-001` is actually implemented — per
+[docs/01-architecture/README.md](../docs/01-architecture/README.md#diagrams-to-be-added-as-their-owning-spec-ships),
+that file is added by the PR that implements it, not before. This
+document is different: it is IaC tooling/convention documentation for the
+`infrastructure/` directory itself, not an architecture view.
+
+## Layout
+
+```text
+infrastructure/
+├── modules/        OpenTofu modules — resource logic, environment-neutral
+│   └── README.md    the module contract standard every module follows
+├── compositions/    (reserved — wiring multiple modules together, if a
+│                     unit ever needs more than one module; empty for M1)
+└── live/            Terragrunt — environment composition, state, DAG
+    ├── root.hcl
+    ├── common/       shared account/tags/version configuration
+    └── oci/eu-madrid-1/lab/   the only environment that exists so far
+```
+
+## Toolchain (verified against authoritative sources, not memory)
+
+| Tool | Version | Source checked |
+| --- | --- | --- |
+| OpenTofu | v1.12.5 | [opentofu/opentofu releases](https://github.com/opentofu/opentofu/releases/latest) — matches local install |
+| Terragrunt | v1.1.3 | [gruntwork-io/terragrunt releases](https://github.com/gruntwork-io/terragrunt/releases/latest) — matches local install |
+| `oracle/oci` provider | v8.27.0 | [oracle/terraform-provider-oci releases](https://github.com/oracle/terraform-provider-oci/releases/latest) |
+| `tflint-ruleset-terraform` | v0.15.0 | [terraform-linters/tflint-ruleset-terraform releases](https://github.com/terraform-linters/tflint-ruleset-terraform/releases/latest) — was unpinned in `.tflint.hcl`, fixed by this change |
+| checkov | via `bridgecrewio/checkov-action` (already pinned in `validate.yml`) | manages its own checkov version |
+
+`validate.yml` pins `tofu_version: "1.x"` (floating minor) via
+`opentofu/setup-opentofu` — intentional, matches that workflow's existing
+convention rather than hard-pinning a patch version CI would need
+updating for every OpenTofu release.
+
+## Requirement-to-resource traceability matrix
+
+Every module below is planned, not yet built. This matrix is the
+contract each future PR's module must satisfy — no resource may be added
+without a row here tracing it to a requirement.
+
+| Spec | Requirements | ARCH ID(s) | Threat-model corpus ref | Module | State unit |
+| --- | --- | --- | --- | --- | --- |
+| SPEC-OCI-001 | REQ-OCI-001..007 | `ARCH-GOV-TENANCY` | `ARCH-OCI-TENANCY`/`ARCH-OCI-COMPARTMENT` scopes (`network.yaml`) | `modules/oci-foundation` | `00-foundation` |
+| SPEC-NET-001 | REQ-NET-001..005 | `ARCH-NET-VCN`, `ARCH-ZONE-*` | `network.yaml` trust_zones (4, already schema-validated) | `modules/oci-network` | `10-network` |
+| SPEC-NET-002 | REQ-NET-006..010 | `ARCH-GW-IGW/NAT/SGW/DRG` | `network.yaml` components `COMP-INTERNET-GATEWAY`/`COMP-NAT-GATEWAY`/`COMP-SERVICE-GATEWAY` | `modules/oci-network` | `10-network` |
+| SPEC-NET-003 | REQ-NET-011..015 | `ARCH-FLOW-INGRESS/EGRESS/SERVICE` | `network.yaml` `FLOW-*` (transport/authz already modeled) | `modules/oci-network` | `10-network` |
+| SPEC-NET-004 | REQ-NET-016..020 | `ARCH-ZONE-MGMT`, NSGs | `network.yaml` `POLICY-CONTROL-NSG-6443`, `CTRL-K8S-API-INGRESS-RESTRICTION`, `COMP-*-NSG` (5) | `modules/oci-network` | `10-network` |
+| SPEC-NET-006 | REQ-NET-028..030 | `ARCH-NET-DNS` | not yet in `network.yaml` — DNS/DHCP wasn't part of the network-domain PoC migration | `modules/oci-network` | `10-network` |
+| SPEC-NET-005 | REQ-NET-021..027 | all `ARCH-FLOW-*` | verification layer — **no module, no state unit** (ADR-0007) | n/a (`tofu test` cross-module assertions) | n/a |
+| SPEC-OCI-002 | REQ-OCI-008..011 | `ARCH-SVC-KMS` | not yet in `network.yaml` (identity/governance domain, not populated) | `modules/oci-kms` | `20-security/kms` |
+| SPEC-OCI-003 | REQ-OCI-012..015 | `ARCH-SVC-LOGGING`, `ARCH-SVC-MONITORING` | not yet in `network.yaml` | `modules/oci-logging-monitoring` | `20-security/logging-monitoring` |
+
+Module names above (`oci-foundation`, `oci-network`, `oci-kms`,
+`oci-logging-monitoring`) are proposed, not yet accepted — each is
+confirmed or revised in the PR that actually scaffolds it, per the master
+execution prompt's instruction not to accept module names blindly.
+
+Threat-model corpus gaps this matrix surfaces (real findings, not
+invented): `network.yaml` doesn't yet model DNS/DHCP (SPEC-NET-006) or
+anything from the OCI-foundation/KMS/logging domains — those live in
+domains (`identity`, `governance`) not yet populated per the threat-model
+corpus's own explicit review gate (still pending your sign-off before
+scaling past `network.yaml`). This is not blocking for M1 IaC work — the
+Specs themselves are the requirement source — but the corpus won't have
+full M1 coverage until those domains are populated.
+
+## State DAG
+
+Fully decided by
+[ADR-0007](../docs/02-decisions/ADR-0007-terragrunt-state-boundaries.md) —
+this section operationalizes that decision, it does not re-derive it.
+
+```mermaid
+flowchart TB
+  FOUNDATION["00-foundation<br/>SPEC-OCI-001<br/>compartment, IAM, dynamic groups,<br/>tags, state-backend bucket"]
+  NETWORK["10-network<br/>SPEC-NET-001/002/003/004/006<br/>VCN, subnets, gateways, routing,<br/>NSGs+SLs, DNS/DHCP"]
+  KMS["20-security/kms<br/>SPEC-OCI-002<br/>Vault + master key"]
+  LOGMON["20-security/logging-monitoring<br/>SPEC-OCI-003<br/>Log Group, VCN flow logs, Audit"]
+
+  FOUNDATION --> NETWORK
+  FOUNDATION --> KMS
+  FOUNDATION --> LOGMON
+  NETWORK --> LOGMON
+```
+
+4 units for M1 (not ~15 — ADR-0007 rejected fine-grained splitting; not 1
+— ADR-0007 rejected monolithic). `40-storage` (I19/M9) and `90-hybrid`
+(possible future DRG split, I21) are explicitly deferred by that ADR —
+not created now. `SPEC-NET-005` (traffic-flow invariants) has no state
+unit — it's a `tofu test` verification layer over `10-network`'s applied
+outputs, not a provisioner.
+
+Bootstrap order is strict: `00-foundation` first (self-bootstrapping, see
+below), then `10-network` and `20-security/kms` in either order, then
+`20-security/logging-monitoring` last (needs both `00-foundation` and
+`10-network`).
+
+## Remote-state bootstrap sequence (REQ-OCI-007)
+
+The chicken-and-egg problem: the OCI Object Storage bucket that will hold
+every unit's remote state cannot itself be backed by that same remote
+state on its first `apply` — the bucket doesn't exist yet.
+
+```text
+1. LOCAL BOOTSTRAP APPLY
+   cd live/oci/eu-madrid-1/lab/00-foundation
+   terragrunt apply -state=bootstrap.local.tfstate
+   -> creates: platform compartment, IAM policies/dynamic groups,
+      defined tags, the state bucket itself (versioned, encrypted,
+      not public — Checkov-enforced, soft_fail: false)
+
+2. MIGRATE STATE
+   terragrunt init -migrate-state
+   -> moves 00-foundation's own state from bootstrap.local.tfstate
+      into the bucket it just created
+
+3. VERIFY REMOTE BACKEND
+   test ! -f terraform.tfstate && test ! -f bootstrap.local.tfstate
+   oci os object list --bucket-name "$STATE_BUCKET" --namespace "$OCI_NS" \
+     --query "data[?starts_with(name, 'foundation/')]"
+
+4. REMOVE BOOTSTRAP DEPENDENCY
+   bootstrap.local.tfstate MUST be deleted immediately after step 3
+   succeeds (SPEC-OCI-001's Failure Modes: "a second bootstrap run
+   would silently diverge from the real remote state" if retained)
+
+5. EVERY SUBSEQUENT UNIT (10-network, 20-security/*)
+   uses the remote backend from its first apply — no bootstrap needed,
+   00-foundation's bucket already exists
+```
+
+This is a **one-time, explicitly-labeled operation per environment**, not
+a repeatable CI step — `plan.yml`/`validate.yml` never run it. Backend:
+OCI Object Storage (native OpenTofu S3-compatible backend against OCI's
+S3-compatibility API, per REQ-OCI-005 — versioning enabled, no third-party
+state SaaS). Locking: OCI Object Storage's S3-compatible backend does not
+provide native state locking the way an S3+DynamoDB pair does; this is a
+**known gap**, not silently assumed away — tracked for the module that
+implements `00-foundation` to resolve or explicitly accept (single-writer,
+single-maintainer risk profile makes this lower-severity than a
+multi-operator team, but it is still a real gap worth a line in that PR's
+own documentation, not just here).
+
+## Secrets and credentials strategy
+
+`plan.yml` already uses static long-lived OCI API key credentials via
+GitHub Actions encrypted secrets (`OCI_TENANCY_OCID`, `OCI_USER_OCID`,
+`OCI_FINGERPRINT`, `OCI_REGION`, `OCI_PRIVATE_KEY`) — matching
+`SPEC-OCI-001`'s explicit, in-scope decision (REQ-OCI-006): "static keys
+are in scope for this Spec; OIDC is a follow-on" (EPIC-OCI-04).
+
+Verified: OCI IAM Workload Identity Federation (WIF) — GitHub Actions
+OIDC → OCI federated, short-lived credentials — exists and is currently
+supported by OCI (not historical/deprecated). This is **not** adopted now:
+`SPEC-OCI-001`'s Non-Goals explicitly defer it, and this document respects
+that Spec's own scope decision rather than silently "upgrading" it ahead
+of the Spec that owns the decision. Recorded here as a confirmed-available
+follow-on for EPIC-OCI-04, not a gap.
+
+Local development authentication strategy (OCI CLI config / API key
+profile vs. session token) is not yet decided — tracked as an open item
+for whichever PR first needs a human to run `tofu`/`terragrunt` locally
+against real OCI (likely `00-foundation`'s own PR, since REQ-OCI-007's
+bootstrap is inherently a local/manual one-time step, not a CI step).
+
+## Tagging contract
+
+Defined Tags namespace `platform`, applied to every resource under the
+platform compartment (REQ-OCI-004 requires `platform`/`environment` at
+minimum). Extending the master execution prompt's proposed dimensions to
+what this repo can actually populate without inventing governance
+decisions:
+
+| Tag | Values (M1) | Source |
+| --- | --- | --- |
+| `Platform.Environment` | `lab` (only environment that exists) | `common/tags.hcl` / `env.hcl` |
+| `Platform.System` | `oracle-free-tier-platform` | `common/tags.hcl` |
+| `Platform.ManagedBy` | `opentofu` | `common/tags.hcl` |
+| `Security.TrustZone` | `edge`\|`management`\|`workload`\|`data`\|`n/a` (foundation-level resources) | per-resource, set in each module |
+
+`Platform.Component`, `Platform.Cluster`, `Platform.Owner`,
+`Security.Exposure`, `Security.DataClassification`, `Security.Criticality`,
+`Operations.Backup`, `Operations.DR`, `Operations.Monitoring`,
+`Operations.Lifecycle` from the master execution prompt's proposed list
+are **not** included yet — each requires a governance decision (who is
+"Owner"? what's the DR policy?) this repo hasn't made. Per that prompt's
+own rule ("do not invent values that require governance decisions"),
+these are deferred, not silently populated with a placeholder. `Platform.Cluster`
+specifically has no value yet because no Kubernetes cluster exists
+(M2+).
+
+## IAM bootstrap model
+
+Four identity classes, kept explicitly distinct (never collapsed into one
+broad grant):
+
+1. **Bootstrap identity** — whoever runs `00-foundation`'s two-phase
+   REQ-OCI-007 sequence for the first time in a new environment. Needs
+   compartment-create, IAM-policy-manage, and Object-Storage-bucket-create
+   rights at (necessarily, since the compartment doesn't exist yet)
+   tenancy scope for that one bootstrap operation only.
+2. **CI/workflow identity** — `plan.yml`'s static credentials today. Needs
+   read/plan-equivalent rights (list/get) across the platform compartment
+   for every resource type M1 touches, scoped to that compartment, never
+   tenancy-wide (REQ-OCI-002). Apply rights are a **separate, narrower**
+   grant than plan/read — the CI identity that plans should not
+   automatically also be authorized to apply (matches the master execution
+   prompt's IAM Summary requirement: "who will perform the apply and with
+   what permissions" must be answered explicitly, not implied).
+3. **Human administrator** — the repo owner, running `terragrunt apply`
+   locally for the authorized-apply step (per the hard stop this phase
+   respects) until CI-driven apply is explicitly designed and approved —
+   not assumed here.
+4. **Future instance/resource principals** — REQ-OCI-003's Dynamic Groups,
+   matching Talos/Flux-managed instances once they exist (M2+). Not needed
+   for M1's own apply, but the Dynamic Group match-rule *shape* is part of
+   `00-foundation`'s scope (REQ-OCI-003) since it's compartment/IAM
+   plumbing, even though nothing consumes it until compute exists.
+
+Exact least-privilege policy statements (the actual OCI policy-statement
+syntax) are **not** written here — that's `00-foundation`'s own module PR,
+where the statements can be verified against the real resource types that
+module creates rather than guessed in advance. This is the bounded-gap
+pattern the master execution prompt requires: the gap is named, not
+silently resolved with a guess.
+
+## Free Tier classification (M1 scope)
+
+Verified against
+[OCI Always Free documentation](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm),
+not historical assumption:
+
+| Resource | Classification | Evidence |
+| --- | --- | --- |
+| Compartment, IAM policies, Dynamic Groups | FREE | no cost dimension exists for these resource types |
+| VCN (1, of 2 allowed) | FREE | Always Free tenancies get up to 2 VCNs |
+| Subnets, route tables | FREE | no per-resource cost; not separately metered |
+| Internet Gateway, NAT Gateway, Service Gateway | FREE | not listed as chargeable; **egress volume** counts against the 10 TB/month allowance (a usage dimension, not a per-gateway charge) |
+| DRG (attached, inert) | FREE | attachment itself carries no direct cost (confirmed by ADR-0008's own research) |
+| NSGs, Security Lists | FREE | no cost dimension |
+| OCI Vault, type `DEFAULT` | FREE | software-protected master-key versions are explicitly "all free"; **`VIRTUAL_PRIVATE` vaults are NOT free** — REQ-OCI-008's `DEFAULT`-only requirement is the guardrail that keeps this FREE |
+| Object Storage (state bucket) | FREE, bounded | 20 GB combined Always-Free allowance; a Terraform/Terragrunt state bucket is KB-scale, nowhere near the limit |
+| OCI Logging (Log Group + VCN flow logs) | FREE, bounded | 10 GB/month ingestion allowance on Always-Free tenancies |
+| OCI Monitoring | FREE, bounded | 500M ingestion + 1B retrieval data points/month allowance |
+| OCI Audit | FREE | tenancy-native, always-on, no separate charge |
+
+**No PAID or UNKNOWN resource is proposed for M1.** Nothing here blocks
+progression to a plan/apply gate on Free Tier grounds. This table should
+be re-verified against current OCI documentation before the actual first
+apply, not assumed to still hold indefinitely.
+
+## Module contract standard
+
+See [modules/README.md](modules/README.md) for the full contract every
+OpenTofu module must satisfy (purpose, input/output contract, security
+invariants, validation, tests, examples). No modules exist yet — this PR
+establishes the contract; the module implementing it (starting with
+`00-foundation`'s `oci-foundation` module) is a separate PR.
+
+## Terragrunt live layout
+
+See `live/` for the account/region/environment composition layer that
+exists so far (`root.hcl`, `common/*.hcl`, `oci/eu-madrid-1/region.hcl`,
+`oci/eu-madrid-1/lab/env.hcl`). Per-unit `terragrunt.hcl` files
+(`00-foundation/terragrunt.hcl`, etc.) are **not** created yet — each is
+added alongside the OpenTofu module it wires in, in that unit's own PR,
+so no `terragrunt.hcl` ever points at a `terraform { source = ... }` that
+doesn't exist.
+
+## CI pipeline — current state and known gap
+
+`validate.yml` (fmt/validate/`tofu test`/tflint/checkov) and `plan.yml`
+(plan against `infrastructure/live/oci/eu-madrid-1/lab`, static secrets,
+skips cleanly if unconfigured) already exist and match this document's
+toolchain. **Known gap, not fixed by this PR**: `plan.yml` currently runs
+a single `tofu plan` directly against the `lab` environment root — once
+real per-unit `terragrunt.hcl` files exist (PR B onward), it needs to
+become Terragrunt-DAG-aware (`terragrunt run-all plan` or a per-unit loop
+in dependency order) so a PR touching `10-network` doesn't silently skip
+planning `20-security/logging-monitoring`'s dependency on it. Deferred to
+the PR that creates the first real `terragrunt.hcl`, per "only create
+paths justified by actual implementation" — updating CI mechanics for
+units that don't exist yet would be speculative.
+
+## Apply gate
+
+Not reached by this PR. No `.tf` resource code exists yet — there is
+nothing to plan or apply. See the phase-4 execution report for the current
+gate status.

--- a/infrastructure/live/common/account.hcl
+++ b/infrastructure/live/common/account.hcl
@@ -1,0 +1,19 @@
+# Account-level values shared by every region/environment under this
+# repo. No OCIDs, secrets, or Customer Secret Keys here — those come from
+# environment variables (local `oci` CLI config / GitHub Actions secrets),
+# never committed. See ../../README.md#secrets-and-credentials-strategy.
+
+locals {
+  platform_name = "oracle-free-tier-platform"
+
+  # Object Storage namespace is tenancy-specific but not itself secret;
+  # still sourced from env rather than hardcoded, since it's account data,
+  # not a portable constant this repo should assume.
+  tenancy_namespace = get_env("OCI_OBJECT_STORAGE_NAMESPACE", "")
+
+  # REQ-OCI-005: dedicated, versioned OCI Object Storage bucket for state.
+  # Created by 00-foundation's own two-phase bootstrap (REQ-OCI-007) —
+  # see ../../README.md#remote-state-bootstrap-sequence. Every other unit
+  # references this same bucket once it exists.
+  state_bucket_name = "oracle-free-tier-platform-tfstate"
+}

--- a/infrastructure/live/common/tags.hcl
+++ b/infrastructure/live/common/tags.hcl
@@ -1,0 +1,11 @@
+# Defined-tags contract. See ../../README.md#tagging-contract for the
+# full dimension list and which dimensions are deferred pending
+# governance decisions this repo hasn't made yet — do not add tags here
+# that require an undecided policy (owner, DR tier, criticality, ...).
+
+locals {
+  platform_tags = {
+    "Platform.System"    = "oracle-free-tier-platform"
+    "Platform.ManagedBy" = "opentofu"
+  }
+}

--- a/infrastructure/live/common/versions.hcl
+++ b/infrastructure/live/common/versions.hcl
@@ -1,0 +1,10 @@
+# Shared version floor. Verified against authoritative upstream sources —
+# see ../../README.md#toolchain-verified-against-authoritative-sources-not-memory
+# — not copied from memory. Each module's own versions.tf still declares
+# its own required_providers block; this file exists so every live/ unit
+# can assert a consistent floor, not to replace that declaration.
+
+locals {
+  opentofu_version_constraint = ">= 1.12.0"
+  oci_provider_version        = "8.27.0" # oracle/terraform-provider-oci, verified 2026-08-18
+}

--- a/infrastructure/live/oci/eu-madrid-1/lab/env.hcl
+++ b/infrastructure/live/oci/eu-madrid-1/lab/env.hcl
@@ -1,0 +1,6 @@
+# Environment-level values. "lab" is the only environment that exists —
+# matches plan.yml's existing infrastructure/live/oci/eu-madrid-1/lab path.
+
+locals {
+  environment = "lab"
+}

--- a/infrastructure/live/oci/eu-madrid-1/region.hcl
+++ b/infrastructure/live/oci/eu-madrid-1/region.hcl
@@ -1,0 +1,6 @@
+# Region-level values. eu-madrid-1 is the only region in scope — matches
+# plan.yml's existing lab-plan job and SPEC-OCI-001's Constraints section.
+
+locals {
+  region = "eu-madrid-1"
+}

--- a/infrastructure/live/root.hcl
+++ b/infrastructure/live/root.hcl
@@ -1,0 +1,86 @@
+# Root Terragrunt configuration. Every unit under oci/<region>/<env>/
+# includes this via `include "root" { path = find_in_parent_folders() }`.
+#
+# BOOTSTRAP EXCEPTION (REQ-OCI-007): the remote_state block below assumes
+# the state bucket already exists. It does NOT exist until 00-foundation's
+# own two-phase bootstrap has run once — see
+# ../README.md#remote-state-bootstrap-sequence. 00-foundation's own
+# terragrunt.hcl (created in the PR that scaffolds that unit, not this
+# one) is the one unit that must NOT include this root.hcl's remote_state
+# block on its first apply; it starts from local state
+# (`-state=bootstrap.local.tfstate`) per that sequence's phase 1, then
+# migrates into the bucket this block creates for every unit after it.
+#
+# CREDENTIAL NOTE: this backend authenticates against OCI Object Storage's
+# S3-compatible API, which requires a Customer Secret Key (Access Key /
+# Secret Key pair) — a DIFFERENT credential type from the OCI API key
+# (tenancy/user OCID + fingerprint + private key) that plan.yml's existing
+# secrets and the `oci` provider block below use. Provisioning that
+# Customer Secret Key is part of 00-foundation's own bootstrap, not this
+# file. access_key/secret_key below read the standard AWS_ACCESS_KEY_ID/
+# AWS_SECRET_ACCESS_KEY env var names (the S3-backend machinery's own
+# convention) rather than inventing repo-specific names.
+#
+# LOCKING NOTE: `use_lockfile = true` enables OpenTofu's native S3-backend
+# locking (conditional writes via If-None-Match — no DynamoDB-equivalent
+# needed). Verified from OpenTofu's own backend docs that this feature
+# exists; NOT yet empirically verified that OCI's S3-compatible API honors
+# If-None-Match conditional PUT semantics identically to AWS S3 — that
+# must be confirmed in 00-foundation's own bootstrap PR against real OCI,
+# not assumed here. If it turns out unsupported, remove `use_lockfile` and
+# record the gap explicitly (single-maintainer risk profile makes
+# unlocked state a lower-severity gap than for a multi-operator team, but
+# it must be a documented decision, not a silent one).
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("common/account.hcl"))
+  tags_vars    = read_terragrunt_config(find_in_parent_folders("common/tags.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  env_vars     = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  s3_compat_endpoint = "https://${local.account_vars.locals.tenancy_namespace}.compat.objectstorage.${local.region_vars.locals.region}.oci.customer-oci.com"
+}
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket = local.account_vars.locals.state_bucket_name
+    key    = "${path_relative_to_include()}/terraform.tfstate"
+    region = local.region_vars.locals.region
+
+    endpoints = {
+      s3 = local.s3_compat_endpoint
+    }
+
+    access_key = get_env("AWS_ACCESS_KEY_ID", "")
+    secret_key = get_env("AWS_SECRET_ACCESS_KEY", "")
+
+    use_path_style              = true
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_s3_checksum            = true
+    use_lockfile                = true
+  }
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "oci" {
+  region = "${local.region_vars.locals.region}"
+}
+EOF
+}
+
+inputs = merge(
+  local.account_vars.locals,
+  local.tags_vars.locals,
+  local.region_vars.locals,
+  local.env_vars.locals,
+)

--- a/infrastructure/modules/README.md
+++ b/infrastructure/modules/README.md
@@ -1,0 +1,120 @@
+# OpenTofu module contract
+
+Every module under `infrastructure/modules/` follows this contract. No
+module exists yet — this is the standard the first module (`oci-foundation`,
+implementing `SPEC-OCI-001`) is held to, not a retrospective description.
+
+## Principles
+
+Composable, narrowly cohesive, environment-neutral, typed, validated,
+documented, testable, security-conscious. A module owns OCI resource
+logic; it never contains environment-specific constants, hard-coded
+OCIDs, or hard-coded credentials — those are Terragrunt `live/` inputs.
+
+Avoid: mega-modules covering more than one Terragrunt state unit's worth
+of resources (state boundaries are decided in
+[../README.md](../README.md#state-dag) — a module's scope should match
+its state unit, not exceed it); pass-through wrappers with no
+architectural value; provider configuration hidden inside a child module
+(providers are configured once, at the `live/` composition layer, never
+inside a reusable module); implicit cross-module dependencies not
+expressed as explicit `variable`/`output` contracts.
+
+## Required file layout
+
+```text
+modules/<name>/
+├── README.md         PURPOSE, INPUT/OUTPUT contract, security invariants,
+│                       failure modes, upgrade expectations (see below)
+├── main.tf            resources
+├── variables.tf        typed inputs, validation blocks
+├── outputs.tf           outputs consumed by other units/modules
+├── versions.tf            required_providers, required_version
+├── locals.tf               (only if genuinely needed — don't create an
+│                             empty file to satisfy this list)
+├── data.tf                  (only if the module reads existing OCI state)
+├── tests/
+│   └── *.tftest.hcl          unit/contract tests, including negative tests
+└── examples/
+    └── minimal/                a runnable example with placeholder inputs
+```
+
+Don't create empty files to satisfy aesthetics — `locals.tf`/`data.tf`
+exist in this list because most modules will need them, not because every
+module must have every file.
+
+## Module `README.md` must define
+
+- **Purpose** — one paragraph, what this module owns and why it's a
+  separate module (tie back to the state-DAG rationale in
+  [../README.md](../README.md#state-dag)).
+- **Input contract** — every variable, its type, whether required,
+  validation rules applied.
+- **Output contract** — every output, what consumes it (name the
+  downstream module/unit).
+- **Resource ownership** — the exact OCI resource types this module
+  creates; nothing implicit.
+- **Security invariants** — the specific guarantees this module's
+  `variable` validation blocks and/or resource arguments enforce (e.g.
+  "no subnet in this module can set `prohibit-public-ip-on-vnic = false`
+  except when `zone == \"edge\"`").
+- **Validation** — how to run `tofu validate`/`tflint`/`tofu test` for
+  this module specifically.
+- **Failure modes** — what a partial/failed apply leaves behind, and
+  whether it's safe to re-run.
+- **Upgrade expectations** — what changing an existing input does
+  (in-place update vs. forces-replacement), called out per variable where
+  destructive.
+- **Example** — a working reference to `examples/minimal/`.
+- **Tests** — what `tests/*.tftest.hcl` actually asserts, in prose.
+
+## Validation blocks — what to encode, what not to
+
+Use `variable` validation blocks for this repository's own invariants:
+
+- CIDR structure and the approved network contract (10.10.0.0/16 and its
+  four /24s — see [../README.md](../README.md)'s traceability matrix).
+- Allowed trust-zone names (`edge`, `management`, `workload`, `data` —
+  nothing else).
+- No public IP on Management/Workload/Data (REQ-NET-003) — enforced at
+  the module boundary, not left to composition-time discipline
+  (`SPEC-NET-001`'s own Security Requirements section demands this).
+- Required tags present (per [../README.md](../README.md#tagging-contract)).
+- Allowed environment values (currently only `lab` exists).
+
+Do **not** re-validate provider behavior OCI/the `oracle/oci` provider
+already strongly validates upstream (e.g. don't hand-roll OCID format
+checking — the provider rejects a malformed OCID on `apply` already;
+duplicating that in a `validate` block adds no real invariant).
+
+## Testing
+
+`tofu test` (`.tftest.hcl`) covers module invariants and negative tests —
+see the master execution prompt's negative-testing examples (public IP on
+a private zone, workload routed directly to IGW, missing mandatory tags,
+overlapping CIDR, invalid environment — each MUST FAIL). Every
+security-sensitive module needs at least one negative test; happy-path-only
+coverage is insufficient for a module implementing a `SPEC-NET-004`-class
+security requirement.
+
+## Candidate first modules
+
+Proposed, not accepted — each name is confirmed or revised in the PR that
+actually scaffolds it:
+
+| Candidate name | Spec | State unit |
+| --- | --- | --- |
+| `oci-foundation` | SPEC-OCI-001 | `00-foundation` |
+| `oci-network` | SPEC-NET-001/002/003/004/006 | `10-network` |
+| `oci-kms` | SPEC-OCI-002 | `20-security/kms` |
+| `oci-logging-monitoring` | SPEC-OCI-003 | `20-security/logging-monitoring` |
+
+`oci-network` bundles VCN/subnets/gateways/routing/NSGs/DNS into one
+module because ADR-0007 already decided `10-network` is one state unit —
+a module boundary narrower than its state unit would just add internal
+plumbing with no independent-apply benefit; a module boundary wider than
+its state unit isn't possible (Terragrunt wires exactly one module source
+per unit). This does not preclude internal file organization within
+`oci-network/main.tf` mirroring each Spec (vcn.tf, subnets.tf, gateways.tf,
+routing.tf, security.tf, dns.tf) for readability — only the Terragrunt/
+state boundary is fixed, not the internal file layout.


### PR DESCRIPTION
## Summary

Phase 4 (OCI foundation implementation), **PR A** of the dependency-oriented increment sequence: conventions + state architecture + module contract only. No OpenTofu resource code, no plan, no apply — this is the design layer the actual modules (PR B onward, starting with `00-foundation`/`SPEC-OCI-001`) are built against, per the master execution prompt's explicit "do not implement the entire foundation in one giant PR" instruction.

### Toolchain (verified against authoritative sources, not memory)

OpenTofu **v1.12.5**, Terragrunt **v1.1.3**, `oracle/oci` provider **v8.27.0**, `tflint-ruleset-terraform` **v0.15.0** (was unpinned in `infrastructure/.tflint.hcl` — fixed). OCI Free Tier eligibility verified for every M1-scope resource type against current OCI docs — nothing classifies PAID or UNKNOWN.

### `infrastructure/README.md`

- Requirement-to-resource traceability matrix — every `SPEC-OCI-00[1-3]`/`SPEC-NET-00[1-6]` requirement traced to an ARCH ID, a threat-model corpus ref where one exists, a proposed module, and a state unit. Surfaces a real, non-blocking gap: the threat-model corpus's `network.yaml` doesn't yet cover DNS/DHCP or the OCI-foundation/KMS/logging domains — those domains are still pending the review gate from the schema-v2 PR (#36).
- The Terragrunt state DAG — **operationalizes ADR-0007's already-decided 4-unit split** (`00-foundation`, `10-network`, `20-security/kms`, `20-security/logging-monitoring`), not re-derived.
- The REQ-OCI-007 remote-state bootstrap sequence, IAM bootstrap model (4 distinct identity classes, least-privilege deferred as a named gap rather than guessed), tagging contract (only dimensions this repo can populate without inventing a governance decision), secrets/credentials strategy (static GH secrets now per `SPEC-OCI-001`'s own explicit scope decision — verified GitHub-OIDC-to-OCI Workload Identity Federation exists and is current, deliberately not adopted early), Free Tier classification table, and a documented CI gap (`plan.yml` needs to become Terragrunt-DAG-aware once real per-unit `terragrunt.hcl` files exist — deferred to that PR).

**Important**: this is `infrastructure/README.md`, not `docs/01-architecture/foundation.md`. `docs/01-architecture/README.md` explicitly reserves `foundation.md` for "once `SPEC-OCI-001` is implemented" ("avoids documentation drifting ahead of what's actually built") — writing it now would have violated that repo convention. This document covers the same design content but lives in `infrastructure/` as IaC tooling/convention documentation, not an architecture view.

### `infrastructure/modules/README.md`

The module contract standard every future module must satisfy. Candidate module names (`oci-foundation`, `oci-network`, `oci-kms`, `oci-logging-monitoring`) proposed, explicitly not yet accepted.

### `infrastructure/live/`

The shared Terragrunt composition layer — `root.hcl`, `common/{account,tags,versions}.hcl`, `oci/eu-madrid-1/{region.hcl,lab/env.hcl}`. No per-unit `terragrunt.hcl` yet (each is added alongside its OpenTofu module, so none ever points at a `terraform{source=...}` that doesn't exist).

`root.hcl`'s `remote_state` block: verified OCI Object Storage's S3-compatible API against official OCI docs (endpoint domain is `*.oci.customer-oci.com`, **not** `*.oraclecloud.com` as an unverified guess would have produced) and OpenTofu's native S3-backend locking (`use_lockfile`, conditional writes via `If-None-Match`, no DynamoDB-equivalent needed — verified from OpenTofu's own backend docs). Explicitly flagged, not assumed: the S3 Compatibility API requires a **Customer Secret Key** (Access Key/Secret Key pair) — a different credential from the OCI API key `plan.yml`'s existing secrets use — provisioning it is `00-foundation`'s bootstrap concern, not this file's. Whether OCI's S3-compat layer actually honors `If-None-Match` identically to AWS S3 is **not yet empirically verified** — documented as a gap to confirm in the bootstrap PR.

All HCL validated with `terragrunt hcl fmt --check` and `terragrunt hcl validate` (both pass) despite no per-unit config existing yet.

### Tooling docs

`AGENTS.md`/`CONTRIBUTING.md`: added Terragrunt commands, and — a real gap from earlier threat-model PRs — the `npm run validate:threat-model`/`test:threat-model` commands that were never actually added to `AGENTS.md`'s canonical command list despite being pre-commit-wired since #35/#36. `.pre-commit-config.yaml`: `terragrunt-hclfmt` local hook. `.markdownlint-cli2.yaml`/`docs.yml`: `infrastructure/**/*.md` was covered by neither the config's own globs nor CI's explicit globs input — same gap class already fixed for `AGENTS.md` earlier, now fixed for this new directory.

## Validation

- [x] `terragrunt hcl fmt --check` / `terragrunt hcl validate` (from `infrastructure/live/`): pass
- [x] `pre-commit run --all-files`: all hooks passed
- [x] `npx markdownlint-cli2` (full repo-wide glob incl. `infrastructure/**/*.md`): 0 issues
- [x] Commit is DCO sign-off'd and GPG-signed (`git log --format=%G?` → `G`)

## Impact

- [x] Architecture decision changed (IaC conventions/state DAG now documented)
- [ ] Threat model / trust boundaries / DFD / risk register affected
- [ ] New infrastructure state boundary introduced (no resources yet — DAG is designed, not applied)
- [ ] Credential, secret, or access policy touched
- [x] README / docs updated

## Not in this PR

Any OCI resource code, any per-unit `terragrunt.hcl`, any tests, any CI plan mechanics changes, any IAM policy statements, any apply gate. **PR B (compartment + tags + IAM + state backend, `SPEC-OCI-001`) is next.**
