### PR TITLE
docs: capture 00-foundation + 10-network deployed evidence

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -297,14 +297,16 @@ against the real `oracle/oci` v8.27.0 provider schema.
 
 See `live/` for the account/region/environment composition layer
 (`root.hcl`, `common/*.hcl`, `oci/eu-madrid-1/region.hcl`,
-`oci/eu-madrid-1/lab/env.hcl`) plus the first real unit,
-`oci/eu-madrid-1/lab/00-foundation/terragrunt.hcl` (PR B), wired to
-`modules/foundation`. Verified end-to-end with `terragrunt render`
-(includes resolve, `inputs` merge correctly, `generate` blocks produce
-valid provider/backend HCL) — not just `hcl fmt`/`hcl validate` syntax
-checks. `10-network`/`20-security/*` units still don't exist — each is
-added alongside its own module, so no `terragrunt.hcl` ever points at a
-`terraform { source = ... }` that doesn't exist.
+`oci/eu-madrid-1/lab/env.hcl`) plus the real units: `00-foundation` (PR
+B), wired to `modules/foundation`, and `10-network` (PR C), wired to
+`modules/network` via a Terragrunt `dependency` block consuming
+`00-foundation`'s real `compartment_ocid` output (`mock_outputs` scoped
+to `validate`/`plan`/`init` only, never `apply`). Both verified
+end-to-end with `terragrunt render` (inputs resolve, `generate` blocks
+produce valid provider/backend HCL) — not just `hcl fmt`/`hcl validate`
+syntax checks — and both are now real, deployed, `0/0/0`-plan-verified
+infrastructure; see "Apply gate" below. `20-security/*` units still
+don't exist — added alongside their own modules, same pattern.
 
 ## CI pipeline — current state and known gap
 
@@ -324,23 +326,49 @@ literally named `main.tf` (resources split by concern into
 added a real, non-empty navigational `main.tf` rather than change the
 discovery pattern.
 
-**Still a known gap, not fixed by this PR**: `plan.yml` currently runs a
-single `tofu plan` directly against the `lab` environment root — once
-`10-network`/`20-security/*` also have real `terragrunt.hcl` files, it
-needs to become Terragrunt-DAG-aware (`terragrunt run-all plan` or a
-per-unit loop in dependency order) so a PR touching `10-network` doesn't
-silently skip planning `20-security/logging-monitoring`'s dependency on
-it. Deferred to the PR that creates the second real unit — with only
-`00-foundation` existing, there's no DAG yet to be unaware of.
+**Fixed by PR B, confirmed still correct now that a real DAG exists (PR
+C)**: `plan.yml` runs `terragrunt run-all plan` from the `lab`
+environment root (`gruntwork-io/terragrunt-action`), not a single flat
+`tofu plan` — it resolves the `00-foundation` → `10-network` dependency
+order automatically. It still skips cleanly (not a false green) when
+`OCI_TENANCY_OCID` isn't configured as a GitHub Actions secret, which
+remains the case in this repo today.
 
-## Apply gate
+## Apply gate — deployed evidence
 
-Not reached by this PR. `modules/foundation` exists, is `tofu
-validate`/`tofu test`/`tflint`/`checkov`-clean, and its Terragrunt unit
-(`00-foundation`) renders correctly — but no real OCI credentials are
-configured in this environment, so no real `tofu plan` has ever been
-generated against actual OCI. Per the master execution prompt's APPLY
-GATE requirements, an ungenerated plan alone is sufficient to keep this
-gate closed regardless of how clean static validation is. See the phase-4
-PR B execution report for the current gate status and the full
-[Cause]→[Impact]→[Remediation] on the S3-compat locking finding.
+Both `00-foundation` and `10-network` are real, deployed, independently
+verified against the live tenancy — not just statically clean. This
+section records what "deployed" means here, since GitHub Actions still
+has no OCI credentials configured (`plan.yml` correctly skips there;
+every apply below ran from a local operator session with real `~/.oci`
+credentials and a Customer Secret Key for the S3-compat state backend).
+
+**`00-foundation`** (PR B/#38, dynamic-group and IAM-policy deferral
+fixes #39/#40, Oracle-Tags drift fix #41): 8 resources — platform
+compartment, `Platform`/`Security` tag namespaces, 4 tag definitions, the
+OpenTofu state bucket. Bootstrapped per REQ-OCI-007's two-phase sequence
+against an untracked scratch copy, state migrated into
+`oracle-free-tier-platform-tfstate`. Every resource independently
+confirmed via `oci` CLI (not just `tofu state`). A real `tofu plan`
+against the live tenancy returns `0 to add, 0 to change, 0 to destroy`.
+
+**`10-network`** (PR C/#43): 5 resources — one VCN (`10.10.0.0/16`) and
+four trust-zone subnets (Edge `10.10.10.0/24`, Management
+`10.10.20.0/24`, Workload `10.10.30.0/24`, Data `10.10.40.0/24`), each
+independently confirmed via `oci` CLI, including
+`prohibit-public-ip-on-vnic` per zone (`false` for Edge, `true` for the
+other three). `compartment_id` resolves through a real Terragrunt
+`dependency` block to `00-foundation`'s actual output, confirmed by
+inspecting the plan JSON directly rather than trusting the wiring. A real
+`tofu plan` against the live tenancy returns `0 to add, 0 to change, 0 to
+destroy`.
+
+**S3-compat backend locking**: still `use_lockfile = false`
+(unresolved conditional-write support, documented in `root.hcl`).
+Confirmed in practice during this bootstrap: the backend also exhibited
+transient `SignatureDoesNotMatch` failures for several minutes after each
+new Customer Secret Key's creation (IAM→Object-Storage-compat credential
+propagation lag, not a config defect — resolved on its own every time,
+confirmed by reproducing the same failure/success pattern independently
+via the AWS CLI). Single-writer discipline remains a hard requirement
+until this is revisited.

--- a/infrastructure/live/oci/eu-madrid-1/lab/00-foundation/.terraform.lock.hcl
+++ b/infrastructure/live/oci/eu-madrid-1/lab/00-foundation/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/oracle/oci" {
+  version     = "8.27.0"
+  constraints = "8.27.0"
+  hashes = [
+    "h1:AjL/F1LqP/NnqC/85zz/dpbwtOkyNxUmxPwor7Hkj9A=",
+    "h1:H7OoMqL2xxC7L2Yw2fEkFixQdbmcvPsdCgJMkIEpDNk=",
+    "h1:J2rPY5OC6lyOm5x9/4NZGwRObavf0K2tj1Z3XbSxfnc=",
+    "h1:K14lmG1OoKZ91MHJFCWLfG88j9qwn2QHgqYW705VEIM=",
+    "h1:KHD+5YqwHItc1wHGXS8Xc+/J/O42F7B4vo9O24ZgXAo=",
+    "h1:MxFf+EHJ0n5ynhddfuSOJzIhVNrGig5c/RiBoAQojPg=",
+    "h1:QrYgpQr9Vgd6sZ6WJi+jFDmSCfPtGil6+Oz84A+hWNA=",
+    "h1:T4zljEl0dK346N50cUUs4v65zg+KNRlPmehjd4G3GZY=",
+    "h1:eYektTaEIOl06Pes66VyCLXWq1J+kW8Wg0D+HkqzYUU=",
+    "h1:iUB9eoB/apT4/8nk/QKmg315yQSxkoXACZCH5KN4OL8=",
+    "h1:lGISh5fY2mqyPRkwmdksLX37VRs8sTA4OCbis9W6XVg=",
+    "h1:pJ7DmHo9MfhDM7gscoPE7OHqEKxwUNEwz2/A5ZOUUN0=",
+    "h1:xCGfRz9+0pHOj0tisklLK+2tQbRliTWnBfLFhOVwMBA=",
+    "zh:17aac70ae4c46bd85a285420414fac19a4fe42a340c95c1cf4ab6d29da71e656",
+    "zh:1cbbd87089cda3d67423927b431e4f0fceff17aa4dc13437909bbaaf306bd9f5",
+    "zh:1cd6fb7b78af954620eae64431d6f123f3dd701320bc3ab8cb6b47f1480d79b9",
+    "zh:3ca2f70cf877df758c3fca9b01138446728167e8cfba6556028e64df24903d37",
+    "zh:490588f364393c8e53d8621aeaf5c23d92c55d32ebca2b1d1a48d93b1cd3ff9d",
+    "zh:594cb7d04e1dde0ca0d848e1aa848ea136d0d9315cf77b2dd44df5af0e54156a",
+    "zh:69f58679129f332798c3f5a9f249c1dd4d4a0f80a44c89a540a1907e0ac5f1c9",
+    "zh:7a4f19a156084dc4ba8acf6117cee0de7c0d11574e99d2f6525df6da46f5d0d3",
+    "zh:8378cc00db7b0f9fa1007ba105122fb2d4c052947db1b1c65fb0a1111670c001",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a95ed489c8e00dbe950fb440dec6f51632b1401b738bd187384e33b3bcb393ad",
+    "zh:c1bc19afd167c54789d21777f6ed60b472acf7d3e2d50ebc8691e7a1cd90c4f4",
+    "zh:e1f7b2b516334ef070c6a94a85ce11560db9f2510f28128fc04b5ac724db3e55",
+    "zh:f2c19157c2b4a79aea8bf89e76f51f9363dd743fc8607f5d9b87684a47444c99",
+  ]
+}

--- a/infrastructure/live/oci/eu-madrid-1/lab/10-network/.terraform.lock.hcl
+++ b/infrastructure/live/oci/eu-madrid-1/lab/10-network/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/oracle/oci" {
+  version     = "8.27.0"
+  constraints = "8.27.0"
+  hashes = [
+    "h1:AjL/F1LqP/NnqC/85zz/dpbwtOkyNxUmxPwor7Hkj9A=",
+    "h1:H7OoMqL2xxC7L2Yw2fEkFixQdbmcvPsdCgJMkIEpDNk=",
+    "h1:J2rPY5OC6lyOm5x9/4NZGwRObavf0K2tj1Z3XbSxfnc=",
+    "h1:K14lmG1OoKZ91MHJFCWLfG88j9qwn2QHgqYW705VEIM=",
+    "h1:KHD+5YqwHItc1wHGXS8Xc+/J/O42F7B4vo9O24ZgXAo=",
+    "h1:MxFf+EHJ0n5ynhddfuSOJzIhVNrGig5c/RiBoAQojPg=",
+    "h1:QrYgpQr9Vgd6sZ6WJi+jFDmSCfPtGil6+Oz84A+hWNA=",
+    "h1:T4zljEl0dK346N50cUUs4v65zg+KNRlPmehjd4G3GZY=",
+    "h1:eYektTaEIOl06Pes66VyCLXWq1J+kW8Wg0D+HkqzYUU=",
+    "h1:iUB9eoB/apT4/8nk/QKmg315yQSxkoXACZCH5KN4OL8=",
+    "h1:lGISh5fY2mqyPRkwmdksLX37VRs8sTA4OCbis9W6XVg=",
+    "h1:pJ7DmHo9MfhDM7gscoPE7OHqEKxwUNEwz2/A5ZOUUN0=",
+    "h1:xCGfRz9+0pHOj0tisklLK+2tQbRliTWnBfLFhOVwMBA=",
+    "zh:17aac70ae4c46bd85a285420414fac19a4fe42a340c95c1cf4ab6d29da71e656",
+    "zh:1cbbd87089cda3d67423927b431e4f0fceff17aa4dc13437909bbaaf306bd9f5",
+    "zh:1cd6fb7b78af954620eae64431d6f123f3dd701320bc3ab8cb6b47f1480d79b9",
+    "zh:3ca2f70cf877df758c3fca9b01138446728167e8cfba6556028e64df24903d37",
+    "zh:490588f364393c8e53d8621aeaf5c23d92c55d32ebca2b1d1a48d93b1cd3ff9d",
+    "zh:594cb7d04e1dde0ca0d848e1aa848ea136d0d9315cf77b2dd44df5af0e54156a",
+    "zh:69f58679129f332798c3f5a9f249c1dd4d4a0f80a44c89a540a1907e0ac5f1c9",
+    "zh:7a4f19a156084dc4ba8acf6117cee0de7c0d11574e99d2f6525df6da46f5d0d3",
+    "zh:8378cc00db7b0f9fa1007ba105122fb2d4c052947db1b1c65fb0a1111670c001",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a95ed489c8e00dbe950fb440dec6f51632b1401b738bd187384e33b3bcb393ad",
+    "zh:c1bc19afd167c54789d21777f6ed60b472acf7d3e2d50ebc8691e7a1cd90c4f4",
+    "zh:e1f7b2b516334ef070c6a94a85ce11560db9f2510f28128fc04b5ac724db3e55",
+    "zh:f2c19157c2b4a79aea8bf89e76f51f9363dd743fc8607f5d9b87684a47444c99",
+  ]
+}


### PR DESCRIPTION
Both `00-foundation` and `10-network` are now real, deployed, independently
verified against the live tenancy. Updates `infrastructure/README.md`'s
Apply gate section (written before either apply happened) to record real
deployed evidence — masked OCIDs, 0/0/0 plans, the IAM-propagation-delay
operational note.

Also fixes two stale claims caught in passing: the Terragrunt live layout
section still said `10-network` didn't exist, and the CI pipeline section
still described `plan.yml` as a flat single `tofu plan` — both already
superseded by earlier merged work.

Docs-only, no infrastructure change.