### PR TITLE
fix(foundation): defer CI/admin IAM policies until real principals exist

### DIFF
--- a/docs/specs/SPEC-OCI-001.md
+++ b/docs/specs/SPEC-OCI-001.md
@@ -33,6 +33,22 @@ between plan and apply.
   written — tracked in `docs/00-overview/roadmap.md` under I02).
 - OCI OIDC federation for CI (EPIC-OCI-04 — static keys are in scope for
   this Spec; OIDC is a follow-on).
+- Steady-state least-privilege CI/admin IAM policies (REQ-OCI-002):
+  deferred until the principals they'd bind to actually exist — a
+  federated CI identity (GitHub OIDC, EPIC-OCI-04) and/or a dedicated
+  human admin group distinct from the tenancy's built-in `Administrators`
+  group. **Architecture gap, tracked here until EPIC-OCI-04 and the
+  Identity/Governance threat-model domain give it a permanent home**:
+  this Spec's module does not grant the bootstrap principal (whichever
+  existing `Administrators` member runs the first apply) any additional
+  policy of its own — that principal's authority is an external
+  prerequisite for creating this module's resources, not something the
+  module grants to itself. Binding a real least-privilege policy to
+  `Administrators` today would be decorative: it adds no permission
+  beyond that group's existing tenancy-wide grant (see the tenancy's
+  built-in Tenant Admin Policy, untouched by this Spec) while implying a
+  separation of duties that does not exist until distinct CI/admin
+  principals do.
 
 ## Requirements
 
@@ -41,7 +57,14 @@ between plan and apply.
   never provisioning platform resources directly into the root.
 - **REQ-OCI-002** The platform MUST define IAM policies scoped to the
   platform compartment only — no policy statement may grant access at the
-  tenancy level.
+  tenancy level — created only once a real, distinct principal exists to
+  bind them to (a dedicated human admin group or a federated CI
+  identity). The bootstrap principal used to create this module's own
+  resources (the tenancy's existing `Administrators` group membership)
+  MUST NOT be granted a compartment-scoped policy by this module when
+  doing so would add no effective permission beyond that principal's
+  existing tenancy-wide grant — see Non-Goals for the bootstrap-vs-
+  steady-state identity distinction this defers.
 - **REQ-OCI-003** The platform MUST define Dynamic Groups matching
   Talos/Flux-managed instance principals, so in-cluster workloads
   authenticate to OCI APIs (Object Storage, KMS) via instance principal,
@@ -122,7 +145,11 @@ Given the OCI foundation module is applied in the lab environment
 When the REQ-OCI-007 bootstrap sequence completes (phase 1 local apply,
   phase 2 migrate-state)
 Then a platform compartment exists as a child of the tenancy root compartment
-And IAM policies grant access scoped to that compartment only
+And no IAM policy is created for the bootstrap principal that only
+  duplicates its existing tenancy-wide grant (REQ-OCI-002, Non-Goals)
+And, once a dedicated CI or admin principal exists and policies for it are
+  enabled, those policies grant access scoped to the platform compartment
+  only
 And no local `terraform.tfstate` file remains in the module directory
 And the state object is present in the OCI Object Storage state bucket
 ```
@@ -193,7 +220,16 @@ IaC ownership split this Spec's module structure follows).
 ## Threat Model Impact
 
 Establishes the IAM trust boundary between tenancy root and platform
-compartment — feeds EPIC-TM-01 (I20) directly once that epic starts.
+compartment — feeds EPIC-TM-01 (I20) directly once that epic starts. When
+the Identity/Governance threat-model domain is populated, it MUST
+represent these as three distinct principals, not one collapsed
+identity: **bootstrap identity** (existing `Administrators` membership,
+a temporary external prerequisite for creating this module's resources)
+≠ **human platform administrator role** (future explicit least-privilege
+model, not yet implemented) ≠ **CI/workflow identity** (future federated
+workload identity — GitHub OIDC, EPIC-OCI-04 — never an OCI human user
+group). None of the latter two exist today; neither may be recorded as
+`implemented` in the corpus before real evidence exists.
 
 ## Operational Impact
 

--- a/infrastructure/live/oci/eu-madrid-1/lab/00-foundation/terragrunt.hcl
+++ b/infrastructure/live/oci/eu-madrid-1/lab/00-foundation/terragrunt.hcl
@@ -29,6 +29,14 @@ inputs = {
   # tenancy_ocid and state_bucket_name are NOT redeclared here -- both
   # already arrive via root.hcl's `inputs = merge(...)` from
   # common/account.hcl, so there's exactly one place each is defined.
+  #
+  # create_iam_policies is NOT set here -- defaults to false
+  # (variables.tf). The first apply uses the bootstrap principal
+  # (existing tenancy Administrators membership) directly; it is not
+  # granted a policy of its own (SPEC-OCI-001 Non-Goals). The names
+  # below are placeholders for when create_iam_policies is deliberately
+  # flipped to true against real, distinct CI/admin groups -- they do
+  # not need to resolve to existing groups until then.
   ci_group_name    = get_env("OCI_CI_GROUP_NAME", "platform-ci")
   admin_group_name = get_env("OCI_ADMIN_GROUP_NAME", "platform-admins")
 }

--- a/infrastructure/modules/foundation/README.md
+++ b/infrastructure/modules/foundation/README.md
@@ -22,15 +22,18 @@ and one lifecycle (essentially create-once).
 | `compartment_description` | string | no | — |
 | `environment` | string | yes | one of `lab`, `staging`, `prod` |
 | `platform_name` | string | no (default `"oracle-free-tier-platform"`) | — |
-| `ci_group_name` | string | yes | non-empty |
-| `admin_group_name` | string | yes | non-empty |
 | `state_bucket_name` | string | yes | valid OCI bucket name pattern |
 | `dynamic_group_name` | string | no (default `"platform-instances"`) | — |
 | `create_dynamic_group` | bool | no (default `false`) | — |
+| `create_iam_policies` | bool | no (default `false`) | — |
+| `ci_group_name` | string | no (default `""`) | non-empty when `create_iam_policies` is `true` |
+| `admin_group_name` | string | no (default `""`) | non-empty when `create_iam_policies` is `true` |
 
 `ci_group_name`/`admin_group_name` reference **existing** OCI IAM Groups —
 this module does not create IAM Users or Groups (see "Security invariants"
-below for why).
+below for why). Both are only used, and only required, when
+`create_iam_policies` is `true` — see that variable's description and
+`SPEC-OCI-001`'s Non-Goals for why policy creation is deferred by default.
 
 ## Output contract
 
@@ -47,10 +50,11 @@ below for why).
 `oci_identity_compartment` (1), `oci_identity_tag_namespace` (2:
 Platform, Security), `oci_identity_tag` (4: Platform.Environment,
 Platform.System, Platform.ManagedBy, Security.TrustZone),
-`oci_identity_policy` (2: CI, admin), `oci_identity_dynamic_group` (0 or
-1, gated by `var.create_dynamic_group` — see Security invariants),
-`oci_objectstorage_bucket` (1: state), `data.oci_objectstorage_namespace`
-(1, read-only).
+`oci_identity_policy` (0 or 2: CI, admin, gated by
+`var.create_iam_policies` — see Security invariants),
+`oci_identity_dynamic_group` (0 or 1, gated by `var.create_dynamic_group`
+— see Security invariants), `oci_objectstorage_bucket` (1: state),
+`data.oci_objectstorage_namespace` (1, read-only).
 
 **Not owned here**: IAM Users/Groups (see Security invariants), the
 tenancy-level bootstrap-identity grant (see Bootstrap runbook), any
@@ -65,10 +69,17 @@ sharing the state bucket).
   `oci_identity_compartment.platform.id` — never a resource placed
   directly in the tenancy root that could instead live in the platform
   compartment.
-- **REQ-OCI-002**: every `oci_identity_policy` statement targets
-  `compartment ${oci_identity_compartment.platform.name}` — grep the
-  module for the literal string `in tenancy` to confirm none exists.
-  Statements also enumerate specific resource-type families
+- **REQ-OCI-002**: deferred by default (`var.create_iam_policies =
+  false`) — this module's bootstrap principal is whichever existing
+  tenancy `Administrators` member runs the first apply, and binding
+  either policy to that same group would add no effective permission
+  beyond its existing tenancy-wide grant (the built-in Tenant Admin
+  Policy, untouched by this module) while implying a CI/admin separation
+  of duties that doesn't exist until distinct principals do. See
+  `SPEC-OCI-001`'s Non-Goals. When enabled, every `oci_identity_policy`
+  statement targets `compartment ${oci_identity_compartment.platform.name}`
+  — grep the module for the literal string `in tenancy` to confirm none
+  exists. Statements also enumerate specific resource-type families
   (`compartments`, `tag-namespaces`, `dynamic-groups`, `policies`,
   `object-family`) rather than `all-resources` — an initial draft of the
   CI policy used `read all-resources`, which technically stayed
@@ -157,13 +168,18 @@ tofu init -input=false   # no backend declared -> defaults to local ./terraform.
 tofu apply -input=false \
   -var="tenancy_ocid=$OCI_TENANCY_OCID" \
   -var="environment=lab" \
-  -var="ci_group_name=<existing CI group name>" \
-  -var="admin_group_name=<existing admin group name>" \
   -var="state_bucket_name=oracle-free-tier-platform-tfstate"
 ```
 
-Creates: the compartment, both tag namespaces + 4 tags, both IAM
-policies, the dynamic group, and — critically — the state bucket itself.
+Creates: the compartment, both tag namespaces + 4 tags, and — critically
+— the state bucket itself. `create_iam_policies` and `create_dynamic_group`
+both default to `false` and are deliberately omitted above — the first
+apply's bootstrap principal (existing tenancy `Administrators`
+membership) is not granted a policy of its own (`SPEC-OCI-001` Non-Goals),
+and no compute exists yet to match a dynamic group. Add
+`-var="create_iam_policies=true" -var="ci_group_name=<...>"
+-var="admin_group_name=<...>"` (and/or `-var="create_dynamic_group=true"`)
+in a later, separate apply once those real principals exist.
 
 ### Phase 2 — write the real backend and migrate (same scratch copy)
 

--- a/infrastructure/modules/foundation/iam.tf
+++ b/infrastructure/modules/foundation/iam.tf
@@ -1,5 +1,12 @@
 # REQ-OCI-002: IAM policies scoped to the platform compartment only -- no
-# statement below references the tenancy root as its target.
+# statement below references the tenancy root as its target. Deferred by
+# default (var.create_iam_policies = false): this module's bootstrap
+# principal is whichever existing tenancy `Administrators` member runs
+# the first apply, and binding either policy to that same group today
+# would add no effective permission beyond its existing tenancy-wide
+# grant (the built-in Tenant Admin Policy, untouched by this module)
+# while implying a CI/admin separation of duties that does not exist
+# until distinct principals do -- see SPEC-OCI-001's Non-Goals.
 #
 # What this module does NOT do: create OCI IAM Users or Groups. Group
 # membership (who is actually in the CI/admin group) is an
@@ -23,6 +30,8 @@
 # all-resources", which would silently broaden CI's visibility into
 # every future resource type without this module's own PR reviewing it).
 resource "oci_identity_policy" "ci" {
+  count = var.create_iam_policies ? 1 : 0
+
   compartment_id = oci_identity_compartment.platform.id
   name           = "platform-ci-policy"
   description    = "Least-privilege grant for the CI/workflow identity (REQ-OCI-002, REQ-OCI-006). Plan-equivalent (read) rights on exactly the resource types this module creates; apply rights are the human administrator's, not CI's, until a future PR explicitly designs CI-driven apply."
@@ -45,6 +54,8 @@ resource "oci_identity_policy" "ci" {
 }
 
 resource "oci_identity_policy" "admin" {
+  count = var.create_iam_policies ? 1 : 0
+
   compartment_id = oci_identity_compartment.platform.id
   name           = "platform-admin-policy"
   description    = "Human administrator: manage rights for the resources THIS module creates, scoped to the platform compartment (REQ-OCI-002). Does not grant tenancy-level rights -- see README.md#iam-bootstrap for the separate, undocumented-here bootstrap-identity requirement."

--- a/infrastructure/modules/foundation/tests/foundation.tftest.hcl
+++ b/infrastructure/modules/foundation/tests/foundation.tftest.hcl
@@ -6,8 +6,6 @@ mock_provider "oci" {}
 variables {
   tenancy_ocid      = "ocid1.tenancy.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
   environment       = "lab"
-  ci_group_name     = "platform-ci"
-  admin_group_name  = "platform-admins"
   state_bucket_name = "oracle-free-tier-platform-tfstate"
 }
 
@@ -39,29 +37,56 @@ run "state_bucket_is_private_and_versioned" {
   }
 }
 
-run "ci_policy_has_no_tenancy_scope" {
+run "iam_policies_deferred_by_default" {
   command = plan
 
   assert {
-    condition     = !anytrue([for s in oci_identity_policy.ci.statements : strcontains(s, "in tenancy")])
+    condition     = length(oci_identity_policy.ci) == 0 && length(oci_identity_policy.admin) == 0
+    error_message = "REQ-OCI-002/SPEC-OCI-001 Non-Goals: CI/admin policies must be deferred (create_iam_policies defaults to false) until distinct principals exist -- binding them to the bootstrap Administrators group today would be decorative"
+  }
+}
+
+run "ci_policy_has_no_tenancy_scope_when_enabled" {
+  command = plan
+
+  variables {
+    create_iam_policies = true
+    ci_group_name       = "platform-ci"
+    admin_group_name    = "platform-admins"
+  }
+
+  assert {
+    condition     = !anytrue([for s in oci_identity_policy.ci[0].statements : strcontains(s, "in tenancy")])
     error_message = "REQ-OCI-002: no CI policy statement may target tenancy scope"
   }
 }
 
-run "ci_policy_does_not_grant_all_resources" {
+run "ci_policy_does_not_grant_all_resources_when_enabled" {
   command = plan
 
+  variables {
+    create_iam_policies = true
+    ci_group_name       = "platform-ci"
+    admin_group_name    = "platform-admins"
+  }
+
   assert {
-    condition     = !anytrue([for s in oci_identity_policy.ci.statements : strcontains(s, "all-resources")])
+    condition     = !anytrue([for s in oci_identity_policy.ci[0].statements : strcontains(s, "all-resources")])
     error_message = "REQ-OCI-002/least-privilege: CI policy must enumerate specific resource-type families, never all-resources -- that would silently broaden CI visibility as new resource types are added elsewhere"
   }
 }
 
-run "admin_policy_has_no_tenancy_scope" {
+run "admin_policy_has_no_tenancy_scope_when_enabled" {
   command = plan
 
+  variables {
+    create_iam_policies = true
+    ci_group_name       = "platform-ci"
+    admin_group_name    = "platform-admins"
+  }
+
   assert {
-    condition     = !anytrue([for s in oci_identity_policy.admin.statements : strcontains(s, "in tenancy")])
+    condition     = !anytrue([for s in oci_identity_policy.admin[0].statements : strcontains(s, "in tenancy")])
     error_message = "REQ-OCI-002: no admin policy statement may target tenancy scope"
   }
 }

--- a/infrastructure/modules/foundation/tests/foundation_negative.tftest.hcl
+++ b/infrastructure/modules/foundation/tests/foundation_negative.tftest.hcl
@@ -8,8 +8,6 @@ mock_provider "oci" {}
 variables {
   tenancy_ocid      = "ocid1.tenancy.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
   environment       = "lab"
-  ci_group_name     = "platform-ci"
-  admin_group_name  = "platform-admins"
   state_bucket_name = "oracle-free-tier-platform-tfstate"
 }
 
@@ -23,21 +21,25 @@ run "invalid_environment_rejected" {
   expect_failures = [var.environment]
 }
 
-run "empty_ci_group_name_rejected" {
+run "empty_ci_group_name_rejected_when_policies_enabled" {
   command = plan
 
   variables {
-    ci_group_name = ""
+    create_iam_policies = true
+    ci_group_name       = ""
+    admin_group_name    = "platform-admins"
   }
 
   expect_failures = [var.ci_group_name]
 }
 
-run "empty_admin_group_name_rejected" {
+run "empty_admin_group_name_rejected_when_policies_enabled" {
   command = plan
 
   variables {
-    admin_group_name = "   " # whitespace-only, trimspace() catches this
+    create_iam_policies = true
+    ci_group_name       = "platform-ci"
+    admin_group_name    = "   " # whitespace-only, trimspace() catches this
   }
 
   expect_failures = [var.admin_group_name]

--- a/infrastructure/modules/foundation/variables.tf
+++ b/infrastructure/modules/foundation/variables.tf
@@ -36,29 +36,49 @@ variable "platform_name" {
   description = "Platform.System defined-tag value."
 }
 
+variable "create_iam_policies" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+    Whether to create the platform-ci-policy/platform-admin-policy IAM
+    policies now. Defaults to false: this module's bootstrap principal is
+    whichever existing tenancy `Administrators` member runs the first
+    apply, and binding a policy to that same group would add no effective
+    permission beyond its existing tenancy-wide grant while implying a
+    separation of duties (CI vs admin) that doesn't exist until distinct
+    principals do -- a dedicated human admin group and/or a federated CI
+    identity (GitHub OIDC, EPIC-OCI-04). See SPEC-OCI-001's Non-Goals for
+    the bootstrap-vs-steady-state identity distinction. Set true once
+    ci_group_name/admin_group_name reference real, distinct principals.
+  EOT
+}
+
 variable "ci_group_name" {
   type        = string
+  default     = ""
   description = <<-EOT
     Name of the existing OCI IAM Group the CI/workflow identity (plan.yml's
-    static credentials, REQ-OCI-006) belongs to. This module does NOT create
-    IAM users/groups — group membership is an identity-governance decision
+    static credentials, REQ-OCI-006) belongs to. Only used when
+    create_iam_policies is true. This module does NOT create IAM
+    users/groups — group membership is an identity-governance decision
     made outside OpenTofu's Free-Tier bootstrap scope; this module only
     grants that existing group compartment-scoped policy rights (REQ-OCI-002).
   EOT
 
   validation {
-    condition     = length(trimspace(var.ci_group_name)) > 0
-    error_message = "ci_group_name must not be empty."
+    condition     = !var.create_iam_policies || length(trimspace(var.ci_group_name)) > 0
+    error_message = "ci_group_name must not be empty when create_iam_policies is true."
   }
 }
 
 variable "admin_group_name" {
   type        = string
-  description = "Name of the existing OCI IAM Group the human administrator belongs to. Same non-creation rationale as ci_group_name."
+  default     = ""
+  description = "Name of the existing OCI IAM Group the human administrator belongs to. Only used when create_iam_policies is true. Same non-creation rationale as ci_group_name."
 
   validation {
-    condition     = length(trimspace(var.admin_group_name)) > 0
-    error_message = "admin_group_name must not be empty."
+    condition     = !var.create_iam_policies || length(trimspace(var.admin_group_name)) > 0
+    error_message = "admin_group_name must not be empty when create_iam_policies is true."
   }
 }
 


### PR DESCRIPTION
## Why

Preparing `00-foundation` for its first real apply against the live OCI
tenancy surfaced that both `platform-ci-policy` and `platform-admin-policy`
would bind to the same group: **`Administrators`**, the only group that
exists in the tenancy today. That makes the intended CI/admin separation
of duties decorative — `Administrators` already holds tenancy-wide
`manage all-resources` via the built-in Tenant Admin Policy, so either
policy adds no effective permission.

## Decision

Do not create a placeholder `platform-ci` group just to make the policy
shape match the module. Instead defer policy creation until a real,
distinct principal exists:

- **Bootstrap principal** — existing `Administrators` membership, an
  external prerequisite for creating this module's resources, not
  something the module grants a policy to itself.
- **Steady-state human admin** — future dedicated least-privilege group,
  not yet created.
- **CI principal** — future federated workload identity (GitHub OIDC,
  EPIC-OCI-04), never an OCI human user group.

## Change

- `create_iam_policies` (bool, default `false`) gates both
  `oci_identity_policy` resources via `count`.
- `ci_group_name`/`admin_group_name` become optional (default `""`),
  required only when `create_iam_policies = true` (cross-variable
  validation).
- Tests: new `iam_policies_deferred_by_default`; existing policy-shape
  tests moved behind `create_iam_policies = true` overrides; negative
  tests for empty group names updated to enable policies first so the
  validation actually fires.
- `SPEC-OCI-001`: REQ-OCI-002, Non-Goals, Acceptance Criteria, and Threat
  Model Impact updated to record bootstrap-vs-steady-state identity as
  an explicit, traceable architecture gap — not a silent deviation from
  what the Spec required.
- Module README, bootstrap runbook, and the `00-foundation` Terragrunt
  unit's inputs comment updated to match.

Set `create_iam_policies = true` (with real group names) once dedicated
principals exist — no other module change needed.

## Validation

- `tofu fmt -check`, `tofu validate`: pass
- `tofu test`: 14/14 pass (was 13, net +1 for the deferred-by-default case)
- `tflint`: 0 issues
- `checkov` (`--skip-check CKV_OCI_9`): 4/4 pass
- `terragrunt hcl fmt --check` / `hcl validate`: pass
- `gitleaks`: no leaks
- `markdownlint`: 0 issues on changed docs

Follows directly from #39 (dynamic-group deferral) — same rationale
applied to the other piece of "IAM machinery with no real principal yet."