### PR TITLE
feat: 10-network VCN + trust-zone subnets module (PR C)

### DIFF
--- a/infrastructure/live/oci/eu-madrid-1/lab/10-network/terragrunt.hcl
+++ b/infrastructure/live/oci/eu-madrid-1/lab/10-network/terragrunt.hcl
@@ -1,0 +1,28 @@
+# SPEC-NET-001, ADR-0007's 10-network. Depends on 00-foundation for the
+# platform compartment OCID -- see ADR-0007's dependency-direction diagram
+# (00-foundation -> 10-network).
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../../../modules/network"
+}
+
+dependency "foundation" {
+  config_path = "../00-foundation"
+
+  # Lets `terragrunt validate`/`plan` (and CI's plan.yml, before real
+  # credentials exist) run without 00-foundation's real remote state
+  # being reachable. `apply`/`destroy` are deliberately excluded --
+  # never plan-and-apply this unit against a fabricated compartment OCID.
+  mock_outputs = {
+    compartment_ocid = "ocid1.compartment.oc1..aaaaaaaamockmockmockmockmockmockmockmockmockmockmockmockmock"
+  }
+  mock_outputs_allowed_terraform_commands = ["validate", "plan", "init"]
+}
+
+inputs = {
+  compartment_ocid = dependency.foundation.outputs.compartment_ocid
+}

--- a/infrastructure/modules/network/.terraform.lock.hcl
+++ b/infrastructure/modules/network/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/oracle/oci" {
+  version     = "8.27.0"
+  constraints = "8.27.0"
+  hashes = [
+    "h1:AjL/F1LqP/NnqC/85zz/dpbwtOkyNxUmxPwor7Hkj9A=",
+    "h1:H7OoMqL2xxC7L2Yw2fEkFixQdbmcvPsdCgJMkIEpDNk=",
+    "h1:J2rPY5OC6lyOm5x9/4NZGwRObavf0K2tj1Z3XbSxfnc=",
+    "h1:K14lmG1OoKZ91MHJFCWLfG88j9qwn2QHgqYW705VEIM=",
+    "h1:KHD+5YqwHItc1wHGXS8Xc+/J/O42F7B4vo9O24ZgXAo=",
+    "h1:MxFf+EHJ0n5ynhddfuSOJzIhVNrGig5c/RiBoAQojPg=",
+    "h1:QrYgpQr9Vgd6sZ6WJi+jFDmSCfPtGil6+Oz84A+hWNA=",
+    "h1:T4zljEl0dK346N50cUUs4v65zg+KNRlPmehjd4G3GZY=",
+    "h1:eYektTaEIOl06Pes66VyCLXWq1J+kW8Wg0D+HkqzYUU=",
+    "h1:iUB9eoB/apT4/8nk/QKmg315yQSxkoXACZCH5KN4OL8=",
+    "h1:lGISh5fY2mqyPRkwmdksLX37VRs8sTA4OCbis9W6XVg=",
+    "h1:pJ7DmHo9MfhDM7gscoPE7OHqEKxwUNEwz2/A5ZOUUN0=",
+    "h1:xCGfRz9+0pHOj0tisklLK+2tQbRliTWnBfLFhOVwMBA=",
+    "zh:17aac70ae4c46bd85a285420414fac19a4fe42a340c95c1cf4ab6d29da71e656",
+    "zh:1cbbd87089cda3d67423927b431e4f0fceff17aa4dc13437909bbaaf306bd9f5",
+    "zh:1cd6fb7b78af954620eae64431d6f123f3dd701320bc3ab8cb6b47f1480d79b9",
+    "zh:3ca2f70cf877df758c3fca9b01138446728167e8cfba6556028e64df24903d37",
+    "zh:490588f364393c8e53d8621aeaf5c23d92c55d32ebca2b1d1a48d93b1cd3ff9d",
+    "zh:594cb7d04e1dde0ca0d848e1aa848ea136d0d9315cf77b2dd44df5af0e54156a",
+    "zh:69f58679129f332798c3f5a9f249c1dd4d4a0f80a44c89a540a1907e0ac5f1c9",
+    "zh:7a4f19a156084dc4ba8acf6117cee0de7c0d11574e99d2f6525df6da46f5d0d3",
+    "zh:8378cc00db7b0f9fa1007ba105122fb2d4c052947db1b1c65fb0a1111670c001",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a95ed489c8e00dbe950fb440dec6f51632b1401b738bd187384e33b3bcb393ad",
+    "zh:c1bc19afd167c54789d21777f6ed60b472acf7d3e2d50ebc8691e7a1cd90c4f4",
+    "zh:e1f7b2b516334ef070c6a94a85ce11560db9f2510f28128fc04b5ac724db3e55",
+    "zh:f2c19157c2b4a79aea8bf89e76f51f9363dd743fc8607f5d9b87684a47444c99",
+  ]
+}

--- a/infrastructure/modules/network/README.md
+++ b/infrastructure/modules/network/README.md
@@ -1,0 +1,136 @@
+# `network` module
+
+## Purpose
+
+Implements `SPEC-NET-001` (REQ-NET-001..005): the platform VCN and its
+four trust-zone subnets (Edge, Management, Workload, Data), as decided by
+`ADR-0006`. This is the second module in the state DAG — every downstream
+network Spec (`SPEC-NET-002` gateways, `SPEC-NET-003` route tables,
+`SPEC-NET-004` NSGs/Security Lists, `SPEC-NET-006` DNS/DHCP) and I04
+(compute) attach to the VCN/subnets this module creates. `ADR-0007`
+already decided `10-network` is one state unit covering all of
+`SPEC-NET-001` through `SPEC-NET-006` — this module is built incrementally
+across PRs against that same eventual state unit (this PR: `vcn.tf` +
+`subnets.tf` only; a later PR adds `gateways.tf`/`routing.tf`/
+`security.tf`/`dns.tf`), per `../README.md`'s own documented internal-
+file-organization note. Not a further-split target: OCI network topology
+within one VCN is provisioned and changed as a unit in practice.
+
+## Input contract
+
+| Variable | Type | Required | Validation |
+| --- | --- | --- | --- |
+| `compartment_ocid` | string | yes | must match `^ocid1\.compartment\.` |
+| `environment` | string | yes | one of `lab`, `staging`, `prod` |
+| `platform_name` | string | no (default `"oracle-free-tier-platform"`) | — |
+
+No CIDR variables. REQ-NET-001/REQ-NET-002 mandate exact values, and
+ADR-0006 is explicit they're fixed absent a superseding ADR — see
+`vcn.tf`'s locals and `variables.tf`'s comment for why these are
+hardcoded constants, not tunables.
+
+## Output contract
+
+| Output | Consumed by |
+| --- | --- |
+| `vcn_id` | `SPEC-NET-002` (gateways), `SPEC-NET-003` (route tables), `SPEC-NET-004` (NSGs/Security Lists) |
+| `vcn_cidr` | downstream modules needing the VCN's own range (e.g. future DRG peering, I21) |
+| `subnet_ids` | map keyed by zone (`edge`/`management`/`workload`/`data`) — `SPEC-NET-002`/`SPEC-NET-004`/I04 attach resources to specific subnets by zone |
+| `subnet_cidrs` | map keyed by zone — downstream Security List/NSG rules referencing zone ranges |
+
+## Resource ownership
+
+`oci_core_vcn` (1), `oci_core_subnet` (4, one per trust zone, via
+`for_each`).
+
+**Not owned here**: gateways (Internet/NAT/Service/DRG — `SPEC-NET-002`),
+route tables/associations (`SPEC-NET-003`), NSGs/Security Lists
+(`SPEC-NET-004`), DNS/DHCP options (`SPEC-NET-006`), compute attachment
+(I04). Subnets use OCI's auto-created default route table (empty — no
+gateway routes exist yet) and default security list until those Specs'
+files are added to this same module.
+
+## Security invariants
+
+- **REQ-NET-001**: exactly one VCN, CIDR `10.10.0.0/16` (`vcn.tf`'s
+  `local.vcn_cidr`) — hardcoded, not derived from a variable, so no
+  environment can silently diverge from ADR-0006's agreed range.
+- **REQ-NET-002**: exactly four subnets, each with the exact CIDR
+  ADR-0006's table specifies (`local.subnet_cidrs`) — cross-checked
+  against `docs/arch/cloud-deployment.mmd` before writing this module,
+  not assumed to match.
+- **REQ-NET-003/004**: `prohibit_public_ip_on_vnic` is `true` for every
+  zone except `edge` (`subnets.tf`'s `local.subnet_public_allowed`) —
+  `tests/network.tftest.hcl` asserts this per zone, not just for one
+  representative subnet.
+- **CIDR self-check**: `vcn.tf`'s `check "trust_zone_cidrs_are_valid_and_disjoint"`
+  block validates the locals themselves at plan/apply time — every CIDR
+  is syntactically valid (`can(cidrhost(...))`), every subnet CIDR falls
+  within the VCN CIDR (`cidrcontains`), no two subnet CIDRs are identical
+  or overlap. This does not attempt exhaustive interval arithmetic for a
+  partial overlap that contains neither CIDR's own network address — a
+  case that cannot arise among these four same-size, non-nested `/24`
+  allocations, but would need different math for an arbitrary future
+  CIDR set. `cidrcontains`/`cidrhost` behavior confirmed empirically
+  against the pinned OpenTofu 1.12.5 (`tofu console`), not assumed.
+- **Tag ownership**: same OCI-managed-vs-Platform-managed split as
+  `infrastructure/modules/foundation/state_backend.tf` — `lifecycle.ignore_changes`
+  on exactly `Oracle-Tags.CreatedBy`/`Oracle-Tags.CreatedOn`, on both the
+  VCN and every subnet, never the whole `defined_tags` attribute.
+
+## Validation
+
+```sh
+cd infrastructure/modules/network
+tofu fmt -check -recursive
+tofu init -backend=false -input=false
+tofu validate
+tofu test
+```
+
+## Failure modes
+
+- **Partial apply (VCN created, subnet creation fails)**: `oci_core_subnet`
+  resources use `for_each`, so a failure creating one subnet leaves the
+  others (and the VCN) in state correctly — re-running `tofu apply`
+  retries only the missing subnet(s), no orphaned state.
+- **CIDR self-check failure**: `tofu plan`/`apply` fails before any API
+  call — the `check` block runs against the locals directly, so a bad
+  hand-edit is caught before it ever reaches OCI.
+
+## Upgrade expectations
+
+Changing any subnet's CIDR or the VCN's CIDR forces replacement (OCI VCN/
+subnet CIDRs are immutable) — destructive, and per REQ-NET-001/002 should
+only ever happen via a superseding ADR, never a casual edit. Changing
+`environment` updates the `Platform.Environment` tag value in place (no
+replacement).
+
+## Example
+
+See `examples/minimal/main.tf`.
+
+## Tests
+
+`tests/network.tftest.hcl` (positive, `mock_provider`):
+
+- VCN has the exact CIDR REQ-NET-001 mandates.
+- All four subnets exist with the exact CIDRs REQ-NET-002 mandates.
+- Edge subnet allows public IP; Management, Workload, and Data each
+  independently assert `prohibit_public_ip_on_vnic == true` (not one
+  representative check standing in for all three).
+- The CIDR self-check `check` block assertions hold for the real locals
+  (validated by `tofu validate`/`tofu test` succeeding at all — a broken
+  `check` block fails the whole run).
+
+`tests/network_negative.tftest.hcl`: this module's CIDRs are hardcoded
+locals, not variables (see Input contract) — there is no variable surface
+to feed a malformed/overlapping/out-of-range CIDR into, so classic
+`expect_failures` negative tests don't apply the way they do for
+`foundation`'s string/OCID variables. Malformed-CIDR protection is
+enforced by `tofu validate`'s type system at parse time (a non-CIDR-shaped
+string literal fails HCL evaluation immediately); overlap/containment/
+duplication protection is enforced by `vcn.tf`'s `check` block instead
+(see Security invariants). This file's negative tests instead cover the
+one real variable-driven invariant this module has: rejecting an invalid
+`environment` value.

--- a/infrastructure/modules/network/examples/minimal/.terraform.lock.hcl
+++ b/infrastructure/modules/network/examples/minimal/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/oracle/oci" {
+  version     = "8.27.0"
+  constraints = "8.27.0"
+  hashes = [
+    "h1:AjL/F1LqP/NnqC/85zz/dpbwtOkyNxUmxPwor7Hkj9A=",
+    "h1:H7OoMqL2xxC7L2Yw2fEkFixQdbmcvPsdCgJMkIEpDNk=",
+    "h1:J2rPY5OC6lyOm5x9/4NZGwRObavf0K2tj1Z3XbSxfnc=",
+    "h1:K14lmG1OoKZ91MHJFCWLfG88j9qwn2QHgqYW705VEIM=",
+    "h1:KHD+5YqwHItc1wHGXS8Xc+/J/O42F7B4vo9O24ZgXAo=",
+    "h1:MxFf+EHJ0n5ynhddfuSOJzIhVNrGig5c/RiBoAQojPg=",
+    "h1:QrYgpQr9Vgd6sZ6WJi+jFDmSCfPtGil6+Oz84A+hWNA=",
+    "h1:T4zljEl0dK346N50cUUs4v65zg+KNRlPmehjd4G3GZY=",
+    "h1:eYektTaEIOl06Pes66VyCLXWq1J+kW8Wg0D+HkqzYUU=",
+    "h1:iUB9eoB/apT4/8nk/QKmg315yQSxkoXACZCH5KN4OL8=",
+    "h1:lGISh5fY2mqyPRkwmdksLX37VRs8sTA4OCbis9W6XVg=",
+    "h1:pJ7DmHo9MfhDM7gscoPE7OHqEKxwUNEwz2/A5ZOUUN0=",
+    "h1:xCGfRz9+0pHOj0tisklLK+2tQbRliTWnBfLFhOVwMBA=",
+    "zh:17aac70ae4c46bd85a285420414fac19a4fe42a340c95c1cf4ab6d29da71e656",
+    "zh:1cbbd87089cda3d67423927b431e4f0fceff17aa4dc13437909bbaaf306bd9f5",
+    "zh:1cd6fb7b78af954620eae64431d6f123f3dd701320bc3ab8cb6b47f1480d79b9",
+    "zh:3ca2f70cf877df758c3fca9b01138446728167e8cfba6556028e64df24903d37",
+    "zh:490588f364393c8e53d8621aeaf5c23d92c55d32ebca2b1d1a48d93b1cd3ff9d",
+    "zh:594cb7d04e1dde0ca0d848e1aa848ea136d0d9315cf77b2dd44df5af0e54156a",
+    "zh:69f58679129f332798c3f5a9f249c1dd4d4a0f80a44c89a540a1907e0ac5f1c9",
+    "zh:7a4f19a156084dc4ba8acf6117cee0de7c0d11574e99d2f6525df6da46f5d0d3",
+    "zh:8378cc00db7b0f9fa1007ba105122fb2d4c052947db1b1c65fb0a1111670c001",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a95ed489c8e00dbe950fb440dec6f51632b1401b738bd187384e33b3bcb393ad",
+    "zh:c1bc19afd167c54789d21777f6ed60b472acf7d3e2d50ebc8691e7a1cd90c4f4",
+    "zh:e1f7b2b516334ef070c6a94a85ce11560db9f2510f28128fc04b5ac724db3e55",
+    "zh:f2c19157c2b4a79aea8bf89e76f51f9363dd743fc8607f5d9b87684a47444c99",
+  ]
+}

--- a/infrastructure/modules/network/examples/minimal/main.tf
+++ b/infrastructure/modules/network/examples/minimal/main.tf
@@ -1,0 +1,36 @@
+# Minimal runnable reference. Not applied by CI (validate.yml only runs
+# `tofu init -backend=false && tofu validate` against every modules/**
+# and compositions/** directory containing main.tf -- this counts). Real
+# usage is via Terragrunt: see
+# infrastructure/live/oci/eu-madrid-1/lab/10-network/terragrunt.hcl.
+
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "8.27.0"
+    }
+  }
+}
+
+provider "oci" {
+  region = "eu-madrid-1"
+}
+
+module "network" {
+  source = "../.."
+
+  compartment_ocid = var.compartment_ocid
+  environment      = "lab"
+}
+
+variable "compartment_ocid" {
+  type        = string
+  description = "Set via TF_VAR_compartment_ocid or -var, never hardcoded. In practice, infrastructure/modules/foundation's compartment_ocid output."
+}
+
+output "vcn_id" {
+  value = module.network.vcn_id
+}

--- a/infrastructure/modules/network/main.tf
+++ b/infrastructure/modules/network/main.tf
@@ -1,0 +1,12 @@
+# Entry point / file map for this module. Resources are split by concern
+# rather than living in this file directly -- see modules/README.md's
+# "internal file organization" note. Kept as a real, non-empty file
+# (rather than omitted) because validate.yml's module-discovery loop
+# looks for a literal main.tf to identify root-module directories to
+# validate -- an empty or missing main.tf here would silently exclude
+# this module from that automated check.
+#
+#   vcn.tf       REQ-NET-001 -- the platform VCN; also the CIDR/tag locals
+#                and the check block self-validating them
+#   subnets.tf   REQ-NET-002/003/004 -- the four trust-zone subnets
+#   variables.tf / outputs.tf / versions.tf -- standard module contract

--- a/infrastructure/modules/network/outputs.tf
+++ b/infrastructure/modules/network/outputs.tf
@@ -1,0 +1,22 @@
+# REQ-NET-005: subnet OCIDs exposed keyed by zone name, for SPEC-NET-002
+# (gateways) and I04 (compute) to consume.
+
+output "vcn_id" {
+  value       = oci_core_vcn.this.id
+  description = "OCID of the platform VCN (SPEC-NET-001 Interfaces). Consumed by SPEC-NET-002 (gateways), SPEC-NET-003 (route tables), SPEC-NET-004 (NSGs/Security Lists)."
+}
+
+output "vcn_cidr" {
+  value       = local.vcn_cidr
+  description = "CIDR block of the platform VCN (REQ-NET-001)."
+}
+
+output "subnet_ids" {
+  value       = { for zone, subnet in oci_core_subnet.this : zone => subnet.id }
+  description = "Subnet OCIDs keyed by trust-zone name (edge, management, workload, data) -- REQ-NET-005."
+}
+
+output "subnet_cidrs" {
+  value       = local.subnet_cidrs
+  description = "Subnet CIDRs keyed by trust-zone name (REQ-NET-002)."
+}

--- a/infrastructure/modules/network/subnets.tf
+++ b/infrastructure/modules/network/subnets.tf
@@ -1,0 +1,45 @@
+# REQ-NET-003: Management, Workload, and Data MUST NOT allow public IP.
+# REQ-NET-004: only Edge MAY allow public IP -- allowed here at the
+# subnet level, not assigned to anything, since no compute/ingress/
+# OpenZiti-edge-router VNIC exists yet (that attachment is SPEC-NET-004
+# scope, explicitly out of this module's Non-Goals for now).
+#
+# No route_table_id/security_list_ids set on any subnet: each gets OCI's
+# auto-created default route table (empty -- no gateway routes exist
+# until SPEC-NET-002/003 add them) and default security list. This is
+# what "the module must not silently attach IGW/NAT/SGW routes yet"
+# means in practice -- there is nothing to attach until those Specs'
+# modules exist, so the safe default is exactly what OCI already does
+# for an unconfigured subnet.
+locals {
+  subnet_public_allowed = {
+    edge       = true
+    management = false
+    workload   = false
+    data       = false
+  }
+}
+
+resource "oci_core_subnet" "this" {
+  for_each = local.subnet_cidrs
+
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.this.id
+  cidr_block     = each.value
+  display_name   = "platform-${each.key}"
+  dns_label      = each.key
+
+  prohibit_public_ip_on_vnic = !local.subnet_public_allowed[each.key]
+
+  freeform_tags = { "provisioned-by" = "opentofu", "trust-zone" = each.key }
+  defined_tags  = local.network_defined_tags
+
+  lifecycle {
+    prevent_destroy = true
+
+    ignore_changes = [
+      defined_tags["Oracle-Tags.CreatedBy"],
+      defined_tags["Oracle-Tags.CreatedOn"],
+    ]
+  }
+}

--- a/infrastructure/modules/network/tests/network.tftest.hcl
+++ b/infrastructure/modules/network/tests/network.tftest.hcl
@@ -1,0 +1,116 @@
+# Positive tests -- module contract at plan time, no real OCI credentials
+# required (mock_provider stands in for the real provider).
+
+mock_provider "oci" {}
+
+variables {
+  compartment_ocid = "ocid1.compartment.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
+  environment      = "lab"
+}
+
+run "vcn_has_exact_cidr" {
+  command = plan
+
+  assert {
+    condition     = oci_core_vcn.this.cidr_blocks[0] == "10.10.0.0/16"
+    error_message = "REQ-NET-001: VCN must use exactly 10.10.0.0/16"
+  }
+
+  assert {
+    condition     = length(oci_core_vcn.this.cidr_blocks) == 1
+    error_message = "REQ-NET-001: exactly one VCN CIDR block, not multiple"
+  }
+}
+
+run "four_subnets_with_exact_cidrs" {
+  command = plan
+
+  assert {
+    condition     = length(oci_core_subnet.this) == 4
+    error_message = "REQ-NET-002: exactly four trust-zone subnets must exist"
+  }
+
+  assert {
+    condition     = oci_core_subnet.this["edge"].cidr_block == "10.10.10.0/24"
+    error_message = "REQ-NET-002: Edge subnet must use exactly 10.10.10.0/24"
+  }
+
+  assert {
+    condition     = oci_core_subnet.this["management"].cidr_block == "10.10.20.0/24"
+    error_message = "REQ-NET-002: Management subnet must use exactly 10.10.20.0/24"
+  }
+
+  assert {
+    condition     = oci_core_subnet.this["workload"].cidr_block == "10.10.30.0/24"
+    error_message = "REQ-NET-002: Workload subnet must use exactly 10.10.30.0/24"
+  }
+
+  assert {
+    condition     = oci_core_subnet.this["data"].cidr_block == "10.10.40.0/24"
+    error_message = "REQ-NET-002: Data subnet must use exactly 10.10.40.0/24"
+  }
+}
+
+run "edge_subnet_allows_public_ip" {
+  command = plan
+
+  assert {
+    condition     = oci_core_subnet.this["edge"].prohibit_public_ip_on_vnic == false
+    error_message = "REQ-NET-004: Edge subnet MAY allow public IP -- prohibit_public_ip_on_vnic must be false"
+  }
+}
+
+run "management_subnet_prohibits_public_ip" {
+  command = plan
+
+  assert {
+    condition     = oci_core_subnet.this["management"].prohibit_public_ip_on_vnic == true
+    error_message = "REQ-NET-003: Management subnet must prohibit public IP"
+  }
+}
+
+run "workload_subnet_prohibits_public_ip" {
+  command = plan
+
+  assert {
+    condition     = oci_core_subnet.this["workload"].prohibit_public_ip_on_vnic == true
+    error_message = "REQ-NET-003: Workload subnet must prohibit public IP"
+  }
+}
+
+run "data_subnet_prohibits_public_ip" {
+  command = plan
+
+  assert {
+    condition     = oci_core_subnet.this["data"].prohibit_public_ip_on_vnic == true
+    error_message = "REQ-NET-003: Data subnet must prohibit public IP"
+  }
+}
+
+run "subnets_carry_no_oracle_managed_tag_keys" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone, subnet in oci_core_subnet.this :
+      !anytrue([for k in keys(subnet.defined_tags) : strcontains(k, "Oracle-Tags")])
+    ])
+    error_message = "this module must never itself declare an Oracle-Tags.* key -- see subnets.tf/vcn.tf's ignore_changes"
+  }
+}
+
+run "vcn_and_subnets_use_the_platform_compartment" {
+  command = plan
+
+  assert {
+    condition     = oci_core_vcn.this.compartment_id == var.compartment_ocid
+    error_message = "the VCN must live in the platform compartment passed in, never a hardcoded compartment"
+  }
+
+  assert {
+    condition = alltrue([
+      for zone, subnet in oci_core_subnet.this : subnet.compartment_id == var.compartment_ocid
+    ])
+    error_message = "every subnet must live in the platform compartment passed in"
+  }
+}

--- a/infrastructure/modules/network/tests/network_negative.tftest.hcl
+++ b/infrastructure/modules/network/tests/network_negative.tftest.hcl
@@ -1,0 +1,36 @@
+# Negative tests -- every one of these MUST fail. See README.md's "Tests"
+# section for why this module has only one variable-driven negative case:
+# CIDRs are hardcoded locals (REQ-NET-001/002), not variables, so there is
+# no user-input surface for malformed/overlapping/out-of-range CIDR
+# negative tests the way infrastructure/modules/foundation has for its
+# string/OCID variables. That protection is enforced instead by vcn.tf's
+# `check` block (validated positively in network.tftest.hcl -- a broken
+# check block fails `tofu test` outright, since `tofu validate`/`plan`
+# would fail first).
+
+mock_provider "oci" {}
+
+variables {
+  compartment_ocid = "ocid1.compartment.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
+  environment      = "lab"
+}
+
+run "invalid_environment_rejected" {
+  command = plan
+
+  variables {
+    environment = "production" # not one of lab|staging|prod
+  }
+
+  expect_failures = [var.environment]
+}
+
+run "invalid_compartment_ocid_rejected" {
+  command = plan
+
+  variables {
+    compartment_ocid = "not-an-ocid"
+  }
+
+  expect_failures = [var.compartment_ocid]
+}

--- a/infrastructure/modules/network/variables.tf
+++ b/infrastructure/modules/network/variables.tf
@@ -1,0 +1,33 @@
+variable "compartment_ocid" {
+  type        = string
+  description = "OCID of the platform compartment (SPEC-OCI-001 output). This module places every resource here -- never the tenancy root."
+
+  validation {
+    condition     = can(regex("^ocid1\\.compartment\\.", var.compartment_ocid))
+    error_message = "compartment_ocid must be a valid compartment OCID (ocid1.compartment....)."
+  }
+}
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment. Only 'lab' exists today (infrastructure/README.md#tagging-contract)."
+
+  validation {
+    condition     = contains(["lab", "staging", "prod"], var.environment)
+    error_message = "environment must be one of: lab, staging, prod."
+  }
+}
+
+variable "platform_name" {
+  type        = string
+  default     = "oracle-free-tier-platform"
+  description = "Platform.System defined-tag value -- matches infrastructure/modules/foundation's own default."
+}
+
+# No CIDR variables, deliberately: REQ-NET-001/REQ-NET-002 mandate exact
+# values ("MUST create ... using CIDR 10.10.0.0/16", "MUST create four
+# subnets: Edge (10.10.10.0/24)..."), and ADR-0006 is explicit --
+# "Preserve these exactly unless an approved ADR changes them." Exposing
+# them as tunable variables would let a future environment silently
+# deviate from the agreed trust-zone model without a superseding ADR.
+# See vcn.tf/subnets.tf's locals.

--- a/infrastructure/modules/network/vcn.tf
+++ b/infrastructure/modules/network/vcn.tf
@@ -1,0 +1,92 @@
+# REQ-NET-001: exactly one VCN, exact CIDR. REQ-NET-002: four trust-zone
+# subnets, exact CIDRs. ADR-0006 is explicit these are fixed, not
+# per-environment tunables -- see variables.tf's comment. Hardcoded here
+# as locals (not resource-inline literals) so subnets.tf and the `check`
+# block below share one source of truth.
+locals {
+  vcn_cidr = "10.10.0.0/16"
+
+  # Zone name -> CIDR. Matches ADR-0006's table and
+  # docs/arch/cloud-deployment.mmd exactly (cross-checked against both
+  # before writing this module, not assumed).
+  subnet_cidrs = {
+    edge       = "10.10.10.0/24"
+    management = "10.10.20.0/24"
+    workload   = "10.10.30.0/24"
+    data       = "10.10.40.0/24"
+  }
+
+  # REQ-OCI-004: every resource under the platform compartment carries
+  # Defined Tags. "Platform"/"Security" are the fixed tag-namespace names
+  # infrastructure/modules/foundation creates (see its tags.tf) --
+  # hardcoded here the same way foundation hardcodes them itself, not
+  # re-exposed as a variable.
+  network_defined_tags = {
+    "Platform.Environment" = var.environment
+    "Platform.System"      = var.platform_name
+    "Platform.ManagedBy"   = "opentofu"
+  }
+}
+
+# Self-check on the locals above, not on the deployed resources --
+# guards against a future hand-edit introducing a CIDR outside the VCN, a
+# duplicate, or a syntactically invalid value. Verified empirically
+# against the pinned OpenTofu 1.12.5 that `cidrcontains`/`cidrhost` behave
+# as expected (`tofu console`), not assumed. See network/README.md's
+# "CIDR validation" section for what this can and cannot prove -- it does
+# not attempt exhaustive interval arithmetic for partial overlaps that
+# contain neither CIDR's own network address, a case that cannot arise
+# among these four same-size, non-nested /24 allocations.
+check "trust_zone_cidrs_are_valid_and_disjoint" {
+  assert {
+    condition = alltrue([
+      for cidr in concat([local.vcn_cidr], values(local.subnet_cidrs)) : can(cidrhost(cidr, 0))
+    ])
+    error_message = "every VCN/subnet CIDR must be a syntactically valid CIDR block"
+  }
+
+  assert {
+    condition = alltrue([
+      for cidr in values(local.subnet_cidrs) : cidrcontains(local.vcn_cidr, cidr)
+    ])
+    error_message = "REQ-NET-002: every trust-zone subnet CIDR must fall within the VCN CIDR (${local.vcn_cidr})"
+  }
+
+  assert {
+    condition     = length(distinct(values(local.subnet_cidrs))) == length(values(local.subnet_cidrs))
+    error_message = "no two trust-zone subnets may share the same CIDR"
+  }
+
+  assert {
+    condition = alltrue(flatten([
+      for a_name, a_cidr in local.subnet_cidrs : [
+        for b_name, b_cidr in local.subnet_cidrs :
+        a_name == b_name || (!cidrcontains(a_cidr, b_cidr) && !cidrcontains(b_cidr, a_cidr))
+      ]
+    ]))
+    error_message = "no two trust-zone subnets may overlap"
+  }
+}
+
+resource "oci_core_vcn" "this" {
+  compartment_id = var.compartment_ocid
+  cidr_blocks    = [local.vcn_cidr]
+  display_name   = "platform-vcn"
+  dns_label      = "platform"
+
+  freeform_tags = { "provisioned-by" = "opentofu" }
+  defined_tags  = local.network_defined_tags
+
+  lifecycle {
+    prevent_destroy = true
+
+    # Same rationale as infrastructure/modules/foundation/state_backend.tf
+    # -- OCI's built-in Oracle-Tags namespace auto-injects
+    # CreatedBy/CreatedOn on every resource; ignore exactly those two
+    # keys, never the whole defined_tags attribute.
+    ignore_changes = [
+      defined_tags["Oracle-Tags.CreatedBy"],
+      defined_tags["Oracle-Tags.CreatedOn"],
+    ]
+  }
+}

--- a/infrastructure/modules/network/versions.tf
+++ b/infrastructure/modules/network/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "8.27.0"
+    }
+  }
+
+  # No backend block, deliberately -- same rationale as
+  # infrastructure/modules/foundation/versions.tf: Terragrunt's
+  # `remote_state { generate { path = "backend.tf" } }` (root.hcl) owns
+  # backend config once a live unit exists. A backend block here too
+  # would be a second declaration, which OpenTofu rejects outright
+  # ("Duplicate backend configuration").
+}


### PR DESCRIPTION
## Scope

`SPEC-NET-001` (REQ-NET-001..005) only: one VCN (`10.10.0.0/16`) and four
trust-zone subnets — Edge (`10.10.10.0/24`), Management (`10.10.20.0/24`),
Workload (`10.10.30.0/24`), Data (`10.10.40.0/24`) — per `ADR-0006`.

**Deliberately excluded**: gateways, route tables, NSGs, Security Lists,
DNS/DHCP, compute, DRG activation. `ADR-0007` already decided
`10-network` is one state unit covering `SPEC-NET-001`–`006`;
`infrastructure/modules/README.md` already documents this exact
incremental internal-file-organization pattern (`vcn.tf`/`subnets.tf`
now, `gateways.tf`/`routing.tf`/`security.tf`/`dns.tf` in later PRs
against the same module) — this PR follows that, not deviates from it.

## Design notes

- **CIDRs are hardcoded module locals, not variables.** REQ-NET-001/002
  use "MUST" language for exact values; ADR-0006 says preserve them
  exactly absent a superseding ADR. Exposing them as tunables would let
  an environment silently drift from the agreed trust-zone model.
- **Self-validating `check` block** (`vcn.tf`) proves the locals
  themselves: every CIDR syntactically valid, every subnet contained in
  the VCN, no duplicates/overlaps — using `cidrcontains`/`cidrhost`,
  confirmed against the pinned OpenTofu 1.12.5 via `tofu console` before
  writing any code, not assumed from memory or training data.
- **No route table / security list set on subnets** — both default to
  OCI's auto-created, empty ones. That's what "don't silently attach
  IGW/NAT/SGW routes yet" means in practice: nothing exists to attach
  until `SPEC-NET-002`/`003` land.
- **Terragrunt `dependency` block** (`infrastructure/live/.../10-network/terragrunt.hcl`)
  consumes `00-foundation`'s real `compartment_ocid` output — no
  duplicated/hardcoded compartment identity. `mock_outputs` scoped to
  `validate`/`plan`/`init` only, never `apply`. Confirmed via
  `terragrunt render --format json` that the dependency resolves
  correctly and the backend key computes to
  `oci/eu-madrid-1/lab/10-network/terraform.tfstate`.
- Same `Oracle-Tags.CreatedBy`/`CreatedOn` `ignore_changes` pattern as
  `infrastructure/modules/foundation/state_backend.tf` (PR #41),
  applied to the VCN and all four subnets.

## Tests

`tests/network.tftest.hcl` (positive): exact VCN/subnet CIDRs, Edge
allows public IP, Management/Workload/Data each independently assert
`prohibit_public_ip_on_vnic == true` (REQ-NET-003/004), no
`Oracle-Tags.*` key ever declared by this module, every resource lives
in the passed-in compartment.

`tests/network_negative.tftest.hcl`: only one real variable-driven
negative case exists (`environment`, `compartment_ocid`) — CIDRs are
locals, not variables, so there's no user-input surface for
malformed/overlapping-CIDR `expect_failures` tests the way
`foundation`'s string/OCID variables have. That protection is the
`check` block instead. README's "Tests" section explains this
explicitly rather than pretending the coverage exists where it can't.

## Free Tier

VCN and subnets: **FREE** — confirmed via
[Oracle's Always Free Resources docs](https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm)
(VCN explicitly Always Free, up to 2 per tenancy — we use 1; subnets
have never been a billed OCI resource type).

## Validation

- `tofu fmt -check -recursive`, `tofu validate`: pass
- `tofu test`: 10/10 pass
- `tflint`: 0 issues
- `checkov`: 1/1 pass (OCI's ruleset has no VCN/subnet-specific checks —
  only the generic provider check applies)
- `terragrunt hcl fmt --check` / `hcl validate`: pass
- `gitleaks`: no leaks
- `markdownlint`: 0 issues

No real plan generated yet in this environment (no OCI credentials
configured in GitHub Actions) — matches this repo's established pattern
for `plan.yml`. Real plan against the live tenancy to follow after
merge, with an apply-gate report. **No apply in this PR.**