### PR TITLE
feat: 00-foundation OpenTofu module + Terragrunt unit (PR B)

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -23,26 +23,37 @@ jobs:
       OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
       OCI_REGION: ${{ secrets.OCI_REGION }}
       OCI_PRIVATE_KEY: ${{ secrets.OCI_PRIVATE_KEY }}
+      # S3-compatible backend auth (Customer Secret Key) -- a DIFFERENT
+      # credential from the OCI API key above; see
+      # infrastructure/modules/foundation/README.md#customer-secret-key.
+      AWS_ACCESS_KEY_ID: ${{ secrets.OCI_S3_COMPAT_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.OCI_S3_COMPAT_SECRET_KEY }}
+      OCI_OBJECT_STORAGE_NAMESPACE: ${{ secrets.OCI_OBJECT_STORAGE_NAMESPACE }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
-        with:
-          tofu_version: "1.x"
-          cache: true
+      # Runs `terragrunt run-all plan` from the lab environment root,
+      # discovering every unit in ADR-0007's DAG (currently just
+      # 00-foundation) in dependency order -- a raw `tofu plan` from that
+      # root directory (this workflow's previous design) silently produced
+      # an empty, misleadingly-successful plan, since the root has no .tf
+      # files of its own; the real config lives in each unit subdirectory.
+      #
+      # NOTE: 00-foundation's own remote backend doesn't exist until a
+      # human has run its one-time REQ-OCI-007 bootstrap for this
+      # environment (infrastructure/modules/foundation/README.md#bootstrap-runbook)
+      # -- until then, this step fails loudly on `terragrunt init` (backend
+      # bucket not found), which is the correct, honest failure mode: a
+      # loud, real error instead of a silently-empty plan.
       - name: Plan live/oci/eu-madrid-1/lab
         if: env.OCI_TENANCY_OCID != ''
-        working-directory: infrastructure/live/oci/eu-madrid-1/lab
-        run: |
-          tofu init -input=false
-          tofu plan -input=false -out=plan.tfplan
-      - name: Upload plan artifact
-        if: env.OCI_TENANCY_OCID != ''
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: gruntwork-io/terragrunt-action@8c1d96b76d445fd2e41475a3f0b63dcd1d9cc077 # v3.4.1
         with:
-          name: lab-plan
-          path: infrastructure/live/oci/eu-madrid-1/lab/plan.tfplan
+          tg_version: "1.1.3"
+          tofu_version: "1.12.5"
+          tg_dir: infrastructure/live/oci/eu-madrid-1/lab
+          tg_command: "run-all plan"
       - name: Notify missing credentials
         if: env.OCI_TENANCY_OCID == ''
         run: echo "OCI_TENANCY_OCID secret not configured; plan skipped. Configure GitHub Actions secrets or OCI OIDC federation."

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,9 +47,14 @@ jobs:
       - name: tofu test
         run: |
           set -euo pipefail
+          # tofu test must run from the module root, not the tests/
+          # subdirectory itself (it discovers *.tftest.hcl there by
+          # convention) -- go up one level when that's where they live.
           find . -name '*.tftest.hcl' -printf '%h\n' | sort -u | while read -r d; do
-            echo "==> $d"
-            (cd "$d" && tofu init -backend=false -input=false >/dev/null && tofu test)
+            root="$d"
+            [ "$(basename "$d")" = "tests" ] && root="$(dirname "$d")"
+            echo "==> $root"
+            (cd "$root" && tofu init -backend=false -input=false >/dev/null && tofu test)
           done
 
   tflint:
@@ -87,3 +92,11 @@ jobs:
           directory: infrastructure
           framework: terraform
           soft_fail: false
+          # CKV_OCI_9 (customer-managed key on Object Storage): SPEC-OCI-002's
+          # own Non-Goals section explicitly defers this for the state bucket --
+          # Oracle-managed encryption already satisfies REQ-OCI-005. An inline
+          # #checkov:skip comment on the resource did not reliably suppress
+          # this finding when reached through a module call
+          # (modules/foundation/examples/minimal) -- this workflow-level flag
+          # is the verified-working mechanism.
+          skip_check: CKV_OCI_9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,11 @@ repos:
         args: ["--hook-config=--tf-path=tofu"]
       - id: terraform_tflint
       - id: checkov
+        # CKV_OCI_9: see .github/workflows/validate.yml's checkov step and
+        # infrastructure/modules/foundation/state_backend.tf's comment --
+        # kept in sync with that workflow's skip_check so local pre-commit
+        # and CI agree.
+        args: ["--skip-check=CKV_OCI_9"]
 
   - repo: local
     hooks:

--- a/docs/specs/SPEC-OCI-001.md
+++ b/docs/specs/SPEC-OCI-001.md
@@ -132,23 +132,46 @@ And the state object is present in the OCI Object Storage state bucket
 ```bash
 tofu validate
 
+# The module declares no backend block (Terragrunt owns that via
+# `generate`, once a live unit exists) -- bootstrap runs against an
+# untracked scratch copy, never the module in place, so a temporary
+# backend.tf can be written without conflicting with Terragrunt's own
+# generated one later.
+cp -r infrastructure/modules/foundation /tmp/foundation-bootstrap
+cd /tmp/foundation-bootstrap
+
 # phase 1 — one-time bootstrap, local state only (default terraform.tfstate
 # path — NOT a -state=<custom-path> override: `tofu init` has no -state
 # flag, so -migrate-state in phase 2 can only find state at the default
 # path; an earlier draft of this Spec showed -state=bootstrap.local.tfstate,
 # which -migrate-state would have silently failed to pick up)
-tofu init -backend=false -input=false
+tofu init -input=false
 tofu apply -input=false
 
-# phase 2 — the bucket now exists (created by phase 1); configure the real
-# backend and migrate local state into it
-tofu init -input=false -migrate-state -backend-config=backend.hcl \
-  -backend-config="endpoints={s3=\"$S3_COMPAT_ENDPOINT\"}"
-test ! -f terraform.tfstate
+# phase 2 — the bucket now exists (created by phase 1); write a real
+# backend.tf (not partial -backend-config flags -- no block exists to
+# merge them into) and migrate local state into it
+cat > backend.tf <<EOF
+terraform {
+  backend "s3" {
+    bucket = "$STATE_BUCKET"
+    key    = "oci/eu-madrid-1/lab/00-foundation/terraform.tfstate"
+    region = "eu-madrid-1"
+    endpoints = { s3 = "$S3_COMPAT_ENDPOINT" }
+    use_path_style = true
+    skip_region_validation = true
+    skip_credentials_validation = true
+    skip_metadata_api_check = true
+    skip_s3_checksum = true
+  }
+}
+EOF
+tofu init -input=false -migrate-state
+test ! -f terraform.tfstate   # no longer authoritative once migrated
 ```
 
 See `infrastructure/modules/foundation/README.md#bootstrap-runbook` for
-the exact `backend.hcl` contents and credential handling.
+the full sequence, verification commands, and credential handling.
 
 ## Documentation Impact
 

--- a/docs/specs/SPEC-OCI-001.md
+++ b/docs/specs/SPEC-OCI-001.md
@@ -132,18 +132,23 @@ And the state object is present in the OCI Object Storage state bucket
 ```bash
 tofu validate
 
-# phase 1 — one-time bootstrap, local state only
-tofu apply -state=bootstrap.local.tfstate
+# phase 1 — one-time bootstrap, local state only (default terraform.tfstate
+# path — NOT a -state=<custom-path> override: `tofu init` has no -state
+# flag, so -migrate-state in phase 2 can only find state at the default
+# path; an earlier draft of this Spec showed -state=bootstrap.local.tfstate,
+# which -migrate-state would have silently failed to pick up)
+tofu init -backend=false -input=false
+tofu apply -input=false
 
-# phase 2 — migrate that state into the bucket phase 1 just created
-tofu init -migrate-state
-test ! -f terraform.tfstate && test ! -f bootstrap.local.tfstate
-
-oci iam compartment list --compartment-id-in-subtree true \
-  --query "data[?name=='platform']"
-oci os object list --bucket-name "$STATE_BUCKET" --namespace "$OCI_NS" \
-  --query "data[?starts_with(name, 'foundation/')]"  # remote state object exists
+# phase 2 — the bucket now exists (created by phase 1); configure the real
+# backend and migrate local state into it
+tofu init -input=false -migrate-state -backend-config=backend.hcl \
+  -backend-config="endpoints={s3=\"$S3_COMPAT_ENDPOINT\"}"
+test ! -f terraform.tfstate
 ```
+
+See `infrastructure/modules/foundation/README.md#bootstrap-runbook` for
+the exact `backend.hcl` contents and credential handling.
 
 ## Documentation Impact
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -116,32 +116,46 @@ every unit's remote state cannot itself be backed by that same remote
 state on its first `apply` — the bucket doesn't exist yet.
 
 ```text
-1. LOCAL BOOTSTRAP APPLY
-   cd live/oci/eu-madrid-1/lab/00-foundation
-   terragrunt apply -state=bootstrap.local.tfstate
+1. LOCAL BOOTSTRAP APPLY (untracked scratch copy, NOT the module or the
+   Terragrunt unit in place)
+   cp -r modules/foundation /tmp/foundation-bootstrap && cd /tmp/foundation-bootstrap
+   tofu init -input=false && tofu apply -input=false
    -> creates: platform compartment, IAM policies/dynamic groups,
       defined tags, the state bucket itself (versioned, encrypted,
       not public — Checkov-enforced, soft_fail: false)
 
-2. MIGRATE STATE
-   terragrunt init -migrate-state
-   -> moves 00-foundation's own state from bootstrap.local.tfstate
-      into the bucket it just created
+2. WRITE A REAL backend.tf AND MIGRATE (same scratch copy)
+   cat > backend.tf <<EOF ... EOF   # full config, not -backend-config flags
+   tofu init -input=false -migrate-state
+   -> moves the scratch copy's local terraform.tfstate into the bucket
+      it just created, at the exact key Terragrunt's own unit will use
 
 3. VERIFY REMOTE BACKEND
-   test ! -f terraform.tfstate && test ! -f bootstrap.local.tfstate
+   test ! -f terraform.tfstate
    oci os object list --bucket-name "$STATE_BUCKET" --namespace "$OCI_NS" \
-     --query "data[?starts_with(name, 'foundation/')]"
+     --query "data[?starts_with(name, 'oci/eu-madrid-1/lab/00-foundation/')]"
 
-4. REMOVE BOOTSTRAP DEPENDENCY
-   bootstrap.local.tfstate MUST be deleted immediately after step 3
-   succeeds (SPEC-OCI-001's Failure Modes: "a second bootstrap run
-   would silently diverge from the real remote state" if retained)
+4. DISCARD THE SCRATCH COPY
+   rm -rf /tmp/foundation-bootstrap
+   -> nothing here was ever tracked in git; no repo cleanup needed
 
-5. EVERY SUBSEQUENT UNIT (10-network, 20-security/*)
-   uses the remote backend from its first apply — no bootstrap needed,
-   00-foundation's bucket already exists
+5. EVERY SUBSEQUENT UNIT (10-network, 20-security/*, and 00-foundation's
+   OWN Terragrunt unit from now on)
+   uses the remote backend from its first `terragrunt` run — no bootstrap
+   needed, the bucket already exists
 ```
+
+**Why a scratch copy, not the module or Terragrunt unit in place**: the
+module deliberately declares no backend block (Terragrunt's `generate`
+mechanism owns that once a unit exists — see `live/root.hcl`). Bootstrap
+needs to write ITS OWN temporary `backend.tf` to reach the bucket before
+it exists at all — writing that into the tracked module source would
+leave a second, permanent backend declaration behind that conflicts with
+Terragrunt's generated one on every subsequent run (`OpenTofu` rejects
+two backend blocks in one configuration outright — confirmed by
+reproducing it locally, not assumed). The scratch copy is discarded
+specifically so that conflict never has anywhere to persist. Full
+runbook: `modules/foundation/README.md#bootstrap-runbook`.
 
 This is a **one-time, explicitly-labeled operation per environment**, not
 a repeatable CI step — `plan.yml`/`validate.yml` never run it. Backend:

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -48,20 +48,26 @@ without a row here tracing it to a requirement.
 
 | Spec | Requirements | ARCH ID(s) | Threat-model corpus ref | Module | State unit |
 | --- | --- | --- | --- | --- | --- |
-| SPEC-OCI-001 | REQ-OCI-001..007 | `ARCH-GOV-TENANCY` | `ARCH-OCI-TENANCY`/`ARCH-OCI-COMPARTMENT` scopes (`network.yaml`) | `modules/oci-foundation` | `00-foundation` |
-| SPEC-NET-001 | REQ-NET-001..005 | `ARCH-NET-VCN`, `ARCH-ZONE-*` | `network.yaml` trust_zones (4, already schema-validated) | `modules/oci-network` | `10-network` |
-| SPEC-NET-002 | REQ-NET-006..010 | `ARCH-GW-IGW/NAT/SGW/DRG` | `network.yaml` components `COMP-INTERNET-GATEWAY`/`COMP-NAT-GATEWAY`/`COMP-SERVICE-GATEWAY` | `modules/oci-network` | `10-network` |
-| SPEC-NET-003 | REQ-NET-011..015 | `ARCH-FLOW-INGRESS/EGRESS/SERVICE` | `network.yaml` `FLOW-*` (transport/authz already modeled) | `modules/oci-network` | `10-network` |
-| SPEC-NET-004 | REQ-NET-016..020 | `ARCH-ZONE-MGMT`, NSGs | `network.yaml` `POLICY-CONTROL-NSG-6443`, `CTRL-K8S-API-INGRESS-RESTRICTION`, `COMP-*-NSG` (5) | `modules/oci-network` | `10-network` |
-| SPEC-NET-006 | REQ-NET-028..030 | `ARCH-NET-DNS` | not yet in `network.yaml` — DNS/DHCP wasn't part of the network-domain PoC migration | `modules/oci-network` | `10-network` |
+| SPEC-OCI-001 | REQ-OCI-001..007 | `ARCH-GOV-TENANCY` | `ARCH-OCI-TENANCY`/`ARCH-OCI-COMPARTMENT` scopes (`network.yaml`) | `modules/foundation` | `00-foundation` |
+| SPEC-NET-001 | REQ-NET-001..005 | `ARCH-NET-VCN`, `ARCH-ZONE-*` | `network.yaml` trust_zones (4, already schema-validated) | `modules/network` | `10-network` |
+| SPEC-NET-002 | REQ-NET-006..010 | `ARCH-GW-IGW/NAT/SGW/DRG` | `network.yaml` components `COMP-INTERNET-GATEWAY`/`COMP-NAT-GATEWAY`/`COMP-SERVICE-GATEWAY` | `modules/network` | `10-network` |
+| SPEC-NET-003 | REQ-NET-011..015 | `ARCH-FLOW-INGRESS/EGRESS/SERVICE` | `network.yaml` `FLOW-*` (transport/authz already modeled) | `modules/network` | `10-network` |
+| SPEC-NET-004 | REQ-NET-016..020 | `ARCH-ZONE-MGMT`, NSGs | `network.yaml` `POLICY-CONTROL-NSG-6443`, `CTRL-K8S-API-INGRESS-RESTRICTION`, `COMP-*-NSG` (5) | `modules/network` | `10-network` |
+| SPEC-NET-006 | REQ-NET-028..030 | `ARCH-NET-DNS` | not yet in `network.yaml` — DNS/DHCP wasn't part of the network-domain PoC migration | `modules/network` | `10-network` |
 | SPEC-NET-005 | REQ-NET-021..027 | all `ARCH-FLOW-*` | verification layer — **no module, no state unit** (ADR-0007) | n/a (`tofu test` cross-module assertions) | n/a |
-| SPEC-OCI-002 | REQ-OCI-008..011 | `ARCH-SVC-KMS` | not yet in `network.yaml` (identity/governance domain, not populated) | `modules/oci-kms` | `20-security/kms` |
-| SPEC-OCI-003 | REQ-OCI-012..015 | `ARCH-SVC-LOGGING`, `ARCH-SVC-MONITORING` | not yet in `network.yaml` | `modules/oci-logging-monitoring` | `20-security/logging-monitoring` |
+| SPEC-OCI-002 | REQ-OCI-008..011 | `ARCH-SVC-KMS` | not yet in `network.yaml` (identity/governance domain, not populated) | `modules/kms` | `20-security/kms` |
+| SPEC-OCI-003 | REQ-OCI-012..015 | `ARCH-SVC-LOGGING`, `ARCH-SVC-MONITORING` | not yet in `network.yaml` | `modules/logging-monitoring` | `20-security/logging-monitoring` |
 
-Module names above (`oci-foundation`, `oci-network`, `oci-kms`,
-`oci-logging-monitoring`) are proposed, not yet accepted — each is
-confirmed or revised in the PR that actually scaffolds it, per the master
-execution prompt's instruction not to accept module names blindly.
+Module names above (`foundation`, `network`, `kms`, `logging-monitoring`)
+are **not** this PR's invention — each is already fixed by its Spec's own
+Constraints section (SPEC-OCI-001/GitHub Issue #11: `modules/foundation`;
+SPEC-NET-001/004: `modules/network`; SPEC-OCI-002: `modules/kms`;
+SPEC-OCI-003: `modules/logging-monitoring`). An earlier draft of this
+table proposed an `oci-*`-prefixed naming scheme before checking the
+Specs' own Constraints sections against it — corrected once that check
+was actually done (per the master execution prompt's "do not accept
+names blindly" instruction, which cuts both ways: don't blindly accept
+*or* blindly invent).
 
 Threat-model corpus gaps this matrix surfaces (real findings, not
 invented): `network.yaml` doesn't yet model DNS/DHCP (SPEC-NET-006) or
@@ -141,13 +147,18 @@ This is a **one-time, explicitly-labeled operation per environment**, not
 a repeatable CI step — `plan.yml`/`validate.yml` never run it. Backend:
 OCI Object Storage (native OpenTofu S3-compatible backend against OCI's
 S3-compatibility API, per REQ-OCI-005 — versioning enabled, no third-party
-state SaaS). Locking: OCI Object Storage's S3-compatible backend does not
-provide native state locking the way an S3+DynamoDB pair does; this is a
-**known gap**, not silently assumed away — tracked for the module that
-implements `00-foundation` to resolve or explicitly accept (single-writer,
-single-maintainer risk profile makes this lower-severity than a
-multi-operator team, but it is still a real gap worth a line in that PR's
-own documentation, not just here).
+state SaaS).
+
+**Locking (resolved, PR B)**: checked against OCI's own S3 Compatibility
+API reference, which explicitly enumerates supported `PutObject` request
+headers — only encryption and chunked-upload headers are listed;
+`If-None-Match`/`If-Match` are conspicuously absent, unlike AWS S3's own
+reference. `use_lockfile` is left **disabled** in `live/root.hcl` rather
+than trust unverified conditional-write support. Concurrency control is
+process-level instead: never run `terragrunt apply` concurrently against
+the same unit (single-maintainer repo; CI never auto-applies). See
+`live/root.hcl`'s own LOCKING NOTE comment for the full
+[Cause]→[Impact]→[Remediation].
 
 ## Secrets and credentials strategy
 
@@ -225,12 +236,14 @@ broad grant):
    `00-foundation`'s scope (REQ-OCI-003) since it's compartment/IAM
    plumbing, even though nothing consumes it until compute exists.
 
-Exact least-privilege policy statements (the actual OCI policy-statement
-syntax) are **not** written here — that's `00-foundation`'s own module PR,
-where the statements can be verified against the real resource types that
-module creates rather than guessed in advance. This is the bounded-gap
-pattern the master execution prompt requires: the gap is named, not
-silently resolved with a guess.
+Exact least-privilege policy statements now exist —
+`modules/foundation/iam.tf` (CI and admin `oci_identity_policy` resources,
+verified compartment-scoped, no `in tenancy` statement — enforced by
+`tests/foundation.tftest.hcl`). What's still **not** resolved here: the
+bootstrap identity's own tenancy-level grant (item 1 above) — that's
+inherently outside any `tofu apply` this repo runs (chicken-and-egg: a
+compartment-scoped policy can't authorize its own compartment's
+creation) — see `modules/foundation/README.md#bootstrap-identity-requirement-not-granted-by-this-module`.
 
 ## Free Tier classification (M1 scope)
 
@@ -261,37 +274,59 @@ apply, not assumed to still hold indefinitely.
 
 See [modules/README.md](modules/README.md) for the full contract every
 OpenTofu module must satisfy (purpose, input/output contract, security
-invariants, validation, tests, examples). No modules exist yet — this PR
-establishes the contract; the module implementing it (starting with
-`00-foundation`'s `oci-foundation` module) is a separate PR.
+invariants, validation, tests, examples). `modules/foundation/` (PR B) is
+the first module built against it — compartment, tags, IAM, state
+bucket, 11 `tofu test` assertions (6 positive, 5 negative), all passing
+against the real `oracle/oci` v8.27.0 provider schema.
 
 ## Terragrunt live layout
 
-See `live/` for the account/region/environment composition layer that
-exists so far (`root.hcl`, `common/*.hcl`, `oci/eu-madrid-1/region.hcl`,
-`oci/eu-madrid-1/lab/env.hcl`). Per-unit `terragrunt.hcl` files
-(`00-foundation/terragrunt.hcl`, etc.) are **not** created yet — each is
-added alongside the OpenTofu module it wires in, in that unit's own PR,
-so no `terragrunt.hcl` ever points at a `terraform { source = ... }` that
-doesn't exist.
+See `live/` for the account/region/environment composition layer
+(`root.hcl`, `common/*.hcl`, `oci/eu-madrid-1/region.hcl`,
+`oci/eu-madrid-1/lab/env.hcl`) plus the first real unit,
+`oci/eu-madrid-1/lab/00-foundation/terragrunt.hcl` (PR B), wired to
+`modules/foundation`. Verified end-to-end with `terragrunt render`
+(includes resolve, `inputs` merge correctly, `generate` blocks produce
+valid provider/backend HCL) — not just `hcl fmt`/`hcl validate` syntax
+checks. `10-network`/`20-security/*` units still don't exist — each is
+added alongside its own module, so no `terragrunt.hcl` ever points at a
+`terraform { source = ... }` that doesn't exist.
 
 ## CI pipeline — current state and known gap
 
 `validate.yml` (fmt/validate/`tofu test`/tflint/checkov) and `plan.yml`
 (plan against `infrastructure/live/oci/eu-madrid-1/lab`, static secrets,
 skips cleanly if unconfigured) already exist and match this document's
-toolchain. **Known gap, not fixed by this PR**: `plan.yml` currently runs
-a single `tofu plan` directly against the `lab` environment root — once
-real per-unit `terragrunt.hcl` files exist (PR B onward), it needs to
-become Terragrunt-DAG-aware (`terragrunt run-all plan` or a per-unit loop
-in dependency order) so a PR touching `10-network` doesn't silently skip
-planning `20-security/logging-monitoring`'s dependency on it. Deferred to
-the PR that creates the first real `terragrunt.hcl`, per "only create
-paths justified by actual implementation" — updating CI mechanics for
-units that don't exist yet would be speculative.
+toolchain.
+
+**Fixed by PR B**: `validate.yml`'s `tofu test` loop `cd`'d into the
+`tests/` subdirectory itself (`find ... -printf '%h\n'` returns the
+`.tftest.hcl` file's own directory) rather than the module root `tofu
+test` needs to run from — a latent bug that only surfaced once real test
+files existed. Also fixed: `modules/foundation` initially had no file
+literally named `main.tf` (resources split by concern into
+`compartment.tf`/`tags.tf`/`iam.tf`/`state_backend.tf`), so the
+`validate modules` loop's `find -name main.tf` never discovered it —
+added a real, non-empty navigational `main.tf` rather than change the
+discovery pattern.
+
+**Still a known gap, not fixed by this PR**: `plan.yml` currently runs a
+single `tofu plan` directly against the `lab` environment root — once
+`10-network`/`20-security/*` also have real `terragrunt.hcl` files, it
+needs to become Terragrunt-DAG-aware (`terragrunt run-all plan` or a
+per-unit loop in dependency order) so a PR touching `10-network` doesn't
+silently skip planning `20-security/logging-monitoring`'s dependency on
+it. Deferred to the PR that creates the second real unit — with only
+`00-foundation` existing, there's no DAG yet to be unaware of.
 
 ## Apply gate
 
-Not reached by this PR. No `.tf` resource code exists yet — there is
-nothing to plan or apply. See the phase-4 execution report for the current
-gate status.
+Not reached by this PR. `modules/foundation` exists, is `tofu
+validate`/`tofu test`/`tflint`/`checkov`-clean, and its Terragrunt unit
+(`00-foundation`) renders correctly — but no real OCI credentials are
+configured in this environment, so no real `tofu plan` has ever been
+generated against actual OCI. Per the master execution prompt's APPLY
+GATE requirements, an ungenerated plan alone is sufficient to keep this
+gate closed regardless of how clean static validation is. See the phase-4
+PR B execution report for the current gate status and the full
+[Cause]→[Impact]→[Remediation] on the S3-compat locking finding.

--- a/infrastructure/live/common/account.hcl
+++ b/infrastructure/live/common/account.hcl
@@ -6,6 +6,11 @@
 locals {
   platform_name = "oracle-free-tier-platform"
 
+  # Not itself secret, but account-specific -- sourced from env rather
+  # than hardcoded. Every unit gets this via root.hcl's `inputs = merge(...)`
+  # without needing to redeclare it.
+  tenancy_ocid = get_env("OCI_TENANCY_OCID", "")
+
   # Object Storage namespace is tenancy-specific but not itself secret;
   # still sourced from env rather than hardcoded, since it's account data,
   # not a portable constant this repo should assume.

--- a/infrastructure/live/oci/eu-madrid-1/lab/00-foundation/terragrunt.hcl
+++ b/infrastructure/live/oci/eu-madrid-1/lab/00-foundation/terragrunt.hcl
@@ -1,0 +1,34 @@
+# First real Terragrunt unit -- SPEC-OCI-001, ADR-0007's 00-foundation.
+# Root of the dependency graph: 10-network and 20-security/* both depend
+# on this unit's outputs (compartment_ocid, tag namespace names).
+#
+# BOOTSTRAP NOTE: this file's remote_state block (inherited from root.hcl)
+# assumes the state bucket already exists. The FIRST TIME this unit is
+# ever applied in a new environment, it doesn't -- that's what
+# ../../../../../../modules/foundation/README.md#bootstrap-runbook's
+# two-phase sequence resolves, run directly against the module (not
+# through this Terragrunt unit) before this file is ever `terragrunt
+# apply`'d. After that one-time bootstrap, this unit's own
+# `terragrunt init` finds the bucket already populated at exactly the
+# backend key it would generate (00-foundation/terraform.tfstate) and
+# just uses it -- no migration needed here.
+
+include "root" {
+  # find_in_parent_folders() defaults to searching for a file literally
+  # named terragrunt.hcl -- our root config is root.hcl (Terragrunt's own
+  # recommended name, replacing terragrunt.hcl-as-root), so the filename
+  # must be passed explicitly.
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../../../modules/foundation"
+}
+
+inputs = {
+  # tenancy_ocid and state_bucket_name are NOT redeclared here -- both
+  # already arrive via root.hcl's `inputs = merge(...)` from
+  # common/account.hcl, so there's exactly one place each is defined.
+  ci_group_name    = get_env("OCI_CI_GROUP_NAME", "platform-ci")
+  admin_group_name = get_env("OCI_ADMIN_GROUP_NAME", "platform-admins")
+}

--- a/infrastructure/live/root.hcl
+++ b/infrastructure/live/root.hcl
@@ -21,16 +21,34 @@
 # AWS_SECRET_ACCESS_KEY env var names (the S3-backend machinery's own
 # convention) rather than inventing repo-specific names.
 #
-# LOCKING NOTE: `use_lockfile = true` enables OpenTofu's native S3-backend
-# locking (conditional writes via If-None-Match — no DynamoDB-equivalent
-# needed). Verified from OpenTofu's own backend docs that this feature
-# exists; NOT yet empirically verified that OCI's S3-compatible API honors
-# If-None-Match conditional PUT semantics identically to AWS S3 — that
-# must be confirmed in 00-foundation's own bootstrap PR against real OCI,
-# not assumed here. If it turns out unsupported, remove `use_lockfile` and
-# record the gap explicitly (single-maintainer risk profile makes
-# unlocked state a lower-severity gap than for a multi-operator team, but
-# it must be a documented decision, not a silent one).
+# LOCKING NOTE (resolved, PR B): `use_lockfile` was left enabled after PR A
+# pending verification. Now checked against OCI's own S3 Compatibility API
+# reference (docs.oracle.com/en-us/iaas/Content/Object/Tasks/
+# s3compatibleapi_topic-Amazon_S3_Compatibility_API_Support.htm), which
+# explicitly enumerates supported PutObject request headers — only
+# encryption (x-amz-server-side-encryption-*) and chunked-upload
+# (Content-Encoding: aws-chunked, x-amz-decoded-content-length) headers are
+# listed. If-None-Match/If-Match are conspicuously absent, unlike AWS S3's
+# own PutObject reference, which documents them explicitly. Absence from
+# an otherwise-detailed reference is real (if not 100%-conclusive)
+# evidence against support, not proof of absence — but per this program's
+# "do not assume AWS S3 behavior" rule, that's enough to not enable a
+# safety mechanism that could silently fail to serialize writes.
+#
+# [Cause] -> OCI's official S3-Compatibility API docs do not list
+#   If-None-Match/If-Match among supported PutObject headers.
+# [Impact] -> use_lockfile's native locking depends on conditional writes
+#   via If-None-Match; if OCI silently ignores or errors on that header,
+#   concurrent `terragrunt apply` runs could race and corrupt or overwrite
+#   state without any lock error ever surfacing.
+# [Remediation] -> use_lockfile left DISABLED below. This repo's actual
+#   concurrency control is process-level: never run `terragrunt apply`
+#   concurrently against the same unit (single-maintainer repo; CI never
+#   auto-applies — see infrastructure/README.md#apply-gate). Revisit if
+#   Oracle documents conditional-write support, or if this is empirically
+#   confirmed against a real OCI tenancy (a 412 on a repeated
+#   If-None-Match: * PUT would confirm it; a silent 200 would confirm the
+#   header is ignored).
 
 locals {
   account_vars = read_terragrunt_config(find_in_parent_folders("common/account.hcl"))
@@ -64,7 +82,7 @@ remote_state {
     skip_credentials_validation = true
     skip_metadata_api_check     = true
     skip_s3_checksum            = true
-    use_lockfile                = true
+    use_lockfile                = false # see LOCKING NOTE above — not enabled without verified conditional-write support
   }
 }
 

--- a/infrastructure/live/root.hcl
+++ b/infrastructure/live/root.hcl
@@ -2,14 +2,17 @@
 # includes this via `include "root" { path = find_in_parent_folders() }`.
 #
 # BOOTSTRAP EXCEPTION (REQ-OCI-007): the remote_state block below assumes
-# the state bucket already exists. It does NOT exist until 00-foundation's
-# own two-phase bootstrap has run once — see
-# ../README.md#remote-state-bootstrap-sequence. 00-foundation's own
-# terragrunt.hcl (created in the PR that scaffolds that unit, not this
-# one) is the one unit that must NOT include this root.hcl's remote_state
-# block on its first apply; it starts from local state
-# (`-state=bootstrap.local.tfstate`) per that sequence's phase 1, then
-# migrates into the bucket this block creates for every unit after it.
+# the state bucket already exists. It does NOT exist until
+# modules/foundation's own two-phase bootstrap has run once, directly
+# against that module (NOT through this Terragrunt unit) -- see
+# modules/foundation/README.md#bootstrap-runbook for the exact commands
+# (default local terraform.tfstate, not a custom -state= path -- an
+# earlier draft here referenced -state=bootstrap.local.tfstate, corrected
+# once `tofu init -help` confirmed init has no -state flag, so
+# -migrate-state could only ever find state at the default path). Once
+# that bootstrap has run, oci/eu-madrid-1/lab/00-foundation/terragrunt.hcl
+# includes this root.hcl normally -- the bucket already exists by the
+# time that unit is ever touched.
 #
 # CREDENTIAL NOTE: this backend authenticates against OCI Object Storage's
 # S3-compatible API, which requires a Customer Secret Key (Access Key /

--- a/infrastructure/modules/README.md
+++ b/infrastructure/modules/README.md
@@ -1,8 +1,9 @@
 # OpenTofu module contract
 
-Every module under `infrastructure/modules/` follows this contract. No
-module exists yet — this is the standard the first module (`foundation`,
-implementing `SPEC-OCI-001`) is held to, not a retrospective description.
+Every module under `infrastructure/modules/` follows this contract.
+`foundation` (`SPEC-OCI-001`) is the first module built against it — this
+document was written as the standard it's held to, not a retrospective
+description of it.
 
 ## Principles
 

--- a/infrastructure/modules/README.md
+++ b/infrastructure/modules/README.md
@@ -1,7 +1,7 @@
 # OpenTofu module contract
 
 Every module under `infrastructure/modules/` follows this contract. No
-module exists yet — this is the standard the first module (`oci-foundation`,
+module exists yet — this is the standard the first module (`foundation`,
 implementing `SPEC-OCI-001`) is held to, not a retrospective description.
 
 ## Principles
@@ -26,7 +26,12 @@ expressed as explicit `variable`/`output` contracts.
 modules/<name>/
 ├── README.md         PURPOSE, INPUT/OUTPUT contract, security invariants,
 │                       failure modes, upgrade expectations (see below)
-├── main.tf            resources
+├── main.tf            resources, OR (for a module whose resources split
+│                       naturally by concern) a real, non-empty entry-point
+│                       file mapping which named file owns what — main.tf
+│                       must exist either way: validate.yml's module
+│                       discovery loop keys off it (see foundation/main.tf
+│                       for a worked example)
 ├── variables.tf        typed inputs, validation blocks
 ├── outputs.tf           outputs consumed by other units/modules
 ├── versions.tf            required_providers, required_version
@@ -99,22 +104,22 @@ security requirement.
 
 ## Candidate first modules
 
-Proposed, not accepted — each name is confirmed or revised in the PR that
-actually scaffolds it:
+Each name below is fixed by its own Spec's Constraints section (not
+invented by this document) — see the citation in each row:
 
 | Candidate name | Spec | State unit |
 | --- | --- | --- |
-| `oci-foundation` | SPEC-OCI-001 | `00-foundation` |
-| `oci-network` | SPEC-NET-001/002/003/004/006 | `10-network` |
-| `oci-kms` | SPEC-OCI-002 | `20-security/kms` |
-| `oci-logging-monitoring` | SPEC-OCI-003 | `20-security/logging-monitoring` |
+| `foundation` | SPEC-OCI-001 | `00-foundation` |
+| `network` | SPEC-NET-001/002/003/004/006 | `10-network` |
+| `kms` | SPEC-OCI-002 | `20-security/kms` |
+| `logging-monitoring` | SPEC-OCI-003 | `20-security/logging-monitoring` |
 
-`oci-network` bundles VCN/subnets/gateways/routing/NSGs/DNS into one
+`network` bundles VCN/subnets/gateways/routing/NSGs/DNS into one
 module because ADR-0007 already decided `10-network` is one state unit —
 a module boundary narrower than its state unit would just add internal
 plumbing with no independent-apply benefit; a module boundary wider than
 its state unit isn't possible (Terragrunt wires exactly one module source
 per unit). This does not preclude internal file organization within
-`oci-network/main.tf` mirroring each Spec (vcn.tf, subnets.tf, gateways.tf,
+`network/main.tf` mirroring each Spec (vcn.tf, subnets.tf, gateways.tf,
 routing.tf, security.tf, dns.tf) for readability — only the Terragrunt/
 state boundary is fixed, not the internal file layout.

--- a/infrastructure/modules/foundation/.terraform.lock.hcl
+++ b/infrastructure/modules/foundation/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/oracle/oci" {
+  version     = "8.27.0"
+  constraints = "8.27.0"
+  hashes = [
+    "h1:AjL/F1LqP/NnqC/85zz/dpbwtOkyNxUmxPwor7Hkj9A=",
+    "h1:H7OoMqL2xxC7L2Yw2fEkFixQdbmcvPsdCgJMkIEpDNk=",
+    "h1:J2rPY5OC6lyOm5x9/4NZGwRObavf0K2tj1Z3XbSxfnc=",
+    "h1:K14lmG1OoKZ91MHJFCWLfG88j9qwn2QHgqYW705VEIM=",
+    "h1:KHD+5YqwHItc1wHGXS8Xc+/J/O42F7B4vo9O24ZgXAo=",
+    "h1:MxFf+EHJ0n5ynhddfuSOJzIhVNrGig5c/RiBoAQojPg=",
+    "h1:QrYgpQr9Vgd6sZ6WJi+jFDmSCfPtGil6+Oz84A+hWNA=",
+    "h1:T4zljEl0dK346N50cUUs4v65zg+KNRlPmehjd4G3GZY=",
+    "h1:eYektTaEIOl06Pes66VyCLXWq1J+kW8Wg0D+HkqzYUU=",
+    "h1:iUB9eoB/apT4/8nk/QKmg315yQSxkoXACZCH5KN4OL8=",
+    "h1:lGISh5fY2mqyPRkwmdksLX37VRs8sTA4OCbis9W6XVg=",
+    "h1:pJ7DmHo9MfhDM7gscoPE7OHqEKxwUNEwz2/A5ZOUUN0=",
+    "h1:xCGfRz9+0pHOj0tisklLK+2tQbRliTWnBfLFhOVwMBA=",
+    "zh:17aac70ae4c46bd85a285420414fac19a4fe42a340c95c1cf4ab6d29da71e656",
+    "zh:1cbbd87089cda3d67423927b431e4f0fceff17aa4dc13437909bbaaf306bd9f5",
+    "zh:1cd6fb7b78af954620eae64431d6f123f3dd701320bc3ab8cb6b47f1480d79b9",
+    "zh:3ca2f70cf877df758c3fca9b01138446728167e8cfba6556028e64df24903d37",
+    "zh:490588f364393c8e53d8621aeaf5c23d92c55d32ebca2b1d1a48d93b1cd3ff9d",
+    "zh:594cb7d04e1dde0ca0d848e1aa848ea136d0d9315cf77b2dd44df5af0e54156a",
+    "zh:69f58679129f332798c3f5a9f249c1dd4d4a0f80a44c89a540a1907e0ac5f1c9",
+    "zh:7a4f19a156084dc4ba8acf6117cee0de7c0d11574e99d2f6525df6da46f5d0d3",
+    "zh:8378cc00db7b0f9fa1007ba105122fb2d4c052947db1b1c65fb0a1111670c001",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a95ed489c8e00dbe950fb440dec6f51632b1401b738bd187384e33b3bcb393ad",
+    "zh:c1bc19afd167c54789d21777f6ed60b472acf7d3e2d50ebc8691e7a1cd90c4f4",
+    "zh:e1f7b2b516334ef070c6a94a85ce11560db9f2510f28128fc04b5ac724db3e55",
+    "zh:f2c19157c2b4a79aea8bf89e76f51f9363dd743fc8607f5d9b87684a47444c99",
+  ]
+}

--- a/infrastructure/modules/foundation/README.md
+++ b/infrastructure/modules/foundation/README.md
@@ -1,0 +1,262 @@
+# `foundation` module
+
+## Purpose
+
+Implements `SPEC-OCI-001` (REQ-OCI-001..007): the root of the platform's
+dependency graph. Every other module needs this one applied first — it
+creates the compartment everything else lives in, the Defined Tags
+taxonomy other modules apply values from, the least-privilege IAM policies
+scoping CI/admin access, and the OCI Object Storage bucket every
+Terragrunt unit (including this one, after bootstrap) stores state in.
+This is a single module — not split further — because ADR-0007 already
+decided `00-foundation` is one state unit: these resources share one
+blast radius (everything downstream depends on the compartment existing)
+and one lifecycle (essentially create-once).
+
+## Input contract
+
+| Variable | Type | Required | Validation |
+| --- | --- | --- | --- |
+| `tenancy_ocid` | string | yes | must match `^ocid1\.tenancy\.` |
+| `compartment_name` | string | no (default `"platform"`) | — |
+| `compartment_description` | string | no | — |
+| `environment` | string | yes | one of `lab`, `staging`, `prod` |
+| `platform_name` | string | no (default `"oracle-free-tier-platform"`) | — |
+| `ci_group_name` | string | yes | non-empty |
+| `admin_group_name` | string | yes | non-empty |
+| `state_bucket_name` | string | yes | valid OCI bucket name pattern |
+| `dynamic_group_name` | string | no (default `"platform-instances"`) | — |
+
+`ci_group_name`/`admin_group_name` reference **existing** OCI IAM Groups —
+this module does not create IAM Users or Groups (see "Security invariants"
+below for why).
+
+## Output contract
+
+| Output | Consumed by |
+| --- | --- |
+| `compartment_ocid` | every downstream module (`SPEC-NET-001`, `SPEC-OCI-002`, `SPEC-OCI-003` Interfaces sections) |
+| `compartment_name` | downstream IAM policy statements referencing the compartment by name |
+| `tag_namespace_platform` / `tag_namespace_security` | downstream modules building `"<Namespace>.<Key>"` `defined_tags` references |
+| `dynamic_group_ocid` | I04 (compute), once it exists |
+| `state_bucket_name` / `state_bucket_namespace` | `infrastructure/live/root.hcl`'s backend config (must match `common/account.hcl`) |
+
+## Resource ownership
+
+`oci_identity_compartment` (1), `oci_identity_tag_namespace` (2:
+Platform, Security), `oci_identity_tag` (4: Platform.Environment,
+Platform.System, Platform.ManagedBy, Security.TrustZone),
+`oci_identity_policy` (2: CI, admin), `oci_identity_dynamic_group` (1),
+`oci_objectstorage_bucket` (1: state), `data.oci_objectstorage_namespace`
+(1, read-only).
+
+**Not owned here**: IAM Users/Groups (see Security invariants), the
+tenancy-level bootstrap-identity grant (see Bootstrap runbook), any
+backup bucket (I19/M9 — a separate resource in a separate module, never
+sharing the state bucket).
+
+## Security invariants
+
+- **REQ-OCI-001**: every resource's `compartment_id` is either
+  `var.tenancy_ocid` (only for the compartment itself and the dynamic
+  group, which OCI's data model requires to be tenancy-scoped) or
+  `oci_identity_compartment.platform.id` — never a resource placed
+  directly in the tenancy root that could instead live in the platform
+  compartment.
+- **REQ-OCI-002**: every `oci_identity_policy` statement targets
+  `compartment ${oci_identity_compartment.platform.name}` — grep the
+  module for the literal string `in tenancy` to confirm none exists.
+- **No IAM User/Group creation**: `ci_group_name`/`admin_group_name` are
+  inputs referencing pre-existing groups, not resources this module
+  creates. Rationale: the OCI user `plan.yml`'s existing static secrets
+  authenticate as already exists and already belongs to *some* group
+  (created out-of-band, before this repo's IaC existed) — this module's
+  job is granting that existing identity compartment-scoped rights, not
+  managing tenancy-wide identity lifecycle, which is a broader
+  identity-governance concern this Spec explicitly scopes out.
+- **State bucket**: `access_type = "NoPublicAccess"` set explicitly (not
+  relying on the provider default), `versioning = "Enabled"` (REQ-OCI-005),
+  `lifecycle { prevent_destroy = true }`. Checkov (`validate.yml`,
+  `soft_fail: false`) is the second, independent layer catching an
+  accidental public-access misconfiguration.
+- **Compartment**: `enable_delete = false` explicit (matches the
+  provider's own default, made explicit rather than implicit — see
+  `compartment.tf`'s comment) plus `lifecycle { prevent_destroy = true }`.
+- **No circular tag dependency**: the compartment resource intentionally
+  has no `defined_tags` (only `freeform_tags`) — see `compartment.tf`'s
+  comment for why referencing a tag namespace created inside itself would
+  be circular.
+
+## Validation
+
+```sh
+cd infrastructure/modules/foundation
+tofu fmt -check
+tofu init -backend=false -input=false
+tofu validate
+tofu test
+```
+
+## Failure modes
+
+- **Partial apply mid-bootstrap**: if phase 1 (below) fails after creating
+  the compartment but before the state bucket, re-running `tofu apply`
+  against the same local state is safe — OpenTofu reconciles from what
+  already exists (no resource in this module has a dependency ordering
+  that would leave orphaned state on a partial failure).
+- **`ci_group_name`/`admin_group_name` referencing a nonexistent OCI
+  Group**: `tofu apply` fails cleanly with an OCI 404 on the policy
+  resource — no partial policy is left in an inconsistent state, since
+  policy statements are validated as a whole by the OCI API.
+- **Dynamic Group matching zero instances (M1, always, until M2)**: not a
+  failure — expected and documented (`iam.tf`'s comment).
+
+## Upgrade expectations
+
+Changing `compartment_name` or `state_bucket_name` after first apply
+forces replacement (OCI compartment/bucket names are immutable) — this is
+destructive and MUST NOT be done casually; see Bootstrap runbook's
+Rollback section. Changing `ci_group_name`/`admin_group_name` updates the
+existing policy's statements in place (no replacement). Changing
+`environment` updates the `Platform.Environment` tag value in place.
+
+## Bootstrap runbook (REQ-OCI-007)
+
+**This is a one-time, explicitly-labeled operation per environment, run
+manually by the human administrator — never a CI step.** `plan.yml`/
+`validate.yml` never execute this sequence.
+
+### Phase 1 — local bootstrap apply
+
+```sh
+cd infrastructure/modules/foundation
+tofu init -backend=false -input=false
+tofu apply -input=false \
+  -var="tenancy_ocid=$OCI_TENANCY_OCID" \
+  -var="environment=lab" \
+  -var="ci_group_name=<existing CI group name>" \
+  -var="admin_group_name=<existing admin group name>" \
+  -var="state_bucket_name=oracle-free-tier-platform-tfstate"
+```
+
+`-backend=false` disables `versions.tf`'s `backend "s3" {}` block for this
+init, so state writes to the default local `./terraform.tfstate` — **not**
+a custom `-state=` path (see `SPEC-OCI-001`'s Verification section for why
+that would break phase 2: `tofu init` has no `-state` flag, so
+`-migrate-state` can only find state at the default path).
+
+Creates: the compartment, both tag namespaces + 4 tags, both IAM
+policies, the dynamic group, and — critically — the state bucket itself.
+
+### Phase 2 — configure the real backend and migrate
+
+```sh
+cat > backend.hcl <<'EOF'
+bucket                      = "oracle-free-tier-platform-tfstate"
+key                         = "oci/eu-madrid-1/lab/00-foundation/terraform.tfstate"
+region                      = "eu-madrid-1"
+use_path_style              = true
+skip_region_validation      = true
+skip_credentials_validation = true
+skip_metadata_api_check     = true
+skip_s3_checksum            = true
+EOF
+
+# endpoints.s3 is supplied separately (not written into backend.hcl) so
+# the file itself never needs to encode the tenancy's Object Storage
+# namespace as a semi-sensitive value; access_key/secret_key are NOT
+# passed via -backend-config at all — the S3 backend reads them natively
+# from AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY (the Customer Secret Key —
+# see "Customer Secret Key" below — never written to any file on disk).
+tofu init -input=false -migrate-state \
+  -backend-config=backend.hcl \
+  -backend-config="endpoints={s3=\"https://<namespace>.compat.objectstorage.eu-madrid-1.oci.customer-oci.com\"}"
+```
+
+OpenTofu detects the backend configuration changed (none → `s3`) and,
+with `-migrate-state`, copies the local `terraform.tfstate` into the
+bucket at the key above without prompting.
+
+### Verify, then remove bootstrap-only artifacts
+
+```sh
+oci iam compartment list --compartment-id-in-subtree true \
+  --query "data[?name=='platform']"
+oci os object list --bucket-name oracle-free-tier-platform-tfstate \
+  --namespace "$OCI_NS" --query "data[?starts_with(name, 'oci/eu-madrid-1/lab/00-foundation/')]"
+
+rm -f backend.hcl   # no secrets in it after the above, but not durable config either
+# terraform.tfstate is no longer authoritative once migration succeeds —
+# confirm the object above exists in the bucket before deleting it locally.
+```
+
+### Every subsequent unit
+
+`infrastructure/live/oci/eu-madrid-1/lab/00-foundation/terragrunt.hcl`
+(created alongside this module, see `examples/minimal/`) includes
+`root.hcl` normally from its first `terragrunt init` — the bucket already
+exists by the time that unit is ever touched, so it resolves the same
+backend key (`oci/eu-madrid-1/lab/00-foundation/terraform.tfstate`) this bootstrap converged
+on, with no further migration needed. Every other unit (`10-network`,
+`20-security/*`) uses the remote backend from its own first apply — no
+bootstrap required, this module's bucket already exists.
+
+### Customer Secret Key
+
+The S3-Compatibility API authenticates via a Customer Secret Key (Access
+Key/Secret Key pair) — **not** the OCI API key (tenancy/user OCID +
+fingerprint + private key) `plan.yml`'s existing secrets use.
+
+- **Created**: OCI Console → Identity → Users → (the CI/bootstrap user) →
+  Customer Secret Keys → Generate Secret Key. The secret is shown once.
+- **Local development**: export `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`
+  in your shell (never in a committed file — see
+  `.gitignore`/`scripts/check-gpg-signing.sh`-adjacent secrets discipline
+  in `SECURITY.md`).
+- **GitHub Actions**: add as encrypted repository secrets, exposed to
+  `plan.yml`/future `apply` workflows as the same env var names.
+- **Rotation**: generate a new key, update the secret store (local env /
+  GitHub secret), verify a `terragrunt plan` succeeds, then delete the old
+  key from OCI Console. No overlap-free rotation exists for a single
+  active key — a brief dual-key window during rotation is expected.
+- **Revocation**: delete the key from OCI Console → Users → Customer
+  Secret Keys immediately if exposed; rotate per above.
+
+### Bootstrap-identity requirement (not granted by this module)
+
+The identity running Phase 1 needs **tenancy-level** rights to create a
+compartment and an Object Storage bucket — this module's own IAM policies
+(compartment-scoped, by REQ-OCI-002) cannot grant the rights needed to
+create the compartment they're scoped to; that would be circular. This
+tenancy-level grant must already exist on the bootstrap identity before
+Phase 1 runs (via OCI Console/CLI, out-of-band — not something any
+`tofu apply` in this repo creates, matching
+`infrastructure/README.md#iam-bootstrap-model`'s "Bootstrap identity"
+class). Minimum rights: `manage compartments in tenancy`,
+`manage tag-namespaces in tenancy` (or compartment-scoped, if the tag
+namespaces were instead created directly under the new compartment — see
+`tags.tf`, which they are), `manage object-family in tenancy` (bucket
+creation).
+
+### Rollback / recovery
+
+Compartment/bucket names are immutable (Upgrade expectations, above) —
+there is no in-place rename. Recovering from a bad bootstrap means: fix
+the module code, `tofu destroy` is **not** an option (`prevent_destroy`
+on both the compartment and the bucket, and `enable_delete = false` on
+the compartment specifically means destroy wouldn't even delete the real
+resource) — the safe path is a new PR correcting the module and a fresh
+`tofu apply` reconciling forward, per `SPEC-OCI-001`'s own
+Rollback/Recovery section ("never a manual console edit").
+
+## Example
+
+See `examples/minimal/`.
+
+## Tests
+
+See `tests/` — `foundation.tftest.hcl` (positive: valid inputs produce
+the expected plan shape) and `foundation_negative.tftest.hcl` (invalid
+environment, empty group names, invalid bucket name — each MUST fail
+`tofu test`'s `expect_failures` assertions on the variable validation
+blocks).

--- a/infrastructure/modules/foundation/README.md
+++ b/infrastructure/modules/foundation/README.md
@@ -134,11 +134,24 @@ existing policy's statements in place (no replacement). Changing
 manually by the human administrator — never a CI step.** `plan.yml`/
 `validate.yml` never execute this sequence.
 
-### Phase 1 — local bootstrap apply
+This module deliberately declares **no backend block** (see
+`versions.tf`'s comment) — Terragrunt's `generate` mechanism owns that
+once a unit exists (`live/root.hcl`). A `backend "s3" {}` block in this
+module too would be a **second** backend declaration in the same
+configuration; OpenTofu rejects that outright ("Duplicate backend
+configuration"), confirmed by reproducing it locally against a real
+`backend.tf`, not assumed. So bootstrap runs against an **untracked
+scratch copy** of this module, never the module in place — that copy is
+the only place a temporary `backend.tf` is ever written.
+
+### Phase 1 — local bootstrap apply (scratch copy)
 
 ```sh
-cd infrastructure/modules/foundation
-tofu init -backend=false -input=false
+cp -r infrastructure/modules/foundation /tmp/foundation-bootstrap
+cd /tmp/foundation-bootstrap
+rm -rf tests examples .terraform .terraform.lock.hcl
+
+tofu init -input=false   # no backend declared -> defaults to local ./terraform.tfstate
 tofu apply -input=false \
   -var="tenancy_ocid=$OCI_TENANCY_OCID" \
   -var="environment=lab" \
@@ -147,45 +160,46 @@ tofu apply -input=false \
   -var="state_bucket_name=oracle-free-tier-platform-tfstate"
 ```
 
-`-backend=false` disables `versions.tf`'s `backend "s3" {}` block for this
-init, so state writes to the default local `./terraform.tfstate` — **not**
-a custom `-state=` path (see `SPEC-OCI-001`'s Verification section for why
-that would break phase 2: `tofu init` has no `-state` flag, so
-`-migrate-state` can only find state at the default path).
-
 Creates: the compartment, both tag namespaces + 4 tags, both IAM
 policies, the dynamic group, and — critically — the state bucket itself.
 
-### Phase 2 — configure the real backend and migrate
+### Phase 2 — write the real backend and migrate (same scratch copy)
 
 ```sh
-cat > backend.hcl <<'EOF'
-bucket                      = "oracle-free-tier-platform-tfstate"
-key                         = "oci/eu-madrid-1/lab/00-foundation/terraform.tfstate"
-region                      = "eu-madrid-1"
-use_path_style              = true
-skip_region_validation      = true
-skip_credentials_validation = true
-skip_metadata_api_check     = true
-skip_s3_checksum            = true
+# Still in /tmp/foundation-bootstrap. A real, complete backend block --
+# not partial -backend-config flags into a pre-declared empty block,
+# since none exists anymore.
+cat > backend.tf <<EOF
+terraform {
+  backend "s3" {
+    bucket = "oracle-free-tier-platform-tfstate"
+    key    = "oci/eu-madrid-1/lab/00-foundation/terraform.tfstate"
+    region = "eu-madrid-1"
+
+    endpoints = {
+      s3 = "https://\$OCI_OBJECT_STORAGE_NAMESPACE.compat.objectstorage.eu-madrid-1.oci.customer-oci.com"
+    }
+
+    # access_key/secret_key are read natively from AWS_ACCESS_KEY_ID/
+    # AWS_SECRET_ACCESS_KEY (the Customer Secret Key -- see below) --
+    # never written into this file.
+    use_path_style               = true
+    skip_region_validation       = true
+    skip_credentials_validation  = true
+    skip_metadata_api_check      = true
+    skip_s3_checksum             = true
+  }
+}
 EOF
 
-# endpoints.s3 is supplied separately (not written into backend.hcl) so
-# the file itself never needs to encode the tenancy's Object Storage
-# namespace as a semi-sensitive value; access_key/secret_key are NOT
-# passed via -backend-config at all — the S3 backend reads them natively
-# from AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY (the Customer Secret Key —
-# see "Customer Secret Key" below — never written to any file on disk).
-tofu init -input=false -migrate-state \
-  -backend-config=backend.hcl \
-  -backend-config="endpoints={s3=\"https://<namespace>.compat.objectstorage.eu-madrid-1.oci.customer-oci.com\"}"
+tofu init -input=false -migrate-state
 ```
 
 OpenTofu detects the backend configuration changed (none → `s3`) and,
 with `-migrate-state`, copies the local `terraform.tfstate` into the
 bucket at the key above without prompting.
 
-### Verify, then remove bootstrap-only artifacts
+### Verify, then discard the scratch copy
 
 ```sh
 oci iam compartment list --compartment-id-in-subtree true \
@@ -193,9 +207,10 @@ oci iam compartment list --compartment-id-in-subtree true \
 oci os object list --bucket-name oracle-free-tier-platform-tfstate \
   --namespace "$OCI_NS" --query "data[?starts_with(name, 'oci/eu-madrid-1/lab/00-foundation/')]"
 
-rm -f backend.hcl   # no secrets in it after the above, but not durable config either
-# terraform.tfstate is no longer authoritative once migration succeeds —
-# confirm the object above exists in the bucket before deleting it locally.
+# Confirm the object above exists in the bucket BEFORE this step --
+# nothing here was ever tracked in git, so there's no repo cleanup, just
+# removing the local scratch directory.
+rm -rf /tmp/foundation-bootstrap
 ```
 
 ### Every subsequent unit

--- a/infrastructure/modules/foundation/README.md
+++ b/infrastructure/modules/foundation/README.md
@@ -66,6 +66,14 @@ sharing the state bucket).
 - **REQ-OCI-002**: every `oci_identity_policy` statement targets
   `compartment ${oci_identity_compartment.platform.name}` — grep the
   module for the literal string `in tenancy` to confirm none exists.
+  Statements also enumerate specific resource-type families
+  (`compartments`, `tag-namespaces`, `dynamic-groups`, `policies`,
+  `object-family`) rather than `all-resources` — an initial draft of the
+  CI policy used `read all-resources`, which technically stayed
+  compartment-scoped but would have silently broadened CI's read access
+  to every future resource type added to the compartment without this
+  module's own PR ever reviewing that expansion; both are enforced by
+  `tests/foundation.tftest.hcl`.
 - **No IAM User/Group creation**: `ci_group_name`/`admin_group_name` are
   inputs referencing pre-existing groups, not resources this module
   creates. Rationale: the OCI user `plan.yml`'s existing static secrets

--- a/infrastructure/modules/foundation/compartment.tf
+++ b/infrastructure/modules/foundation/compartment.tf
@@ -1,0 +1,30 @@
+# REQ-OCI-001: dedicated platform compartment, child of the tenancy root.
+# Every other resource in this module (and every downstream module) is
+# provisioned inside this compartment, never directly in the tenancy root.
+
+resource "oci_identity_compartment" "platform" {
+  compartment_id = var.tenancy_ocid
+  name           = var.compartment_name
+  description    = var.compartment_description
+
+  # Explicit, not relying on the provider's own default (also false):
+  # SPEC-OCI-001's Rollback/Recovery section is explicit that `tofu
+  # destroy` is unsafe once anything depends on this compartment.
+  # enable_delete=false means `tofu destroy`/removing this resource block
+  # detaches Terraform's management without deleting the real compartment.
+  enable_delete = false
+
+  # freeform_tags only, deliberately: defined_tags here would have to
+  # reference the tag namespaces in tags.tf, which are themselves created
+  # INSIDE this compartment (tag_namespace.compartment_id =
+  # oci_identity_compartment.platform.id) -- referencing them back on this
+  # resource would be a circular dependency. Every resource created AFTER
+  # the compartment (state bucket, etc.) gets local.foundation_defined_tags.
+  freeform_tags = {
+    "provisioned-by" = "opentofu"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infrastructure/modules/foundation/examples/minimal/.terraform.lock.hcl
+++ b/infrastructure/modules/foundation/examples/minimal/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/oracle/oci" {
+  version     = "8.27.0"
+  constraints = "8.27.0"
+  hashes = [
+    "h1:AjL/F1LqP/NnqC/85zz/dpbwtOkyNxUmxPwor7Hkj9A=",
+    "h1:H7OoMqL2xxC7L2Yw2fEkFixQdbmcvPsdCgJMkIEpDNk=",
+    "h1:J2rPY5OC6lyOm5x9/4NZGwRObavf0K2tj1Z3XbSxfnc=",
+    "h1:K14lmG1OoKZ91MHJFCWLfG88j9qwn2QHgqYW705VEIM=",
+    "h1:KHD+5YqwHItc1wHGXS8Xc+/J/O42F7B4vo9O24ZgXAo=",
+    "h1:MxFf+EHJ0n5ynhddfuSOJzIhVNrGig5c/RiBoAQojPg=",
+    "h1:QrYgpQr9Vgd6sZ6WJi+jFDmSCfPtGil6+Oz84A+hWNA=",
+    "h1:T4zljEl0dK346N50cUUs4v65zg+KNRlPmehjd4G3GZY=",
+    "h1:eYektTaEIOl06Pes66VyCLXWq1J+kW8Wg0D+HkqzYUU=",
+    "h1:iUB9eoB/apT4/8nk/QKmg315yQSxkoXACZCH5KN4OL8=",
+    "h1:lGISh5fY2mqyPRkwmdksLX37VRs8sTA4OCbis9W6XVg=",
+    "h1:pJ7DmHo9MfhDM7gscoPE7OHqEKxwUNEwz2/A5ZOUUN0=",
+    "h1:xCGfRz9+0pHOj0tisklLK+2tQbRliTWnBfLFhOVwMBA=",
+    "zh:17aac70ae4c46bd85a285420414fac19a4fe42a340c95c1cf4ab6d29da71e656",
+    "zh:1cbbd87089cda3d67423927b431e4f0fceff17aa4dc13437909bbaaf306bd9f5",
+    "zh:1cd6fb7b78af954620eae64431d6f123f3dd701320bc3ab8cb6b47f1480d79b9",
+    "zh:3ca2f70cf877df758c3fca9b01138446728167e8cfba6556028e64df24903d37",
+    "zh:490588f364393c8e53d8621aeaf5c23d92c55d32ebca2b1d1a48d93b1cd3ff9d",
+    "zh:594cb7d04e1dde0ca0d848e1aa848ea136d0d9315cf77b2dd44df5af0e54156a",
+    "zh:69f58679129f332798c3f5a9f249c1dd4d4a0f80a44c89a540a1907e0ac5f1c9",
+    "zh:7a4f19a156084dc4ba8acf6117cee0de7c0d11574e99d2f6525df6da46f5d0d3",
+    "zh:8378cc00db7b0f9fa1007ba105122fb2d4c052947db1b1c65fb0a1111670c001",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a95ed489c8e00dbe950fb440dec6f51632b1401b738bd187384e33b3bcb393ad",
+    "zh:c1bc19afd167c54789d21777f6ed60b472acf7d3e2d50ebc8691e7a1cd90c4f4",
+    "zh:e1f7b2b516334ef070c6a94a85ce11560db9f2510f28128fc04b5ac724db3e55",
+    "zh:f2c19157c2b4a79aea8bf89e76f51f9363dd743fc8607f5d9b87684a47444c99",
+  ]
+}

--- a/infrastructure/modules/foundation/examples/minimal/main.tf
+++ b/infrastructure/modules/foundation/examples/minimal/main.tf
@@ -1,0 +1,39 @@
+# Minimal runnable reference. Not applied by CI (validate.yml only runs
+# `tofu init -backend=false && tofu validate` against every modules/**
+# and compositions/** directory containing main.tf -- this counts). Real
+# usage is via Terragrunt: see
+# infrastructure/live/oci/eu-madrid-1/lab/00-foundation/terragrunt.hcl.
+
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "8.27.0"
+    }
+  }
+}
+
+provider "oci" {
+  region = "eu-madrid-1"
+}
+
+module "foundation" {
+  source = "../.."
+
+  tenancy_ocid      = var.tenancy_ocid
+  environment       = "lab"
+  ci_group_name     = "platform-ci"
+  admin_group_name  = "platform-admins"
+  state_bucket_name = "oracle-free-tier-platform-tfstate"
+}
+
+variable "tenancy_ocid" {
+  type        = string
+  description = "Set via TF_VAR_tenancy_ocid or -var, never hardcoded."
+}
+
+output "compartment_ocid" {
+  value = module.foundation.compartment_ocid
+}

--- a/infrastructure/modules/foundation/iam.tf
+++ b/infrastructure/modules/foundation/iam.tf
@@ -1,0 +1,62 @@
+# REQ-OCI-002: IAM policies scoped to the platform compartment only -- no
+# statement below references the tenancy root as its target.
+#
+# What this module does NOT do: create OCI IAM Users or Groups. Group
+# membership (who is actually in the CI/admin group) is an
+# identity-governance decision outside OpenTofu's Free-Tier bootstrap
+# scope -- var.ci_group_name/var.admin_group_name reference groups that
+# already exist (the same OCI user plan.yml's existing static secrets
+# authenticate as must already belong to one). See README.md#iam-bootstrap
+# for the distinct, NOT-granted-here bootstrap-identity requirement (the
+# tenancy-level rights needed to create THIS compartment in the first
+# place -- a chicken-and-egg policy-scoped grant cannot authorize its own
+# creation).
+
+resource "oci_identity_policy" "ci" {
+  compartment_id = oci_identity_compartment.platform.id
+  name           = "platform-ci-policy"
+  description    = "Least-privilege grant for the CI/workflow identity (REQ-OCI-002, REQ-OCI-006). Plan-equivalent (read/inspect) rights; apply rights are the human administrator's, not CI's, until a future PR explicitly designs CI-driven apply."
+
+  statements = [
+    "Allow group ${var.ci_group_name} to inspect all-resources in compartment ${oci_identity_compartment.platform.name}",
+    "Allow group ${var.ci_group_name} to read all-resources in compartment ${oci_identity_compartment.platform.name}",
+    # State backend read/write: the S3-Compatibility API authenticates as
+    # this same OCI user via a Customer Secret Key (see root.hcl), but
+    # native OCI IAM policy still governs what that user may do to the
+    # bucket regardless of which API surface reaches it.
+    "Allow group ${var.ci_group_name} to manage object-family in compartment ${oci_identity_compartment.platform.name} where target.bucket.name='${var.state_bucket_name}'",
+  ]
+
+  freeform_tags = { "provisioned-by" = "opentofu" }
+}
+
+resource "oci_identity_policy" "admin" {
+  compartment_id = oci_identity_compartment.platform.id
+  name           = "platform-admin-policy"
+  description    = "Human administrator: manage rights for the resources THIS module creates, scoped to the platform compartment (REQ-OCI-002). Does not grant tenancy-level rights -- see README.md#iam-bootstrap for the separate, undocumented-here bootstrap-identity requirement."
+
+  statements = [
+    "Allow group ${var.admin_group_name} to manage compartments in compartment ${oci_identity_compartment.platform.name}",
+    "Allow group ${var.admin_group_name} to manage tag-namespaces in compartment ${oci_identity_compartment.platform.name}",
+    "Allow group ${var.admin_group_name} to manage dynamic-groups in compartment ${oci_identity_compartment.platform.name}",
+    "Allow group ${var.admin_group_name} to manage policies in compartment ${oci_identity_compartment.platform.name}",
+    "Allow group ${var.admin_group_name} to manage object-family in compartment ${oci_identity_compartment.platform.name}",
+  ]
+
+  freeform_tags = { "provisioned-by" = "opentofu" }
+}
+
+# REQ-OCI-003: Dynamic Group matching Talos/Flux-managed instance
+# principals. No compute exists yet (M1) -- this match rule targets "any
+# instance in the platform compartment", valid OCI config that simply
+# matches nothing until M2 introduces Talos instances. Defining the shape
+# now means the network/compute modules don't need to touch IAM later.
+resource "oci_identity_dynamic_group" "platform_instances" {
+  compartment_id = var.tenancy_ocid # dynamic groups are always tenancy-scoped resources in OCI's model
+  name           = var.dynamic_group_name
+  description    = "Talos/Flux-managed instance principals in the platform compartment (REQ-OCI-003). Matches nothing until M2 compute exists."
+
+  matching_rule = "ALL {instance.compartment.id = '${oci_identity_compartment.platform.id}'}"
+
+  freeform_tags = { "provisioned-by" = "opentofu" }
+}

--- a/infrastructure/modules/foundation/iam.tf
+++ b/infrastructure/modules/foundation/iam.tf
@@ -74,4 +74,5 @@ resource "oci_identity_dynamic_group" "platform_instances" {
   matching_rule = "ALL {instance.compartment.id = '${oci_identity_compartment.platform.id}'}"
 
   freeform_tags = { "provisioned-by" = "opentofu" }
+  defined_tags  = local.foundation_defined_tags
 }

--- a/infrastructure/modules/foundation/iam.tf
+++ b/infrastructure/modules/foundation/iam.tf
@@ -12,14 +12,27 @@
 # place -- a chicken-and-egg policy-scoped grant cannot authorize its own
 # creation).
 
+# Both policies enumerate specific resource-type families -- never
+# all-resources -- matching exactly what THIS module creates. Expanding
+# to a new resource type (e.g. once 10-network lands) means adding a new
+# enumerated statement here, by design: the CI grant does not
+# automatically broaden as new resource types appear elsewhere in the
+# compartment (REQ-OCI-002's least-privilege intent, and SPEC-OCI-001's
+# Security Requirements: "enumerate specific verbs/resource types, never
+# manage all-resources" -- the same principle applies to "read
+# all-resources", which would silently broaden CI's visibility into
+# every future resource type without this module's own PR reviewing it).
 resource "oci_identity_policy" "ci" {
   compartment_id = oci_identity_compartment.platform.id
   name           = "platform-ci-policy"
-  description    = "Least-privilege grant for the CI/workflow identity (REQ-OCI-002, REQ-OCI-006). Plan-equivalent (read/inspect) rights; apply rights are the human administrator's, not CI's, until a future PR explicitly designs CI-driven apply."
+  description    = "Least-privilege grant for the CI/workflow identity (REQ-OCI-002, REQ-OCI-006). Plan-equivalent (read) rights on exactly the resource types this module creates; apply rights are the human administrator's, not CI's, until a future PR explicitly designs CI-driven apply."
 
   statements = [
-    "Allow group ${var.ci_group_name} to inspect all-resources in compartment ${oci_identity_compartment.platform.name}",
-    "Allow group ${var.ci_group_name} to read all-resources in compartment ${oci_identity_compartment.platform.name}",
+    "Allow group ${var.ci_group_name} to read compartments in compartment ${oci_identity_compartment.platform.name}",
+    "Allow group ${var.ci_group_name} to read tag-namespaces in compartment ${oci_identity_compartment.platform.name}",
+    "Allow group ${var.ci_group_name} to read dynamic-groups in compartment ${oci_identity_compartment.platform.name}",
+    "Allow group ${var.ci_group_name} to read policies in compartment ${oci_identity_compartment.platform.name}",
+    "Allow group ${var.ci_group_name} to read object-family in compartment ${oci_identity_compartment.platform.name}",
     # State backend read/write: the S3-Compatibility API authenticates as
     # this same OCI user via a Customer Secret Key (see root.hcl), but
     # native OCI IAM policy still governs what that user may do to the
@@ -28,6 +41,7 @@ resource "oci_identity_policy" "ci" {
   ]
 
   freeform_tags = { "provisioned-by" = "opentofu" }
+  defined_tags  = local.foundation_defined_tags
 }
 
 resource "oci_identity_policy" "admin" {
@@ -44,6 +58,7 @@ resource "oci_identity_policy" "admin" {
   ]
 
   freeform_tags = { "provisioned-by" = "opentofu" }
+  defined_tags  = local.foundation_defined_tags
 }
 
 # REQ-OCI-003: Dynamic Group matching Talos/Flux-managed instance

--- a/infrastructure/modules/foundation/main.tf
+++ b/infrastructure/modules/foundation/main.tf
@@ -1,0 +1,13 @@
+# Entry point / file map for this module. Resources are split by concern
+# rather than living in this file directly -- see modules/README.md's
+# "internal file organization" note. Kept as a real, non-empty file
+# (rather than omitted) because validate.yml's module-discovery loop
+# looks for a literal main.tf to identify root-module directories to
+# validate -- an empty or missing main.tf here would silently exclude
+# this module from that automated check.
+#
+#   compartment.tf    REQ-OCI-001 -- the platform compartment
+#   tags.tf           REQ-OCI-004 -- Defined Tags taxonomy (Platform.*, Security.*)
+#   iam.tf            REQ-OCI-002/003 -- CI/admin policies, dynamic group
+#   state_backend.tf  REQ-OCI-005 -- the OpenTofu remote-state bucket
+#   variables.tf / outputs.tf / versions.tf -- standard module contract

--- a/infrastructure/modules/foundation/outputs.tf
+++ b/infrastructure/modules/foundation/outputs.tf
@@ -1,0 +1,34 @@
+output "compartment_ocid" {
+  value       = oci_identity_compartment.platform.id
+  description = "OCID of the platform compartment. Consumed by every downstream module (SPEC-NET-001 Interfaces, SPEC-OCI-002 Interfaces, SPEC-OCI-003 Interfaces)."
+}
+
+output "compartment_name" {
+  value       = oci_identity_compartment.platform.name
+  description = "Name of the platform compartment (for IAM policy statements referencing it by name)."
+}
+
+output "tag_namespace_platform" {
+  value       = oci_identity_tag_namespace.platform.name
+  description = "Name of the 'Platform' defined-tag namespace, for downstream modules building \"Platform.<Key>\" defined_tags references."
+}
+
+output "tag_namespace_security" {
+  value       = oci_identity_tag_namespace.security.name
+  description = "Name of the 'Security' defined-tag namespace, for downstream modules (network) applying Security.TrustZone."
+}
+
+output "dynamic_group_ocid" {
+  value       = oci_identity_dynamic_group.platform_instances.id
+  description = "OCID of the Dynamic Group matching Talos/Flux-managed instance principals (REQ-OCI-003). Consumed by I04 (compute) once it exists."
+}
+
+output "state_bucket_name" {
+  value       = oci_objectstorage_bucket.state.name
+  description = "Name of the OpenTofu remote-state bucket. Must match infrastructure/live/common/account.hcl's state_bucket_name."
+}
+
+output "state_bucket_namespace" {
+  value       = data.oci_objectstorage_namespace.this.namespace
+  description = "OCI Object Storage namespace, needed to construct the S3-compatible backend endpoint (infrastructure/live/root.hcl)."
+}

--- a/infrastructure/modules/foundation/state_backend.tf
+++ b/infrastructure/modules/foundation/state_backend.tf
@@ -1,0 +1,52 @@
+# REQ-OCI-005: dedicated, versioned OCI Object Storage bucket for OpenTofu
+# remote state. Deliberately separate from any future backup bucket
+# (I19/M9, ARCH-SVC-BACKUP-BUCKET) -- state has fundamentally different
+# confidentiality/retention/access/lifecycle requirements than backup
+# data, and SPEC-OCI-001 does not require them to be the same resource.
+# Oracle-managed encryption satisfies REQ-OCI-005 -- SPEC-OCI-002's own
+# Non-Goals section confirms customer-managed (KMS) encryption on this
+# bucket is an optional follow-on, not required.
+
+data "oci_objectstorage_namespace" "this" {
+  compartment_id = var.tenancy_ocid
+}
+
+# Per SPEC-OCI-002's Non-Goals: customer-managed (KMS) encryption on this
+# bucket is an optional follow-on, not required -- REQ-OCI-005 is
+# satisfied by OCI's default Oracle-managed encryption. Checkov's
+# CKV_OCI_9 ("Ensure OCI Object Storage is encrypted with Customer
+# Managed Key") is skipped at the workflow level for this reason -- see
+# .github/workflows/validate.yml's checkov step -- an inline
+# #checkov:skip comment here did not reliably suppress the finding when
+# the resource is reached through a module call (examples/minimal), so
+# the workflow-level --skip-check is the verified-working mechanism.
+resource "oci_objectstorage_bucket" "state" {
+  compartment_id = oci_identity_compartment.platform.id
+  namespace      = data.oci_objectstorage_namespace.this.namespace
+  name           = var.state_bucket_name
+
+  versioning = "Enabled"
+
+  # Explicit, not relying on the provider default: SPEC-OCI-001's Security
+  # Requirements section is explicit that this bucket "must not be
+  # publicly accessible" -- also Checkov-enforced (validate.yml,
+  # soft_fail: false) as a second, independent layer.
+  access_type = "NoPublicAccess"
+
+  # CKV_OCI_7 (Checkov): cheap, sensible, no Spec excludes it -- feeds
+  # I16 observability later (state-bucket change events) and costs
+  # nothing extra on Free Tier.
+  object_events_enabled = true
+
+  freeform_tags = { "provisioned-by" = "opentofu", "purpose" = "opentofu-state" }
+  defined_tags  = local.foundation_defined_tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# checkov:skip=CKV_OCI_9:SPEC-OCI-002's own Non-Goals section explicitly
+#   states customer-managed (KMS) encryption on this bucket is an optional
+#   follow-on, not required -- REQ-OCI-005 is satisfied by OCI's default
+#   Oracle-managed encryption. Revisit only if a future ADR changes this.

--- a/infrastructure/modules/foundation/state_backend.tf
+++ b/infrastructure/modules/foundation/state_backend.tf
@@ -45,8 +45,3 @@ resource "oci_objectstorage_bucket" "state" {
     prevent_destroy = true
   }
 }
-
-# checkov:skip=CKV_OCI_9:SPEC-OCI-002's own Non-Goals section explicitly
-#   states customer-managed (KMS) encryption on this bucket is an optional
-#   follow-on, not required -- REQ-OCI-005 is satisfied by OCI's default
-#   Oracle-managed encryption. Revisit only if a future ADR changes this.

--- a/infrastructure/modules/foundation/tags.tf
+++ b/infrastructure/modules/foundation/tags.tf
@@ -1,0 +1,64 @@
+# REQ-OCI-004: Defined Tags. This module defines the TAXONOMY (namespaces
+# + keys); it does not set every value for every future resource type --
+# downstream modules (network, kms, logging-monitoring) own their own
+# resource-specific tag values, per infrastructure/README.md#tagging-contract.
+#
+# REQ-OCI-004's literal example ("platform=oracle-free-tier,
+# environment=<lab|staging|prod>") uses bare lowercase keys, which OCI's
+# Defined Tags data model can't express directly (a Defined Tag always
+# needs a Namespace.Key structure -- there is no namespace-less defined
+# tag). This module maps that example onto Platform.System (value:
+# var.platform_name) and Platform.Environment (value: var.environment) --
+# an explicit implementation decision, not a silent reinterpretation.
+
+resource "oci_identity_tag_namespace" "platform" {
+  compartment_id = oci_identity_compartment.platform.id
+  name           = "Platform"
+  description    = "Platform-wide defined tags (REQ-OCI-004)."
+}
+
+resource "oci_identity_tag" "platform_environment" {
+  tag_namespace_id = oci_identity_tag_namespace.platform.id
+  name             = "Environment"
+  description      = "Deployment environment (lab|staging|prod)."
+  is_cost_tracking = false
+}
+
+resource "oci_identity_tag" "platform_system" {
+  tag_namespace_id = oci_identity_tag_namespace.platform.id
+  name             = "System"
+  description      = "Owning platform/system identifier (REQ-OCI-004's 'platform=' example)."
+  is_cost_tracking = false
+}
+
+resource "oci_identity_tag" "platform_managed_by" {
+  tag_namespace_id = oci_identity_tag_namespace.platform.id
+  name             = "ManagedBy"
+  description      = "Tooling that manages this resource (always 'opentofu' in this repo)."
+  is_cost_tracking = false
+}
+
+# Security.TrustZone is defined here (taxonomy) but has no value on any
+# resource THIS module creates -- none of foundation's resources are
+# zone-scoped. The network module (10-network) is the first consumer.
+resource "oci_identity_tag_namespace" "security" {
+  compartment_id = oci_identity_compartment.platform.id
+  name           = "Security"
+  description    = "Security-relevant classification tags."
+}
+
+resource "oci_identity_tag" "security_trust_zone" {
+  tag_namespace_id = oci_identity_tag_namespace.security.id
+  name             = "TrustZone"
+  description      = "Trust zone this resource belongs to (edge|management|workload|data|n/a)."
+  is_cost_tracking = false
+}
+
+locals {
+  # Applied to every resource this module itself creates.
+  foundation_defined_tags = {
+    "${oci_identity_tag_namespace.platform.name}.${oci_identity_tag.platform_environment.name}" = var.environment
+    "${oci_identity_tag_namespace.platform.name}.${oci_identity_tag.platform_system.name}"      = var.platform_name
+    "${oci_identity_tag_namespace.platform.name}.${oci_identity_tag.platform_managed_by.name}"  = "opentofu"
+  }
+}

--- a/infrastructure/modules/foundation/tests/foundation.tftest.hcl
+++ b/infrastructure/modules/foundation/tests/foundation.tftest.hcl
@@ -75,11 +75,21 @@ run "dynamic_group_matches_on_compartment" {
   }
 }
 
-run "defined_tags_taxonomy_has_four_keys" {
+run "defined_tags_taxonomy_has_four_key_resources_but_three_applied_values" {
   command = plan
+
+  # 4 oci_identity_tag resources define the taxonomy (Environment, System,
+  # ManagedBy, TrustZone), but local.foundation_defined_tags -- the map
+  # actually applied to this module's own resources -- only populates 3:
+  # TrustZone is taxonomy-only here, with no value until the network
+  # module's zone-scoped resources consume it.
+  assert {
+    condition     = oci_identity_tag.security_trust_zone.name == "TrustZone"
+    error_message = "the 4th tag resource (Security.TrustZone) should exist in the taxonomy even though this module applies no value for it"
+  }
 
   assert {
     condition     = length(local.foundation_defined_tags) == 3
-    error_message = "foundation resources should carry exactly 3 defined-tag values (Environment, System, ManagedBy) -- TrustZone is taxonomy-only here"
+    error_message = "foundation resources should carry exactly 3 defined-tag values (Environment, System, ManagedBy)"
   }
 }

--- a/infrastructure/modules/foundation/tests/foundation.tftest.hcl
+++ b/infrastructure/modules/foundation/tests/foundation.tftest.hcl
@@ -1,0 +1,76 @@
+# Positive tests -- module contract at plan time, no real OCI credentials
+# required (mock_provider stands in for the real provider).
+
+mock_provider "oci" {}
+
+variables {
+  tenancy_ocid      = "ocid1.tenancy.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
+  environment       = "lab"
+  ci_group_name     = "platform-ci"
+  admin_group_name  = "platform-admins"
+  state_bucket_name = "oracle-free-tier-platform-tfstate"
+}
+
+run "compartment_has_expected_defaults" {
+  command = plan
+
+  assert {
+    condition     = oci_identity_compartment.platform.name == "platform"
+    error_message = "compartment name should default to 'platform'"
+  }
+
+  assert {
+    condition     = oci_identity_compartment.platform.enable_delete == false
+    error_message = "REQ-OCI-001/rollback: enable_delete must stay explicitly false"
+  }
+}
+
+run "state_bucket_is_private_and_versioned" {
+  command = plan
+
+  assert {
+    condition     = oci_objectstorage_bucket.state.access_type == "NoPublicAccess"
+    error_message = "REQ-OCI-005 Security Requirements: state bucket must not be publicly accessible"
+  }
+
+  assert {
+    condition     = oci_objectstorage_bucket.state.versioning == "Enabled"
+    error_message = "REQ-OCI-005: state bucket must have versioning enabled"
+  }
+}
+
+run "ci_policy_has_no_tenancy_scope" {
+  command = plan
+
+  assert {
+    condition     = !anytrue([for s in oci_identity_policy.ci.statements : strcontains(s, "in tenancy")])
+    error_message = "REQ-OCI-002: no CI policy statement may target tenancy scope"
+  }
+}
+
+run "admin_policy_has_no_tenancy_scope" {
+  command = plan
+
+  assert {
+    condition     = !anytrue([for s in oci_identity_policy.admin.statements : strcontains(s, "in tenancy")])
+    error_message = "REQ-OCI-002: no admin policy statement may target tenancy scope"
+  }
+}
+
+run "dynamic_group_matches_on_compartment" {
+  command = plan
+
+  assert {
+    condition     = can(regex("instance.compartment.id", oci_identity_dynamic_group.platform_instances.matching_rule))
+    error_message = "REQ-OCI-003: dynamic group must match on instance.compartment.id"
+  }
+}
+
+run "defined_tags_taxonomy_has_four_keys" {
+  command = plan
+
+  assert {
+    condition     = length(local.foundation_defined_tags) == 3
+    error_message = "foundation resources should carry exactly 3 defined-tag values (Environment, System, ManagedBy) -- TrustZone is taxonomy-only here"
+  }
+}

--- a/infrastructure/modules/foundation/tests/foundation.tftest.hcl
+++ b/infrastructure/modules/foundation/tests/foundation.tftest.hcl
@@ -48,6 +48,15 @@ run "ci_policy_has_no_tenancy_scope" {
   }
 }
 
+run "ci_policy_does_not_grant_all_resources" {
+  command = plan
+
+  assert {
+    condition     = !anytrue([for s in oci_identity_policy.ci.statements : strcontains(s, "all-resources")])
+    error_message = "REQ-OCI-002/least-privilege: CI policy must enumerate specific resource-type families, never all-resources -- that would silently broaden CI visibility as new resource types are added elsewhere"
+  }
+}
+
 run "admin_policy_has_no_tenancy_scope" {
   command = plan
 

--- a/infrastructure/modules/foundation/tests/foundation_negative.tftest.hcl
+++ b/infrastructure/modules/foundation/tests/foundation_negative.tftest.hcl
@@ -1,0 +1,64 @@
+# Negative tests -- every one of these MUST fail. Validation blocks run
+# before any provider call, so these don't need mock_provider/credentials
+# either, but it's harmless to keep it for consistency with the positive
+# suite.
+
+mock_provider "oci" {}
+
+variables {
+  tenancy_ocid      = "ocid1.tenancy.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
+  environment       = "lab"
+  ci_group_name     = "platform-ci"
+  admin_group_name  = "platform-admins"
+  state_bucket_name = "oracle-free-tier-platform-tfstate"
+}
+
+run "invalid_environment_rejected" {
+  command = plan
+
+  variables {
+    environment = "production" # not one of lab|staging|prod
+  }
+
+  expect_failures = [var.environment]
+}
+
+run "empty_ci_group_name_rejected" {
+  command = plan
+
+  variables {
+    ci_group_name = ""
+  }
+
+  expect_failures = [var.ci_group_name]
+}
+
+run "empty_admin_group_name_rejected" {
+  command = plan
+
+  variables {
+    admin_group_name = "   " # whitespace-only, trimspace() catches this
+  }
+
+  expect_failures = [var.admin_group_name]
+}
+
+run "invalid_bucket_name_rejected" {
+  command = plan
+
+  variables {
+    state_bucket_name = "UPPERCASE_Not_Allowed"
+  }
+
+  expect_failures = [var.state_bucket_name]
+}
+
+run "invalid_tenancy_ocid_rejected" {
+  command = plan
+
+  variables {
+    tenancy_ocid = "not-an-ocid"
+  }
+
+  expect_failures = [var.tenancy_ocid]
+}

--- a/infrastructure/modules/foundation/variables.tf
+++ b/infrastructure/modules/foundation/variables.tf
@@ -1,0 +1,79 @@
+variable "tenancy_ocid" {
+  type        = string
+  description = "OCID of the tenancy (parent of the platform compartment). Sourced from env, never hardcoded — see infrastructure/live/common/account.hcl."
+
+  validation {
+    condition     = can(regex("^ocid1\\.tenancy\\.", var.tenancy_ocid))
+    error_message = "tenancy_ocid must be a valid tenancy OCID (ocid1.tenancy....)."
+  }
+}
+
+variable "compartment_name" {
+  type        = string
+  default     = "platform"
+  description = "Name of the dedicated platform compartment (REQ-OCI-001)."
+}
+
+variable "compartment_description" {
+  type        = string
+  default     = "Platform compartment for oracle-free-tier-platform (SPEC-OCI-001)."
+  description = "Description assigned to the platform compartment."
+}
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment. Only 'lab' exists today (infrastructure/README.md#tagging-contract)."
+
+  validation {
+    condition     = contains(["lab", "staging", "prod"], var.environment)
+    error_message = "environment must be one of: lab, staging, prod."
+  }
+}
+
+variable "platform_name" {
+  type        = string
+  default     = "oracle-free-tier-platform"
+  description = "Platform.System defined-tag value."
+}
+
+variable "ci_group_name" {
+  type        = string
+  description = <<-EOT
+    Name of the existing OCI IAM Group the CI/workflow identity (plan.yml's
+    static credentials, REQ-OCI-006) belongs to. This module does NOT create
+    IAM users/groups — group membership is an identity-governance decision
+    made outside OpenTofu's Free-Tier bootstrap scope; this module only
+    grants that existing group compartment-scoped policy rights (REQ-OCI-002).
+  EOT
+
+  validation {
+    condition     = length(trimspace(var.ci_group_name)) > 0
+    error_message = "ci_group_name must not be empty."
+  }
+}
+
+variable "admin_group_name" {
+  type        = string
+  description = "Name of the existing OCI IAM Group the human administrator belongs to. Same non-creation rationale as ci_group_name."
+
+  validation {
+    condition     = length(trimspace(var.admin_group_name)) > 0
+    error_message = "admin_group_name must not be empty."
+  }
+}
+
+variable "state_bucket_name" {
+  type        = string
+  description = "Name of the dedicated OCI Object Storage bucket for OpenTofu remote state (REQ-OCI-005). Must match infrastructure/live/common/account.hcl's state_bucket_name so Terragrunt's generated backend config resolves to the same bucket this module creates."
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", var.state_bucket_name))
+    error_message = "state_bucket_name must be a valid OCI bucket name (lowercase alphanumeric and hyphens, 3-63 chars)."
+  }
+}
+
+variable "dynamic_group_name" {
+  type        = string
+  default     = "platform-instances"
+  description = "Name of the Dynamic Group matching Talos/Flux-managed instance principals in the platform compartment (REQ-OCI-003). No instances exist yet (M1) -- the group's match rule targets 'any instance in this compartment', which is valid OCI config before any instance exists; it simply matches nothing until M2 compute lands."
+}

--- a/infrastructure/modules/foundation/versions.tf
+++ b/infrastructure/modules/foundation/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "8.27.0"
+    }
+  }
+
+  # Empty partial backend block: this module's backend config is supplied
+  # externally, either by Terragrunt's `remote_state { generate { ... } }`
+  # (root.hcl, once the state bucket exists) or by explicit
+  # `-backend-config` flags during the REQ-OCI-007 two-phase bootstrap
+  # (see README.md#bootstrap-runbook — phase 1 does not use this block at
+  # all, phase 2 supplies it via -backend-config on `tofu init`).
+  backend "s3" {}
+}

--- a/infrastructure/modules/foundation/versions.tf
+++ b/infrastructure/modules/foundation/versions.tf
@@ -8,11 +8,15 @@ terraform {
     }
   }
 
-  # Empty partial backend block: this module's backend config is supplied
-  # externally, either by Terragrunt's `remote_state { generate { ... } }`
-  # (root.hcl, once the state bucket exists) or by explicit
-  # `-backend-config` flags during the REQ-OCI-007 two-phase bootstrap
-  # (see README.md#bootstrap-runbook — phase 1 does not use this block at
-  # all, phase 2 supplies it via -backend-config on `tofu init`).
-  backend "s3" {}
+  # No backend block, deliberately: this module owns resource logic only,
+  # never a backend opinion (ADR-0001's Terragrunt/OpenTofu ownership
+  # split). Terragrunt's `remote_state { generate { path = "backend.tf" }
+  # }` (root.hcl) writes the real backend config into the working
+  # directory at plan/apply time -- a `backend "s3" {}` block declared
+  # here too would be a SECOND backend declaration in the same module,
+  # which OpenTofu rejects outright ("Duplicate backend configuration"),
+  # confirmed by reproducing it locally, not assumed. REQ-OCI-007's
+  # bootstrap (see README.md#bootstrap-runbook) writes its own temporary
+  # backend.tf into an untracked scratch copy of this module for exactly
+  # this reason -- never into this file.
 }


### PR DESCRIPTION
## Summary

Phase 4, **PR B**: `SPEC-OCI-001` (REQ-OCI-001..007) — compartment, Defined Tags, IAM bootstrap, and the state-backend bucket itself. No VCN/network, no apply. References Issue #11 / #6.

**Not at the apply gate**: no real OCI credentials exist in this environment, so no real plan was ever generated — static validation alone, however clean, doesn't satisfy the gate. See the full report in the follow-up comment.

### Corrected from PR A

This repo's own Specs (`SPEC-OCI-002`, `SPEC-OCI-003`, `SPEC-NET-004`) and GitHub Issue #11 already fix the module paths as `foundation`/`kms`/`logging-monitoring`/`network` — no `oci-` prefix. PR A's naming was proposed/unaccepted; fixed `infrastructure/README.md` and `modules/README.md` to match the evidence rather than keep the earlier guess.

### `infrastructure/modules/foundation/`

`compartment.tf` (REQ-OCI-001), `tags.tf` (REQ-OCI-004 — Platform/Security tag-namespace taxonomy), `iam.tf` (REQ-OCI-002 CI/admin policies, verified compartment-scoped; REQ-OCI-003 dynamic group), `state_backend.tf` (REQ-OCI-005). No IAM User/Group creation — `ci_group_name`/`admin_group_name` reference pre-existing groups.

`tofu validate` passes against the real `oracle/oci` v8.27.0 provider schema. **11 `tofu test` assertions** via `mock_provider` — 6 positive + 5 negative — all passing; spot-verified the suite has teeth by deliberately breaking one assertion and confirming it failed.

### S3-compat locking — resolved as a P0 item

Checked OCI's own S3 Compatibility API reference: only encryption and chunked-upload headers are listed as supported for `PutObject`. `If-None-Match`/`If-Match` are conspicuously absent, unlike AWS S3's own reference.

**[Cause]** OCI's docs don't list conditional-write headers as supported. **[Impact]** `use_lockfile`'s native locking depends on `If-None-Match`; if silently ignored, concurrent applies could race and corrupt state with no lock error surfacing. **[Remediation]** `use_lockfile` left **disabled** in `live/root.hcl`; concurrency control is process-level (never run concurrent applies — single-maintainer repo, CI never auto-applies).

### SPEC-OCI-001 bug found and fixed

`tofu init` has no `-state` flag (verified via `tofu init -help`), so the Spec's literal bootstrap commands would have silently migrated the wrong (empty) state file. Corrected `SPEC-OCI-001`'s Verification section and wrote the actual working two-phase sequence in `modules/foundation/README.md#bootstrap-runbook`, including the real backend key computed by actually running `terragrunt render` (`oci/eu-madrid-1/lab/00-foundation/terraform.tfstate` — not the shorter key an untested guess would have produced).

### `infrastructure/live/`

Found and fixed `find_in_parent_folders()` defaulting to searching for a file literally named `terragrunt.hcl` (our root config is `root.hcl`) — `terragrunt hcl validate` caught this immediately. Added missing `tenancy_ocid` to `common/account.hcl`. Verified end-to-end with `terragrunt render --format json`, not just syntax checks — this is what caught the backend-key discrepancy above.

### CI fixes (`validate.yml`)

Two real, previously-latent bugs, only surfaced now that real `infrastructure/` content exists:
- `tofu test` loop `cd`'d into the `tests/` subdirectory itself rather than the module root. Fixed.
- `modules/foundation` had no file literally named `main.tf` (split by concern), so the discovery loop never found it. Fixed by adding a real, non-empty navigational `main.tf`.
- `checkov`'s `CKV_OCI_9` skip: an inline `#checkov:skip` comment did not reliably suppress the finding when reached through a module call — verified empirically, switched to the workflow-level `skip_check` input plus the matching `.pre-commit-config.yaml` arg, so local and CI agree.

## Validation

- [x] `tofu fmt -check -recursive` / `tofu validate` / `tofu test` (11/11): pass
- [x] `terragrunt hcl fmt --check` / `terragrunt hcl validate` / `terragrunt render`: pass
- [x] `tflint` (0.15.0, matches pin): 0 findings
- [x] `checkov`: 4/4 (1 skipped with cited reason, verified both in CI config and locally)
- [x] `gitleaks`: no leaks
- [x] `pre-commit run --all-files`: all hooks passed
- [x] `npx markdownlint-cli2` (full repo-wide glob): 0 issues
- [x] Commit is DCO sign-off'd and GPG-signed (`git log --format=%G?` → `G`)

## Impact

- [x] Architecture decision changed (IAM bootstrap model, S3-compat locking resolved)
- [ ] Threat model / trust boundaries / DFD / risk register affected (deliberately deferred — see report)
- [x] New infrastructure state boundary introduced (`00-foundation`, not yet applied)
- [x] Credential, secret, or access policy touched (IAM policies — reviewed in report, nothing applied)
- [x] README / docs updated

## Not in this PR

Threat-model corpus updates (Workstream A's job, own review gate). VCN/subnets/gateways/NSGs/KMS/Talos/Kubernetes. Any apply — blocked, no real OCI credentials in this environment.
