### PR TITLE
fix(foundation): defer Dynamic Group creation until M2 compute exists

### DIFF
--- a/infrastructure/modules/foundation/README.md
+++ b/infrastructure/modules/foundation/README.md
@@ -26,6 +26,7 @@ and one lifecycle (essentially create-once).
 | `admin_group_name` | string | yes | non-empty |
 | `state_bucket_name` | string | yes | valid OCI bucket name pattern |
 | `dynamic_group_name` | string | no (default `"platform-instances"`) | — |
+| `create_dynamic_group` | bool | no (default `false`) | — |
 
 `ci_group_name`/`admin_group_name` reference **existing** OCI IAM Groups —
 this module does not create IAM Users or Groups (see "Security invariants"
@@ -38,7 +39,7 @@ below for why).
 | `compartment_ocid` | every downstream module (`SPEC-NET-001`, `SPEC-OCI-002`, `SPEC-OCI-003` Interfaces sections) |
 | `compartment_name` | downstream IAM policy statements referencing the compartment by name |
 | `tag_namespace_platform` / `tag_namespace_security` | downstream modules building `"<Namespace>.<Key>"` `defined_tags` references |
-| `dynamic_group_ocid` | I04 (compute), once it exists |
+| `dynamic_group_ocid` | I04 (compute), once it exists; `null` while `create_dynamic_group` is `false` (default) |
 | `state_bucket_name` / `state_bucket_namespace` | `infrastructure/live/root.hcl`'s backend config (must match `common/account.hcl`) |
 
 ## Resource ownership
@@ -46,7 +47,8 @@ below for why).
 `oci_identity_compartment` (1), `oci_identity_tag_namespace` (2:
 Platform, Security), `oci_identity_tag` (4: Platform.Environment,
 Platform.System, Platform.ManagedBy, Security.TrustZone),
-`oci_identity_policy` (2: CI, admin), `oci_identity_dynamic_group` (1),
+`oci_identity_policy` (2: CI, admin), `oci_identity_dynamic_group` (0 or
+1, gated by `var.create_dynamic_group` — see Security invariants),
 `oci_objectstorage_bucket` (1: state), `data.oci_objectstorage_namespace`
 (1, read-only).
 

--- a/infrastructure/modules/foundation/iam.tf
+++ b/infrastructure/modules/foundation/iam.tf
@@ -62,11 +62,15 @@ resource "oci_identity_policy" "admin" {
 }
 
 # REQ-OCI-003: Dynamic Group matching Talos/Flux-managed instance
-# principals. No compute exists yet (M1) -- this match rule targets "any
-# instance in the platform compartment", valid OCI config that simply
-# matches nothing until M2 introduces Talos instances. Defining the shape
-# now means the network/compute modules don't need to touch IAM later.
+# principals. Deferred by default (var.create_dynamic_group = false): no
+# compute exists yet (M1), so the match rule below would target "any
+# instance in the platform compartment" and match literally nothing --
+# valid OCI config, but dead IAM machinery with no principal to review it
+# against until M2 introduces Talos instances. Set create_dynamic_group =
+# true once M2 is imminent instead of deploying this ahead of need.
 resource "oci_identity_dynamic_group" "platform_instances" {
+  count = var.create_dynamic_group ? 1 : 0
+
   compartment_id = var.tenancy_ocid # dynamic groups are always tenancy-scoped resources in OCI's model
   name           = var.dynamic_group_name
   description    = "Talos/Flux-managed instance principals in the platform compartment (REQ-OCI-003). Matches nothing until M2 compute exists."

--- a/infrastructure/modules/foundation/outputs.tf
+++ b/infrastructure/modules/foundation/outputs.tf
@@ -19,8 +19,8 @@ output "tag_namespace_security" {
 }
 
 output "dynamic_group_ocid" {
-  value       = oci_identity_dynamic_group.platform_instances.id
-  description = "OCID of the Dynamic Group matching Talos/Flux-managed instance principals (REQ-OCI-003). Consumed by I04 (compute) once it exists."
+  value       = try(oci_identity_dynamic_group.platform_instances[0].id, null)
+  description = "OCID of the Dynamic Group matching Talos/Flux-managed instance principals (REQ-OCI-003), or null while var.create_dynamic_group is false. Consumed by I04 (compute) once it exists."
 }
 
 output "state_bucket_name" {

--- a/infrastructure/modules/foundation/tests/foundation.tftest.hcl
+++ b/infrastructure/modules/foundation/tests/foundation.tftest.hcl
@@ -66,12 +66,25 @@ run "admin_policy_has_no_tenancy_scope" {
   }
 }
 
-run "dynamic_group_matches_on_compartment" {
+run "dynamic_group_deferred_by_default" {
   command = plan
 
   assert {
-    condition     = can(regex("instance.compartment.id", oci_identity_dynamic_group.platform_instances.matching_rule))
-    error_message = "REQ-OCI-003: dynamic group must match on instance.compartment.id"
+    condition     = length(oci_identity_dynamic_group.platform_instances) == 0
+    error_message = "REQ-OCI-003's dynamic group must be deferred (create_dynamic_group defaults to false) until M2 compute exists to match -- see variables.tf"
+  }
+}
+
+run "dynamic_group_matches_on_compartment_when_enabled" {
+  command = plan
+
+  variables {
+    create_dynamic_group = true
+  }
+
+  assert {
+    condition     = can(regex("instance.compartment.id", oci_identity_dynamic_group.platform_instances[0].matching_rule))
+    error_message = "REQ-OCI-003: dynamic group must match on instance.compartment.id when created"
   }
 }
 

--- a/infrastructure/modules/foundation/variables.tf
+++ b/infrastructure/modules/foundation/variables.tf
@@ -77,3 +77,9 @@ variable "dynamic_group_name" {
   default     = "platform-instances"
   description = "Name of the Dynamic Group matching Talos/Flux-managed instance principals in the platform compartment (REQ-OCI-003). No instances exist yet (M1) -- the group's match rule targets 'any instance in this compartment', which is valid OCI config before any instance exists; it simply matches nothing until M2 compute lands."
 }
+
+variable "create_dynamic_group" {
+  type        = bool
+  default     = false
+  description = "Whether to create the Dynamic Group now. Defaults to false: REQ-OCI-003 requires the group exist before Talos/Flux instance principals need it, not before any instance exists -- until M2 compute lands, the match rule matches nothing, so creating it at 00-foundation time would deploy dead IAM machinery with no verifiable principal to review it against. Set true once M2 is imminent."
+}


### PR DESCRIPTION
## Why

Preparing `00-foundation` for its first real `tofu plan`/`apply` against
the live OCI tenancy surfaced a re-evaluation question (not previously
asked in PR B): what concretely matches `oci_identity_dynamic_group.platform_instances`
today?

Answer: **nothing**. No Talos/Flux compute exists until M2. REQ-OCI-003
requires the group exist before instance principals need it, not before
any instance exists. Deploying it now would create real IAM machinery
with no verifiable principal to review it against.

## Change

- `create_dynamic_group` (bool, default `false`) gates the resource via
  `count`.
- `dynamic_group_ocid` output returns `null` while deferred.
- Tests split into `dynamic_group_deferred_by_default` (new) and
  `dynamic_group_matches_on_compartment_when_enabled` (override,
  `create_dynamic_group = true`).
- README input/output tables and resource-ownership count updated.

Set `create_dynamic_group = true` once M2 is imminent — no other change
needed.

## Validation

- `tofu fmt -check`, `tofu validate`: pass
- `tofu test`: 13/13 pass (was 12, +1 for the deferred-by-default case)
- `tflint`: 0 issues
- `checkov` (`--skip-check CKV_OCI_9`, unchanged from PR B): 4/4 pass
- `terragrunt hcl fmt --check` / `hcl validate`: pass
- `gitleaks`: no leaks

No scope beyond this one variable/resource/test/doc change — no VCN,
compute, or other `00-foundation` behavior touched.