### PR TITLE
feat: 10-network gateways + trust-zone route tables (PR C2)

### DIFF
--- a/infrastructure/modules/network/README.md
+++ b/infrastructure/modules/network/README.md
@@ -2,19 +2,21 @@
 
 ## Purpose
 
-Implements `SPEC-NET-001` (REQ-NET-001..005): the platform VCN and its
-four trust-zone subnets (Edge, Management, Workload, Data), as decided by
-`ADR-0006`. This is the second module in the state DAG — every downstream
-network Spec (`SPEC-NET-002` gateways, `SPEC-NET-003` route tables,
-`SPEC-NET-004` NSGs/Security Lists, `SPEC-NET-006` DNS/DHCP) and I04
-(compute) attach to the VCN/subnets this module creates. `ADR-0007`
-already decided `10-network` is one state unit covering all of
-`SPEC-NET-001` through `SPEC-NET-006` — this module is built incrementally
-across PRs against that same eventual state unit (this PR: `vcn.tf` +
-`subnets.tf` only; a later PR adds `gateways.tf`/`routing.tf`/
-`security.tf`/`dns.tf`), per `../README.md`'s own documented internal-
-file-organization note. Not a further-split target: OCI network topology
-within one VCN is provisioned and changed as a unit in practice.
+Implements `SPEC-NET-001` (REQ-NET-001..005, the platform VCN and its
+four trust-zone subnets), `SPEC-NET-002` (REQ-NET-006..010, gateways:
+Internet, NAT, Service, and an inert DRG), and `SPEC-NET-003`
+(REQ-NET-011..015, one route table per trust zone), as decided by
+`ADR-0006` and `ADR-0008`. This is the second module in the state DAG —
+`SPEC-NET-004` (NSGs/Security Lists) and `SPEC-NET-006` (DNS/DHCP) attach
+to what this module creates, and I04 (compute) attaches to its subnets/
+route tables. `ADR-0007` already decided `10-network` is one state unit
+covering all of `SPEC-NET-001` through `SPEC-NET-006` — this module is
+built incrementally across PRs against that same eventual state unit
+(PR C: `vcn.tf` + `subnets.tf`; PR C2, this one: `gateways.tf` +
+`routing.tf`; a later PR adds `security.tf`/`dns.tf`), per
+`../README.md`'s own documented internal-file-organization note. Not a
+further-split target: OCI network topology within one VCN is provisioned
+and changed as a unit in practice.
 
 ## Input contract
 
@@ -33,22 +35,30 @@ hardcoded constants, not tunables.
 
 | Output | Consumed by |
 | --- | --- |
-| `vcn_id` | `SPEC-NET-002` (gateways), `SPEC-NET-003` (route tables), `SPEC-NET-004` (NSGs/Security Lists) |
+| `vcn_id` | `SPEC-NET-004` (NSGs/Security Lists) |
 | `vcn_cidr` | downstream modules needing the VCN's own range (e.g. future DRG peering, I21) |
-| `subnet_ids` | map keyed by zone (`edge`/`management`/`workload`/`data`) — `SPEC-NET-002`/`SPEC-NET-004`/I04 attach resources to specific subnets by zone |
+| `subnet_ids` | map keyed by zone (`edge`/`management`/`workload`/`data`) — `SPEC-NET-004`/I04 attach resources to specific subnets by zone |
 | `subnet_cidrs` | map keyed by zone — downstream Security List/NSG rules referencing zone ranges |
+| `igw_id` / `nat_id` / `sgw_id` / `drg_id` | consumed internally by `routing.tf`; `drg_id` also for I21 once hybrid connectivity begins |
+| `drg_route_table_id` | I21 — the table it populates once hybrid routing activates |
+| `route_table_ids` | map keyed by zone — I04 (compute subnet attachment) |
 
 ## Resource ownership
 
 `oci_core_vcn` (1), `oci_core_subnet` (4, one per trust zone, via
-`for_each`).
+`for_each`), `oci_core_internet_gateway` (1), `oci_core_nat_gateway` (1),
+`oci_core_service_gateway` (1), `oci_core_drg` (1),
+`oci_core_drg_route_table` (1, empty — the inert mechanism),
+`oci_core_drg_attachment` (1), `oci_core_route_table` (4, one per trust
+zone, via `for_each`), `data.oci_core_services` (1, read-only — resolves
+the region's Services Network CIDR label).
 
-**Not owned here**: gateways (Internet/NAT/Service/DRG — `SPEC-NET-002`),
-route tables/associations (`SPEC-NET-003`), NSGs/Security Lists
-(`SPEC-NET-004`), DNS/DHCP options (`SPEC-NET-006`), compute attachment
-(I04). Subnets use OCI's auto-created default route table (empty — no
-gateway routes exist yet) and default security list until those Specs'
-files are added to this same module.
+**Not owned here**: NSGs/Security Lists (`SPEC-NET-004`), DNS/DHCP
+options (`SPEC-NET-006`), compute attachment (I04), any DRG route
+rule/distribution (I21 — this module creates the DRG attached-but-empty,
+never populates it). Subnets use OCI's default security list (unchanged
+until `SPEC-NET-004`) but no longer the default route table — each now
+has its own zone-specific one (`routing.tf`).
 
 ## Security invariants
 
@@ -75,8 +85,99 @@ files are added to this same module.
   against the pinned OpenTofu 1.12.5 (`tofu console`), not assumed.
 - **Tag ownership**: same OCI-managed-vs-Platform-managed split as
   `infrastructure/modules/foundation/state_backend.tf` — `lifecycle.ignore_changes`
-  on exactly `Oracle-Tags.CreatedBy`/`Oracle-Tags.CreatedOn`, on both the
-  VCN and every subnet, never the whole `defined_tags` attribute.
+  on exactly `Oracle-Tags.CreatedBy`/`Oracle-Tags.CreatedOn`, on every
+  resource this module creates, never the whole `defined_tags` attribute.
+- **REQ-NET-010/013 (binding control)**: no route table other than Edge
+  may ever reference the Internet Gateway. Enforced structurally, not
+  just by convention — every route table's rule set is built from one
+  shared `local.route_tables` map (`routing.tf`), so there is exactly one
+  place an accidental Internet Gateway rule could be added to a
+  non-Edge zone, and `tests/routing.tftest.hcl`'s
+  `management_workload_data_never_reference_the_internet_gateway` asserts
+  the *absence* directly — not merely that a NAT rule is also present,
+  which alone wouldn't catch a table carrying both.
+- **REQ-NET-009/ADR-0008 (DRG inertness)**: the DRG attachment references
+  this module's own `oci_core_drg_route_table.inert`, which carries zero
+  static routes (no `oci_core_drg_route_table_route_rule` resource exists
+  in this module) and no `import_drg_route_distribution_id` (unset —
+  no propagation configured). Both together are what "present but inert"
+  means. `mock_provider` cannot prove the second half of this (see
+  `tests/gateways.tftest.hcl`'s `drg_route_table_is_inert` comment) —
+  verified against the real provider in the PR C2 deployment report
+  instead.
+- **REQ-NET-008/014 (Service Gateway target)**: the Services Network CIDR
+  label is resolved via `data.oci_core_services` and matched by name
+  pattern (`"All .* Services In Oracle Services Network"`), never
+  hardcoded — keeps this module region-neutral and fails loudly (a
+  `null` attribute-access error) if OCI's API shape ever changes rather
+  than silently misconfiguring the Service Gateway.
+- **REQ-NET-011**: every subnet's `route_table_id` now points at its own
+  zone's explicit route table (`subnets.tf`), never the VCN default —
+  audited against the live tenancy before this change (all four subnets
+  previously fell back to the empty default route table).
+
+## Requirement traceability
+
+| REQ | Spec | ADR | ARCH-* | Threat-model flow | OCI resource | OpenTofu address | Test |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| REQ-NET-001 | SPEC-NET-001 | ADR-0006 | ARCH-NET-VCN | — | VCN | `oci_core_vcn.this` | `vcn_has_exact_cidr` |
+| REQ-NET-002 | SPEC-NET-001 | ADR-0006 | ARCH-ZONE-* | — | Subnet ×4 | `oci_core_subnet.this` | `four_subnets_with_exact_cidrs` |
+| REQ-NET-003 | SPEC-NET-001 | ADR-0006 | ARCH-ZONE-MGMT/WORKLOAD/DATA | — | Subnet | `prohibit_public_ip_on_vnic` | `{mgmt,workload,data}_subnet_prohibits_public_ip` |
+| REQ-NET-004 | SPEC-NET-001 | ADR-0006 | ARCH-ZONE-EDGE | ARCH-FLOW-INGRESS (RED) | Subnet | `prohibit_public_ip_on_vnic` | `edge_subnet_allows_public_ip` |
+| REQ-NET-005 | SPEC-NET-001 | — | — | — | (output contract) | `outputs.tf` | n/a — structural |
+| REQ-NET-006 | SPEC-NET-002 | — | ARCH-FLOW-INGRESS (RED) | ARCH-FLOW-INGRESS | Internet Gateway | `oci_core_internet_gateway.this` | `internet_gateway_enabled` |
+| REQ-NET-007 | SPEC-NET-002 | — | ARCH-FLOW-EGRESS (GREEN) | ARCH-FLOW-EGRESS | NAT Gateway | `oci_core_nat_gateway.this` | `nat_gateway_exists` |
+| REQ-NET-008 | SPEC-NET-002 | — | ARCH-FLOW-SERVICE (BLUE) | ARCH-FLOW-SERVICE | Service Gateway | `oci_core_service_gateway.this` | `service_gateway_targets_all_services` |
+| REQ-NET-009 | SPEC-NET-002 | ADR-0008 | ARCH-FLOW-HYBRID (ORANGE) | ARCH-FLOW-HYBRID | DRG + attachment + empty DRG RT | `oci_core_drg.this` / `.inert` / `.vcn` | `drg_exists_and_is_attached`, `drg_route_table_is_inert` |
+| REQ-NET-010 | SPEC-NET-002 | — | ARCH-FLOW-INGRESS | ARCH-FLOW-INGRESS | (constraint on all gateways) | n/a — no other gateway carries a `0.0.0.0/0` inbound rule by construction | covered by route-table tests, not a gateway-object test |
+| REQ-NET-011 | SPEC-NET-003 | ADR-0006 | ARCH-ZONE-* | — | Route Table ×4 | `oci_core_route_table.this` | `four_route_tables_one_per_zone`, `every_subnet_uses_its_own_zone_route_table_not_the_default` |
+| REQ-NET-012 | SPEC-NET-003 | — | ARCH-FLOW-INGRESS (RED) | ARCH-FLOW-INGRESS | Route rule (Edge → IGW) | `oci_core_route_table.this["edge"]` | `edge_route_table_routes_internet_to_igw` |
+| REQ-NET-013 | SPEC-NET-003 | — | ARCH-FLOW-EGRESS (GREEN) | ARCH-FLOW-EGRESS | Route rule (Mgmt/Workload/Data → NAT, never IGW) | `oci_core_route_table.this[zone]` | `management_workload_data_never_reference_the_internet_gateway`, `management_workload_data_route_internet_to_nat_only` |
+| REQ-NET-014 | SPEC-NET-003 | — | ARCH-FLOW-SERVICE (BLUE) | ARCH-FLOW-SERVICE | Route rule (all zones → SGW) | `oci_core_route_table.this[*]` | `all_four_zones_route_services_cidr_to_service_gateway` |
+| REQ-NET-015 | SPEC-NET-003 | ADR-0008 | ARCH-FLOW-HYBRID (ORANGE) | ARCH-FLOW-HYBRID | (reserved slot, unpopulated) | n/a — no resource by design | `no_route_table_references_the_drg` |
+
+No orphan infrastructure: every resource and route rule in `gateways.tf`/
+`routing.tf` traces to one of the rows above. Nothing was added that
+isn't required by REQ-NET-006 through REQ-NET-015.
+
+## Route matrix
+
+| Source zone | Destination class | Next hop | Destination prefix/service | Flow class | REQ | Implemented now? |
+| --- | --- | --- | --- | --- | --- | --- |
+| Edge | Internet | Internet Gateway | `0.0.0.0/0` | RED (INGRESS)/GREEN (EGRESS) | REQ-NET-012 | Yes |
+| Edge | OCI services | Service Gateway | Services Network CIDR label | BLUE (SERVICE) | REQ-NET-014 | Yes |
+| Management | Internet (egress only) | NAT Gateway | `0.0.0.0/0` | GREEN (EGRESS) | REQ-NET-013 | Yes |
+| Management | OCI services | Service Gateway | Services Network CIDR label | BLUE (SERVICE) | REQ-NET-014 | Yes |
+| Management | future on-prem/other-cloud | DRG | (reserved, unpopulated) | ORANGE (HYBRID) | REQ-NET-015 | No — I21 |
+| Workload | Internet (egress only) | NAT Gateway | `0.0.0.0/0` | GREEN (EGRESS) | REQ-NET-013 | Yes |
+| Workload | OCI services | Service Gateway | Services Network CIDR label | BLUE (SERVICE) | REQ-NET-014 | Yes |
+| Data | Internet (egress only) | NAT Gateway | `0.0.0.0/0` | GREEN (EGRESS) | REQ-NET-013 | Yes |
+| Data | OCI services (incl. backup) | Service Gateway | Services Network CIDR label | BLUE (SERVICE)/BLUE (BACKUP) | REQ-NET-014 | Yes |
+
+No unexplained `0.0.0.0/0` — every occurrence above is either Edge→IGW
+(REQ-NET-012, the only place it's allowed) or Management/Workload/Data→NAT
+(REQ-NET-013, explicitly never IGW).
+
+## Traffic-flow reconciliation (post–PR C2)
+
+Using `docs/01-architecture/traceability.md`'s RED/GREEN/BLUE/PURPLE/
+ORANGE taxonomy (`ARCH-FLOW-*` → color mapping) — no new taxonomy
+invented here:
+
+- **Physically exist (routable) after PR C2**: RED (`ARCH-FLOW-INGRESS`),
+  GREEN (`ARCH-FLOW-EGRESS`), BLUE (`ARCH-FLOW-SERVICE`/`-BACKUP`).
+- **Routable but not yet authorized**: the same three — routes exist, but
+  no Security List/NSG (`SPEC-NET-004`, PR C3) has been added yet, so
+  "routable" is not "permitted." The shared default Security List (audited
+  against the live tenancy, unchanged by this PR) still allows SSH
+  (22/tcp) and ICMP from `0.0.0.0/0` on every subnet — harmless today
+  (nothing listens), a real gap PR C3 must close.
+- **Remain physically impossible**: PURPLE (`ARCH-FLOW-ADMIN`/`-CONTROL`)
+  — no OpenZiti, no compute/Talos exists yet (I04/I08/M2); this module
+  creates no path for either.
+- **Intentionally deferred**: ORANGE (`ARCH-FLOW-HYBRID`) — DRG present,
+  attached, and inert by construction (ADR-0008); zero routes reference it
+  anywhere in this module.
 
 ## Validation
 
@@ -97,6 +198,19 @@ tofu test
 - **CIDR self-check failure**: `tofu plan`/`apply` fails before any API
   call — the `check` block runs against the locals directly, so a bad
   hand-edit is caught before it ever reaches OCI.
+- **Service Gateway target lookup fails** (`data.oci_core_services`
+  returns no match for the `"All .* Services In Oracle Services Network"`
+  pattern): `local.all_services_in_oracle_services_network` evaluates to
+  `null`, and referencing `.id`/`.cidr_block` on it fails loudly with an
+  "Attempt to get attribute from null value" error at plan time — never a
+  silently misconfigured Service Gateway route. Not currently unit-testable
+  (see `tests/gateways.tftest.hcl`'s mock limitations note); would need
+  a real API response change to trigger.
+- **Partial apply mid-gateway-creation**: each gateway is its own
+  resource (no `for_each`/`count` linking them), so a failure creating,
+  say, the NAT Gateway leaves the Internet Gateway and Service Gateway
+  correctly in state — re-running `tofu apply` retries only what's
+  missing.
 
 ## Upgrade expectations
 
@@ -104,7 +218,10 @@ Changing any subnet's CIDR or the VCN's CIDR forces replacement (OCI VCN/
 subnet CIDRs are immutable) — destructive, and per REQ-NET-001/002 should
 only ever happen via a superseding ADR, never a casual edit. Changing
 `environment` updates the `Platform.Environment` tag value in place (no
-replacement).
+replacement). Changing a subnet's `route_table_id` (e.g. reassigning
+which route table a zone uses) is an in-place update, not a replacement —
+OCI subnets don't force-replace on route table changes; restoring the
+prior route table ID is the rollback path, not `tofu destroy`.
 
 ## Example
 
@@ -134,3 +251,32 @@ duplication protection is enforced by `vcn.tf`'s `check` block instead
 (see Security invariants). This file's negative tests instead cover the
 one real variable-driven invariant this module has: rejecting an invalid
 `environment` value.
+
+`tests/gateways.tftest.hcl` (positive): Internet Gateway enabled, NAT
+Gateway attached, Service Gateway resolves the real Services CIDR label
+(not hardcoded), DRG attached to the VCN specifically, DRG attachment
+references this module's own empty DRG route table, no gateway carries
+an `Oracle-Tags.*` key. Does **not** test that the DRG route table's
+`import_drg_route_distribution_id` stays null — `mock_provider`
+synthesizes a plausible fake value for every computed attribute
+regardless of whether config leaves it unset (confirmed empirically,
+same class of constraint as `foundation`'s `ignore_changes`-on-a-
+config-set-attribute limitation) — verified against the real provider
+in the PR C2 deployment report instead.
+
+`tests/routing.tftest.hcl` (positive; doubles as the negative-shaped
+security tests — see below): four route tables exist, every subnet uses
+its own zone's table rather than the default, Edge routes `0.0.0.0/0` to
+the Internet Gateway, all four zones route the Services CIDR label to
+the Service Gateway, no route table references the DRG. The single most
+important assertion —
+`management_workload_data_never_reference_the_internet_gateway` — is
+written as a positive assertion of an *absence*, which is what actually
+proves REQ-NET-013's binding control; a presence-only check for the NAT
+rule wouldn't catch a table that had both. No separate
+`routing_negative.tftest.hcl` exists: this module's route rules are
+built entirely from hardcoded locals (`local.route_tables`), not
+variables, so there's no user-input surface for `expect_failures`-style
+malformed/overlapping-route negative tests the way `foundation`'s
+string/OCID variables have — the same reasoning as `network_negative.tftest.hcl`
+above, applied to routing.

--- a/infrastructure/modules/network/gateways.tf
+++ b/infrastructure/modules/network/gateways.tf
@@ -1,0 +1,138 @@
+# SPEC-NET-002 (REQ-NET-006..010): Internet Gateway, NAT Gateway, Service
+# Gateway, and an inert Dynamic Routing Gateway. Route-table wiring is
+# routing.tf (SPEC-NET-003) -- this file only creates the gateway objects
+# themselves, per SPEC-NET-002's own Non-Goals.
+
+resource "oci_core_internet_gateway" "this" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "platform-igw"
+  enabled        = true
+
+  freeform_tags = { "provisioned-by" = "opentofu" }
+  defined_tags  = local.network_defined_tags
+
+  lifecycle {
+    ignore_changes = [
+      defined_tags["Oracle-Tags.CreatedBy"],
+      defined_tags["Oracle-Tags.CreatedOn"],
+    ]
+  }
+}
+
+resource "oci_core_nat_gateway" "this" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "platform-nat"
+
+  freeform_tags = { "provisioned-by" = "opentofu" }
+  defined_tags  = local.network_defined_tags
+
+  lifecycle {
+    ignore_changes = [
+      defined_tags["Oracle-Tags.CreatedBy"],
+      defined_tags["Oracle-Tags.CreatedOn"],
+    ]
+  }
+}
+
+# REQ-NET-008: private access to OCI services (Object Storage, KMS,
+# Logging, Monitoring) without traversing the internet. The Services
+# Network CIDR label is a per-region OCI construct, looked up rather than
+# hardcoded -- data.oci_core_services below.
+data "oci_core_services" "all" {}
+
+locals {
+  # The OCI Services Network exposes exactly one "All <REGION> Services In
+  # Oracle Services Network" entry per region -- matched by name pattern,
+  # not a hardcoded per-region ID, so this module stays region-neutral.
+  all_services_in_oracle_services_network = one([
+    for s in data.oci_core_services.all.services : s
+    if can(regex("All .* Services In Oracle Services Network", s.name))
+  ])
+}
+
+resource "oci_core_service_gateway" "this" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "platform-sgw"
+
+  services {
+    service_id = local.all_services_in_oracle_services_network.id
+  }
+
+  freeform_tags = { "provisioned-by" = "opentofu" }
+  defined_tags  = local.network_defined_tags
+
+  lifecycle {
+    ignore_changes = [
+      defined_tags["Oracle-Tags.CreatedBy"],
+      defined_tags["Oracle-Tags.CreatedOn"],
+    ]
+  }
+}
+
+# REQ-NET-009/ADR-0008 (Option B): DRG created and attached now, reserved
+# for I21 hybrid connectivity, but INERT in M1 -- "inert" means the DRG's
+# own route table holds zero route rules and has no import route
+# distribution configured (no propagation), not that the attachment
+# itself is absent. OCI requires every DRG attachment to reference a DRG
+# route table (an attachment can't have "no association"), so this empty
+# table IS the inert mechanism, not a placeholder to fill in later without
+# review.
+resource "oci_core_drg" "this" {
+  compartment_id = var.compartment_ocid
+  display_name   = "platform-drg"
+
+  freeform_tags = { "provisioned-by" = "opentofu" }
+  defined_tags  = local.network_defined_tags
+
+  lifecycle {
+    ignore_changes = [
+      defined_tags["Oracle-Tags.CreatedBy"],
+      defined_tags["Oracle-Tags.CreatedOn"],
+    ]
+  }
+}
+
+resource "oci_core_drg_route_table" "inert" {
+  drg_id       = oci_core_drg.this.id
+  display_name = "platform-drg-rt-inert"
+
+  # import_drg_route_distribution_id deliberately unset: no route
+  # distribution means no propagation into this table -- REQ-NET-009's
+  # "propagation disabled" requirement. No oci_core_drg_route_table_route_rule
+  # resource references this table either, so it also carries zero static
+  # routes. Both together are what ADR-0008 means by "present but inert."
+
+  freeform_tags = { "provisioned-by" = "opentofu" }
+  defined_tags  = local.network_defined_tags
+
+  lifecycle {
+    ignore_changes = [
+      defined_tags["Oracle-Tags.CreatedBy"],
+      defined_tags["Oracle-Tags.CreatedOn"],
+    ]
+  }
+}
+
+resource "oci_core_drg_attachment" "vcn" {
+  drg_id             = oci_core_drg.this.id
+  display_name       = "platform-drg-attachment"
+  drg_route_table_id = oci_core_drg_route_table.inert.id
+
+  network_details {
+    type = "VCN"
+    id   = oci_core_vcn.this.id
+  }
+
+  freeform_tags = { "provisioned-by" = "opentofu" }
+  defined_tags  = local.network_defined_tags
+
+  lifecycle {
+    ignore_changes = [
+      defined_tags["Oracle-Tags.CreatedBy"],
+      defined_tags["Oracle-Tags.CreatedOn"],
+    ]
+  }
+}

--- a/infrastructure/modules/network/main.tf
+++ b/infrastructure/modules/network/main.tf
@@ -9,4 +9,6 @@
 #   vcn.tf       REQ-NET-001 -- the platform VCN; also the CIDR/tag locals
 #                and the check block self-validating them
 #   subnets.tf   REQ-NET-002/003/004 -- the four trust-zone subnets
+#   gateways.tf  REQ-NET-006..010 -- Internet/NAT/Service Gateway, inert DRG
+#   routing.tf   REQ-NET-011..015 -- one route table per trust zone
 #   variables.tf / outputs.tf / versions.tf -- standard module contract

--- a/infrastructure/modules/network/outputs.tf
+++ b/infrastructure/modules/network/outputs.tf
@@ -20,3 +20,38 @@ output "subnet_cidrs" {
   value       = local.subnet_cidrs
   description = "Subnet CIDRs keyed by trust-zone name (REQ-NET-002)."
 }
+
+# SPEC-NET-002 Interfaces: igw_id, nat_id, sgw_id, drg_id -- consumed by
+# SPEC-NET-003 (route tables, already wired internally in this module)
+# and by I04/I21 once compute/hybrid connectivity exist.
+output "igw_id" {
+  value       = oci_core_internet_gateway.this.id
+  description = "OCID of the Internet Gateway (REQ-NET-006)."
+}
+
+output "nat_id" {
+  value       = oci_core_nat_gateway.this.id
+  description = "OCID of the NAT Gateway (REQ-NET-007)."
+}
+
+output "sgw_id" {
+  value       = oci_core_service_gateway.this.id
+  description = "OCID of the Service Gateway (REQ-NET-008)."
+}
+
+output "drg_id" {
+  value       = oci_core_drg.this.id
+  description = "OCID of the DRG (REQ-NET-009) -- attached but inert until I21; see ADR-0008."
+}
+
+output "drg_route_table_id" {
+  value       = oci_core_drg_route_table.inert.id
+  description = "OCID of the DRG's own (empty, no-propagation) route table -- REQ-NET-009's inert mechanism."
+}
+
+# SPEC-NET-003 Interfaces: route_table_ids{edge,management,workload,data}
+# -- consumed by I04 (compute subnet attachment).
+output "route_table_ids" {
+  value       = { for zone, rt in oci_core_route_table.this : zone => rt.id }
+  description = "Route table OCIDs keyed by trust-zone name (REQ-NET-011)."
+}

--- a/infrastructure/modules/network/routing.tf
+++ b/infrastructure/modules/network/routing.tf
@@ -1,0 +1,106 @@
+# SPEC-NET-003 (REQ-NET-011..015): one route table per trust zone. No
+# subnet uses the VCN's default route table (audited against the live
+# tenancy before writing this file: all four subnets currently fall back
+# to it, empty, since PR C created no explicit route table -- this file
+# is what stops relying on that default).
+#
+# REQ-NET-012/013 is the binding security control: Edge is the ONLY route
+# table that may ever reference the Internet Gateway. This is enforced
+# structurally, not just by convention -- local.route_tables below is the
+# single source every route table's rule set is built from, so there is
+# exactly one place an Internet Gateway rule could be added to a
+# non-Edge zone, and tests/routing.tftest.hcl asserts against it directly.
+locals {
+  # REQ-NET-014: all four zones route the OCI Services Network CIDR label
+  # to the Service Gateway -- defined once, appended to every zone's rule
+  # list below rather than repeated per zone.
+  service_gateway_route_rule = {
+    destination       = local.all_services_in_oracle_services_network.cidr_block
+    destination_type  = "SERVICE_CIDR_BLOCK"
+    network_entity_id = oci_core_service_gateway.this.id
+    description       = "REQ-NET-014: OCI services via Service Gateway"
+  }
+
+  route_tables = {
+    edge = {
+      display_name = "platform-edge-rt"
+      route_rules = [
+        {
+          destination       = "0.0.0.0/0"
+          destination_type  = "CIDR_BLOCK"
+          network_entity_id = oci_core_internet_gateway.this.id
+          description       = "REQ-NET-012: internet-bound traffic via Internet Gateway"
+        },
+        local.service_gateway_route_rule,
+      ]
+    }
+    management = {
+      display_name = "platform-management-rt"
+      route_rules = [
+        {
+          destination       = "0.0.0.0/0"
+          destination_type  = "CIDR_BLOCK"
+          network_entity_id = oci_core_nat_gateway.this.id
+          description       = "REQ-NET-013: internet-bound traffic via NAT Gateway only"
+        },
+        local.service_gateway_route_rule,
+        # REQ-NET-015: reserved slot for a future DRG route once I21
+        # activates hybrid connectivity (ADR-0008) -- intentionally
+        # unpopulated here, not a placeholder resource, just documented
+        # absence so I21 doesn't need to re-shape this route table later.
+      ]
+    }
+    workload = {
+      display_name = "platform-workload-rt"
+      route_rules = [
+        {
+          destination       = "0.0.0.0/0"
+          destination_type  = "CIDR_BLOCK"
+          network_entity_id = oci_core_nat_gateway.this.id
+          description       = "REQ-NET-013: internet-bound traffic via NAT Gateway only"
+        },
+        local.service_gateway_route_rule,
+      ]
+    }
+    data = {
+      display_name = "platform-data-rt"
+      route_rules = [
+        {
+          destination       = "0.0.0.0/0"
+          destination_type  = "CIDR_BLOCK"
+          network_entity_id = oci_core_nat_gateway.this.id
+          description       = "REQ-NET-013: internet-bound traffic via NAT Gateway only"
+        },
+        local.service_gateway_route_rule,
+      ]
+    }
+  }
+}
+
+resource "oci_core_route_table" "this" {
+  for_each = local.route_tables
+
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = each.value.display_name
+
+  dynamic "route_rules" {
+    for_each = each.value.route_rules
+    content {
+      destination       = route_rules.value.destination
+      destination_type  = route_rules.value.destination_type
+      network_entity_id = route_rules.value.network_entity_id
+      description       = route_rules.value.description
+    }
+  }
+
+  freeform_tags = { "provisioned-by" = "opentofu" }
+  defined_tags  = local.network_defined_tags
+
+  lifecycle {
+    ignore_changes = [
+      defined_tags["Oracle-Tags.CreatedBy"],
+      defined_tags["Oracle-Tags.CreatedOn"],
+    ]
+  }
+}

--- a/infrastructure/modules/network/subnets.tf
+++ b/infrastructure/modules/network/subnets.tf
@@ -4,13 +4,20 @@
 # OpenZiti-edge-router VNIC exists yet (that attachment is SPEC-NET-004
 # scope, explicitly out of this module's Non-Goals for now).
 #
-# No route_table_id/security_list_ids set on any subnet: each gets OCI's
-# auto-created default route table (empty -- no gateway routes exist
-# until SPEC-NET-002/003 add them) and default security list. This is
-# what "the module must not silently attach IGW/NAT/SGW routes yet"
-# means in practice -- there is nothing to attach until those Specs'
-# modules exist, so the safe default is exactly what OCI already does
-# for an unconfigured subnet.
+# route_table_id: each subnet now uses its own zone's explicit route
+# table (REQ-NET-011, routing.tf) instead of the VCN's default -- audited
+# against the live tenancy before this change: all four subnets
+# previously fell back to the default route table (empty, 0 rules), so
+# this is an in-place update (route_table_id changes from the implicit
+# default to an explicit OCID), not a replacement -- OCI subnets don't
+# force-replace on route_table_id changes.
+#
+# security_list_ids still unset: each subnet keeps the VCN's default
+# security list until SPEC-NET-004 (PR C3) assigns explicit ones. That
+# default list currently allows SSH (22/tcp) and ICMP from 0.0.0.0/0 on
+# every subnet -- audited against the live tenancy, not assumed --
+# harmless today (nothing listens on any subnet yet) but a real,
+# documented gap PR C3 must close, not silently inherit.
 locals {
   subnet_public_allowed = {
     edge       = true
@@ -28,6 +35,7 @@ resource "oci_core_subnet" "this" {
   cidr_block     = each.value
   display_name   = "platform-${each.key}"
   dns_label      = each.key
+  route_table_id = oci_core_route_table.this[each.key].id
 
   prohibit_public_ip_on_vnic = !local.subnet_public_allowed[each.key]
 

--- a/infrastructure/modules/network/tests/gateways.tftest.hcl
+++ b/infrastructure/modules/network/tests/gateways.tftest.hcl
@@ -1,0 +1,101 @@
+# Positive tests for SPEC-NET-002 (REQ-NET-006..010): the four gateway
+# objects and the DRG's inert configuration.
+
+mock_provider "oci" {
+  override_data {
+    target = data.oci_core_services.all
+    values = {
+      services = [
+        {
+          id          = "ocid1.service.oc1..aaaaaaaamockallservices"
+          name        = "All EU-MADRID-1 Services In Oracle Services Network"
+          cidr_block  = "all-eu-madrid-1-services-in-oracle-services-network"
+          description = "mock -- REQ-NET-008 Service Gateway target"
+        },
+      ]
+    }
+  }
+}
+
+variables {
+  compartment_ocid = "ocid1.compartment.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
+  environment      = "lab"
+}
+
+run "internet_gateway_enabled" {
+  command = plan
+
+  assert {
+    condition     = oci_core_internet_gateway.this.enabled == true
+    error_message = "REQ-NET-006: the Internet Gateway must exist and be enabled"
+  }
+}
+
+run "nat_gateway_exists" {
+  command = plan
+
+  assert {
+    condition     = oci_core_nat_gateway.this.vcn_id == oci_core_vcn.this.id
+    error_message = "REQ-NET-007: the NAT Gateway must be attached to the platform VCN"
+  }
+}
+
+run "service_gateway_targets_all_services" {
+  command = plan
+
+  assert {
+    condition     = tolist(oci_core_service_gateway.this.services)[0].service_id == "ocid1.service.oc1..aaaaaaaamockallservices"
+    error_message = "REQ-NET-008: the Service Gateway must target the OCI Services Network CIDR label, resolved via data.oci_core_services, not hardcoded"
+  }
+}
+
+run "drg_exists_and_is_attached" {
+  command = plan
+
+  assert {
+    condition     = oci_core_drg_attachment.vcn.drg_id == oci_core_drg.this.id
+    error_message = "REQ-NET-009: the DRG must be attached to the VCN"
+  }
+
+  assert {
+    condition     = tolist(oci_core_drg_attachment.vcn.network_details)[0].type == "VCN"
+    error_message = "REQ-NET-009: the DRG attachment must attach the VCN specifically"
+  }
+}
+
+run "drg_route_table_is_inert" {
+  command = plan
+
+  assert {
+    condition     = oci_core_drg_attachment.vcn.drg_route_table_id == oci_core_drg_route_table.inert.id
+    error_message = "REQ-NET-009/ADR-0008: the DRG attachment must reference this module's own empty DRG route table, not the account default"
+  }
+
+  # What this run does NOT and cannot test: that
+  # import_drg_route_distribution_id stays null (REQ-NET-009's "no
+  # propagation" requirement). mock_provider synthesizes a plausible fake
+  # value for every computed attribute regardless of whether this
+  # module's config leaves it unset -- confirmed empirically (the mock
+  # always returns a non-null synthetic ID here, identical in kind to the
+  # defined_tags/ignore_changes constraint documented in
+  # infrastructure/modules/foundation/tests/state_bucket_tag_ownership.tftest.hcl).
+  # The only source of truth for "genuinely unset" vs. "computed" is the
+  # real provider. Verified instead by (a) this module's own gateways.tf
+  # never declaring an oci_core_drg_route_distribution resource at all --
+  # grep-verifiable, not runtime-verifiable -- and (b) the real
+  # post-apply plan/OCI CLI check in the PR C2 deployment report.
+}
+
+run "gateways_carry_no_oracle_managed_tag_keys" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      !anytrue([for k in keys(oci_core_internet_gateway.this.defined_tags) : strcontains(k, "Oracle-Tags")]),
+      !anytrue([for k in keys(oci_core_nat_gateway.this.defined_tags) : strcontains(k, "Oracle-Tags")]),
+      !anytrue([for k in keys(oci_core_service_gateway.this.defined_tags) : strcontains(k, "Oracle-Tags")]),
+      !anytrue([for k in keys(oci_core_drg.this.defined_tags) : strcontains(k, "Oracle-Tags")]),
+    ])
+    error_message = "this module must never itself declare an Oracle-Tags.* key on any gateway resource"
+  }
+}

--- a/infrastructure/modules/network/tests/network.tftest.hcl
+++ b/infrastructure/modules/network/tests/network.tftest.hcl
@@ -1,7 +1,21 @@
 # Positive tests -- module contract at plan time, no real OCI credentials
 # required (mock_provider stands in for the real provider).
 
-mock_provider "oci" {}
+mock_provider "oci" {
+  override_data {
+    target = data.oci_core_services.all
+    values = {
+      services = [
+        {
+          id          = "ocid1.service.oc1..aaaaaaaamockallservices"
+          name        = "All EU-MADRID-1 Services In Oracle Services Network"
+          cidr_block  = "all-eu-madrid-1-services-in-oracle-services-network"
+          description = "mock -- REQ-NET-008 Service Gateway target"
+        },
+      ]
+    }
+  }
+}
 
 variables {
   compartment_ocid = "ocid1.compartment.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"

--- a/infrastructure/modules/network/tests/network_negative.tftest.hcl
+++ b/infrastructure/modules/network/tests/network_negative.tftest.hcl
@@ -8,7 +8,21 @@
 # check block fails `tofu test` outright, since `tofu validate`/`plan`
 # would fail first).
 
-mock_provider "oci" {}
+mock_provider "oci" {
+  override_data {
+    target = data.oci_core_services.all
+    values = {
+      services = [
+        {
+          id          = "ocid1.service.oc1..aaaaaaaamockallservices"
+          name        = "All EU-MADRID-1 Services In Oracle Services Network"
+          cidr_block  = "all-eu-madrid-1-services-in-oracle-services-network"
+          description = "mock -- REQ-NET-008 Service Gateway target"
+        },
+      ]
+    }
+  }
+}
 
 variables {
   compartment_ocid = "ocid1.compartment.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"

--- a/infrastructure/modules/network/tests/routing.tftest.hcl
+++ b/infrastructure/modules/network/tests/routing.tftest.hcl
@@ -1,0 +1,132 @@
+# Positive tests for SPEC-NET-003 (REQ-NET-011..015). REQ-NET-013 ("no
+# route table other than Edge references the Internet Gateway") is the
+# binding security control -- tested here by positively asserting its
+# absence on Management/Workload/Data, not merely asserting the NAT route
+# is present (a table could have both and still pass a presence-only
+# check).
+
+mock_provider "oci" {
+  override_data {
+    target = data.oci_core_services.all
+    values = {
+      services = [
+        {
+          id          = "ocid1.service.oc1..aaaaaaaamockallservices"
+          name        = "All EU-MADRID-1 Services In Oracle Services Network"
+          cidr_block  = "all-eu-madrid-1-services-in-oracle-services-network"
+          description = "mock -- REQ-NET-008 Service Gateway target"
+        },
+      ]
+    }
+  }
+}
+
+variables {
+  compartment_ocid = "ocid1.compartment.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
+  environment      = "lab"
+}
+
+run "four_route_tables_one_per_zone" {
+  command = plan
+
+  assert {
+    condition     = length(oci_core_route_table.this) == 4
+    error_message = "REQ-NET-011: exactly four route tables must exist, one per trust zone"
+  }
+}
+
+run "every_subnet_uses_its_own_zone_route_table_not_the_default" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone, subnet in oci_core_subnet.this :
+      subnet.route_table_id == oci_core_route_table.this[zone].id
+    ])
+    error_message = "REQ-NET-011: every subnet must use its own zone's explicit route table, never the VCN default"
+  }
+}
+
+run "edge_route_table_routes_internet_to_igw" {
+  command = plan
+
+  assert {
+    condition = anytrue([
+      for r in oci_core_route_table.this["edge"].route_rules :
+      r.destination == "0.0.0.0/0" && r.network_entity_id == oci_core_internet_gateway.this.id
+    ])
+    error_message = "REQ-NET-012: the Edge route table must route 0.0.0.0/0 to the Internet Gateway"
+  }
+}
+
+run "management_workload_data_never_reference_the_internet_gateway" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone in ["management", "workload", "data"] :
+      !anytrue([
+        for r in oci_core_route_table.this[zone].route_rules :
+        r.network_entity_id == oci_core_internet_gateway.this.id
+      ])
+    ])
+    error_message = "REQ-NET-013: no route table other than Edge may ever reference the Internet Gateway -- this is the binding security control, not just 'NAT route is present'"
+  }
+}
+
+run "management_workload_data_route_internet_to_nat_only" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone in ["management", "workload", "data"] :
+      anytrue([
+        for r in oci_core_route_table.this[zone].route_rules :
+        r.destination == "0.0.0.0/0" && r.network_entity_id == oci_core_nat_gateway.this.id
+      ])
+    ])
+    error_message = "REQ-NET-013: Management, Workload, and Data must route 0.0.0.0/0 to the NAT Gateway"
+  }
+}
+
+run "all_four_zones_route_services_cidr_to_service_gateway" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone, rt in oci_core_route_table.this :
+      anytrue([
+        for r in rt.route_rules :
+        r.destination_type == "SERVICE_CIDR_BLOCK" && r.network_entity_id == oci_core_service_gateway.this.id
+      ])
+    ])
+    error_message = "REQ-NET-014: all four route tables must route the OCI Services Network CIDR label to the Service Gateway"
+  }
+}
+
+run "no_route_table_references_the_drg" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone, rt in oci_core_route_table.this :
+      !anytrue([
+        for r in rt.route_rules :
+        r.network_entity_id == oci_core_drg.this.id
+      ])
+    ])
+    error_message = "REQ-NET-015/ADR-0008: the Management route table's DRG slot must stay unpopulated in M1 -- no route table may reference the DRG until I21"
+  }
+}
+
+run "route_tables_carry_no_oracle_managed_tag_keys" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone, rt in oci_core_route_table.this :
+      !anytrue([for k in keys(rt.defined_tags) : strcontains(k, "Oracle-Tags")])
+    ])
+    error_message = "this module must never itself declare an Oracle-Tags.* key on any route table"
+  }
+}


### PR DESCRIPTION
## Scope

`SPEC-NET-002` (REQ-NET-006..010) and `SPEC-NET-003` (REQ-NET-011..015)
only. Same `infrastructure/modules/network` module and eventual
`10-network` state unit as PR C (#43) — `ADR-0007` already decided this
is one state unit; `modules/README.md` already documents building it
incrementally across PRs.

**Deliberately excluded**: NSGs, Security Lists, DNS/DHCP, compute, DRG
route activation. Those remain `SPEC-NET-004`/`006`, I04, and I21
respectively.

## What this adds

- `gateways.tf`: Internet Gateway, NAT Gateway, Service Gateway (target
  resolved via `data.oci_core_services`, not hardcoded), and a DRG —
  attached but **inert** (ADR-0008 Option B, already accepted): its own
  DRG route table carries zero static routes and no import route
  distribution configured.
- `routing.tf`: one route table per trust zone, built from a single
  shared `local.route_tables` map. Edge → IGW (REQ-NET-012);
  Management/Workload/Data → NAT only, **never** IGW (REQ-NET-013 — the
  binding security control); all four zones → Service Gateway for the
  OCI Services CIDR label (REQ-NET-014); Management's DRG slot stays
  reserved but unpopulated (REQ-NET-015).
- `subnets.tf`: every subnet's `route_table_id` now points at its own
  zone's table instead of the VCN default — an in-place update (OCI
  doesn't force-replace subnets on this), not a replacement.

## Verified, not assumed

- Every resource attribute name (`drg_route_table_id`, `network_details`,
  `route_rules`' `destination`/`destination_type`/`network_entity_id`)
  checked against the real `oracle/oci` v8.27.0 provider schema
  (`tofu providers schema -json`) before writing any code — confirmed
  correct on the first `tofu validate`.
- Audited the **live tenancy's** current OCI defaults before touching
  anything: all four subnets were falling back to the empty default
  route table (now fixed here); the shared default Security List
  currently allows SSH (22/tcp) and ICMP from `0.0.0.0/0` on every
  subnet — harmless today (nothing listens), a real gap `SPEC-NET-004`
  (PR C3) must close, documented rather than silently inherited.
- Tool versions (OpenTofu, Terragrunt, `oracle/oci`, tflint-ruleset)
  checked against upstream latest — all already exactly current, no
  change needed.

## Requirement traceability / route matrix / traffic-flow reconciliation

Full tables in `infrastructure/modules/network/README.md`. Every route
rule traces to a `REQ-NET-*` row; no orphan infrastructure. Using the
repo's existing RED/GREEN/BLUE/PURPLE/ORANGE taxonomy
(`docs/01-architecture/traceability.md`), not inventing a new one: RED/
GREEN/BLUE are physically routable after this PR but not yet
*authorized* (no Security List/NSG exists yet); PURPLE remains
physically impossible (no OpenZiti/compute); ORANGE stays intentionally
inert.

## Tests

24/24 pass (was 10, +14). Two documented, real `mock_provider`
limitations (same class as `foundation`'s `ignore_changes` constraint
from #41): data sources need explicit `override_data` (fixed for the
Services CIDR lookup); "DRG route table has no import distribution"
can't be mock-tested since mock synthesizes a value for every computed
attribute regardless of config — verified against the real provider in
the post-merge deployment report instead.

## Free Tier

Internet Gateway, NAT Gateway, Service Gateway, DRG + attachment, route
tables: all **FREE** — no per-resource charge, no per-byte processing
fee for NAT/SGW (unlike AWS/Azure), no DRG attachment fee. Confirmed
against Oracle's pricing/Always-Free docs, not assumed. Only real
egress traffic (none yet — no compute exists) would count against the
10 TB/month allowance.

## Validation

- `tofu fmt -check -recursive`, `tofu validate`: pass
- `tofu test`: 24/24 pass
- `tflint`: 0 issues
- `checkov`: 1/1 pass (no VCN/gateway-specific OCI checks in its ruleset)
- `terragrunt hcl fmt --check` / `hcl validate`: pass
- `gitleaks`: no leaks
- `markdownlint`: 0 issues
- `npm run validate:threat-model`: pass (network domain unaffected structurally)

No apply in this PR. Real plan + blast-radius analysis + apply-gate
report to follow after merge.