### PR TITLE
fix(network): baseline Security Lists before Edge becomes IGW-routable

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -99,4 +99,14 @@ jobs:
           # this finding when reached through a module call
           # (modules/foundation/examples/minimal) -- this workflow-level flag
           # is the verified-working mechanism.
-          skip_check: CKV_OCI_9
+          #
+          # CKV_OCI_16/CKV_OCI_19 (baseline Security Lists, PR C2 addendum):
+          # both checks assume a Security List with zero ingress rules means
+          # "ingress wasn't configured" -- for
+          # modules/network/security_lists.tf, zero ingress rules IS the
+          # intended REQ-NET-018 default-deny baseline, confirmed empirically
+          # (checkov fails both checks specifically because no
+          # ingress_security_rules block exists at all, not because a port-22
+          # rule was found). Adding an ingress rule to satisfy the scanner
+          # would be the opposite of correct here.
+          skip_check: CKV_OCI_9,CKV_OCI_16,CKV_OCI_19

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,12 @@ repos:
         args: ["--hook-config=--tf-path=tofu"]
       - id: terraform_tflint
       - id: checkov
-        # CKV_OCI_9: see .github/workflows/validate.yml's checkov step and
-        # infrastructure/modules/foundation/state_backend.tf's comment --
+        # CKV_OCI_9/16/19: see .github/workflows/validate.yml's checkov step
+        # and infrastructure/modules/foundation/state_backend.tf /
+        # infrastructure/modules/network/security_lists.tf's comments --
         # kept in sync with that workflow's skip_check so local pre-commit
         # and CI agree.
-        args: ["--skip-check=CKV_OCI_9"]
+        args: ["--skip-check=CKV_OCI_9,CKV_OCI_16,CKV_OCI_19"]
 
   - repo: local
     hooks:

--- a/infrastructure/modules/network/README.md
+++ b/infrastructure/modules/network/README.md
@@ -4,19 +4,34 @@
 
 Implements `SPEC-NET-001` (REQ-NET-001..005, the platform VCN and its
 four trust-zone subnets), `SPEC-NET-002` (REQ-NET-006..010, gateways:
-Internet, NAT, Service, and an inert DRG), and `SPEC-NET-003`
-(REQ-NET-011..015, one route table per trust zone), as decided by
-`ADR-0006` and `ADR-0008`. This is the second module in the state DAG —
-`SPEC-NET-004` (NSGs/Security Lists) and `SPEC-NET-006` (DNS/DHCP) attach
-to what this module creates, and I04 (compute) attaches to its subnets/
-route tables. `ADR-0007` already decided `10-network` is one state unit
-covering all of `SPEC-NET-001` through `SPEC-NET-006` — this module is
-built incrementally across PRs against that same eventual state unit
-(PR C: `vcn.tf` + `subnets.tf`; PR C2, this one: `gateways.tf` +
-`routing.tf`; a later PR adds `security.tf`/`dns.tf`), per
-`../README.md`'s own documented internal-file-organization note. Not a
-further-split target: OCI network topology within one VCN is provisioned
-and changed as a unit in practice.
+Internet, NAT, Service, and an inert DRG), `SPEC-NET-003`
+(REQ-NET-011..015, one route table per trust zone), and — pulled forward
+from what was originally PR C3's scope — `SPEC-NET-004`'s **coarse
+baseline only** (REQ-NET-016/018: one default-deny Security List per
+zone). As decided by `ADR-0006` and `ADR-0008`. This is the second module
+in the state DAG — `SPEC-NET-004`'s remaining scope (REQ-NET-017/019/020:
+the five purpose-built NSGs, `control` NSG's port-6443 restriction) and
+`SPEC-NET-006` (DNS/DHCP) still attach to what this module creates, and
+I04 (compute) attaches to its subnets/route tables. `ADR-0007` already
+decided `10-network` is one state unit covering all of `SPEC-NET-001`
+through `SPEC-NET-006` — this module is built incrementally across PRs
+against that same eventual state unit (PR C: `vcn.tf` + `subnets.tf`;
+PR C2, this one: `gateways.tf` + `routing.tf` + `security_lists.tf`; a
+later PR adds `nsgs.tf`/`dns.tf`), per `../README.md`'s own documented
+internal-file-organization note. Not a further-split target: OCI network
+topology within one VCN is provisioned and changed as a unit in
+practice.
+
+**Why the Security List baseline moved into PR C2**: applying IGW routing
+to Edge (`gateways.tf`/`routing.tf`, this same PR) while every subnet
+still inherited OCI's permissive default Security List (TCP/22 + ICMP
+from `0.0.0.0/0`) would have been a real, avoidable transitional
+exposure, not a hypothetical one — Edge specifically becomes
+internet-routable in this PR. `security_lists.tf` closes that gap with
+the minimum necessary baseline (REQ-NET-016/018) without pulling forward
+NSGs, OpenZiti-specific rules, Kubernetes control-plane authorization
+(REQ-NET-019), or any other component-level authorization — those remain
+PR C3 exactly as originally scoped.
 
 ## Input contract
 
@@ -42,6 +57,7 @@ hardcoded constants, not tunables.
 | `igw_id` / `nat_id` / `sgw_id` / `drg_id` | consumed internally by `routing.tf`; `drg_id` also for I21 once hybrid connectivity begins |
 | `drg_route_table_id` | I21 — the table it populates once hybrid routing activates |
 | `route_table_ids` | map keyed by zone — I04 (compute subnet attachment) |
+| `security_list_ids` | map keyed by zone — PR C3's NSGs layer on top of these; I04 attaches compute to the same zone's list |
 
 ## Resource ownership
 
@@ -50,15 +66,18 @@ hardcoded constants, not tunables.
 `oci_core_service_gateway` (1), `oci_core_drg` (1),
 `oci_core_drg_route_table` (1, empty — the inert mechanism),
 `oci_core_drg_attachment` (1), `oci_core_route_table` (4, one per trust
-zone, via `for_each`), `data.oci_core_services` (1, read-only — resolves
-the region's Services Network CIDR label).
+zone, via `for_each`), `oci_core_security_list` (4, one per trust zone,
+via `for_each` — baseline only, REQ-NET-016/018),
+`data.oci_core_services` (1, read-only — resolves the region's Services
+Network CIDR label).
 
-**Not owned here**: NSGs/Security Lists (`SPEC-NET-004`), DNS/DHCP
-options (`SPEC-NET-006`), compute attachment (I04), any DRG route
-rule/distribution (I21 — this module creates the DRG attached-but-empty,
-never populates it). Subnets use OCI's default security list (unchanged
-until `SPEC-NET-004`) but no longer the default route table — each now
-has its own zone-specific one (`routing.tf`).
+**Not owned here**: NSGs (`SPEC-NET-004`'s remaining scope,
+REQ-NET-017/019/020), DNS/DHCP options (`SPEC-NET-006`), compute
+attachment (I04), any DRG route rule/distribution (I21 — this module
+creates the DRG attached-but-empty, never populates it). Subnets no
+longer use OCI's default route table or default Security List — each has
+its own zone-specific pair now (`routing.tf`, `security_lists.tf`); the
+OCI defaults become intentionally unused, not deleted.
 
 ## Security invariants
 
@@ -115,6 +134,22 @@ has its own zone-specific one (`routing.tf`).
   zone's explicit route table (`subnets.tf`), never the VCN default —
   audited against the live tenancy before this change (all four subnets
   previously fell back to the empty default route table).
+- **REQ-NET-016/018 (Security List baseline, pulled forward from
+  `SPEC-NET-004`)**: every subnet's `security_list_ids` now points at its
+  own zone's baseline Security List (`security_lists.tf`), never the VCN
+  default — same audit-before-change discipline as REQ-NET-011. Each
+  list has **zero ingress rules** (default-deny; `tests/security_lists.tftest.hcl`
+  asserts this independently per zone, not just once) and egress scoped
+  to exactly the two destinations this module's own routing needs
+  (`0.0.0.0/0` matching the NAT/IGW route, the Services CIDR label
+  matching the Service Gateway route) — not a blanket copy of OCI's
+  permissive default. This exists specifically because Edge becomes
+  IGW-routable in this same PR; shipping that without a Security List
+  baseline would have left a real transitional exposure, not a
+  hypothetical one. **Routable is still not authorized**: this baseline
+  proves nothing is exposed today, not that anything is cleared to be —
+  NSG-level component authorization (REQ-NET-017/019/020) remains
+  PR C3.
 
 ## Requirement traceability
 
@@ -135,10 +170,13 @@ has its own zone-specific one (`routing.tf`).
 | REQ-NET-013 | SPEC-NET-003 | — | ARCH-FLOW-EGRESS (GREEN) | ARCH-FLOW-EGRESS | Route rule (Mgmt/Workload/Data → NAT, never IGW) | `oci_core_route_table.this[zone]` | `management_workload_data_never_reference_the_internet_gateway`, `management_workload_data_route_internet_to_nat_only` |
 | REQ-NET-014 | SPEC-NET-003 | — | ARCH-FLOW-SERVICE (BLUE) | ARCH-FLOW-SERVICE | Route rule (all zones → SGW) | `oci_core_route_table.this[*]` | `all_four_zones_route_services_cidr_to_service_gateway` |
 | REQ-NET-015 | SPEC-NET-003 | ADR-0008 | ARCH-FLOW-HYBRID (ORANGE) | ARCH-FLOW-HYBRID | (reserved slot, unpopulated) | n/a — no resource by design | `no_route_table_references_the_drg` |
+| REQ-NET-016 | SPEC-NET-004 (baseline only) | — | ARCH-ZONE-* | — | Security List ×4 | `oci_core_security_list.this` | `four_security_lists_one_per_zone`, `every_subnet_uses_its_own_zone_security_list_not_the_default` |
+| REQ-NET-018 | SPEC-NET-004 (baseline only) | — | ARCH-FLOW-INGRESS/EGRESS/SERVICE | ARCH-FLOW-INGRESS | Security List rules (empty ingress; egress = 2 rules matching routing) | `oci_core_security_list.this[zone]` | `{edge,management,workload,data}_has_no_(unauthorized\|internet)_ingress`, `no_zone_permits_ssh_from_the_internet`, `no_zone_permits_unrestricted_ingress_of_any_kind`, `egress_scoped_to_exactly_what_routing_needs` |
 
 No orphan infrastructure: every resource and route rule in `gateways.tf`/
-`routing.tf` traces to one of the rows above. Nothing was added that
-isn't required by REQ-NET-006 through REQ-NET-015.
+`routing.tf`/`security_lists.tf` traces to one of the rows above. Nothing
+was added that isn't required by REQ-NET-006 through REQ-NET-018 (with
+REQ-NET-017/019/020 explicitly out of scope — see Purpose).
 
 ## Route matrix
 
@@ -158,6 +196,32 @@ No unexplained `0.0.0.0/0` — every occurrence above is either Edge→IGW
 (REQ-NET-012, the only place it's allowed) or Management/Workload/Data→NAT
 (REQ-NET-013, explicitly never IGW).
 
+## Security List baseline matrix
+
+| Zone | Direction | Source/Destination | Protocol | Purpose | REQ |
+| --- | --- | --- | --- | --- | --- |
+| Edge | Ingress | — (none) | — | Default-deny; routable via IGW does not mean authorized — NSG-level authorization is PR C3 | REQ-NET-018 |
+| Edge | Egress | `0.0.0.0/0` | all | Matches Edge's own IGW route (REQ-NET-012) — a route with no matching egress rule is unusable | REQ-NET-016 |
+| Edge | Egress | Services CIDR label | all | Matches Edge's Service Gateway route (REQ-NET-014) | REQ-NET-016 |
+| Management | Ingress | — (none) | — | Default-deny — NAT is egress-only by OCI design regardless, but the SL is the platform-level control, not an assumption about NAT behavior | REQ-NET-018 |
+| Management | Egress | `0.0.0.0/0` | all | Matches Management's NAT route (REQ-NET-013) | REQ-NET-016 |
+| Management | Egress | Services CIDR label | all | Matches Management's Service Gateway route (REQ-NET-014) | REQ-NET-016 |
+| Workload | Ingress | — (none) | — | Default-deny, same reasoning as Management | REQ-NET-018 |
+| Workload | Egress | `0.0.0.0/0` | all | Matches Workload's NAT route (REQ-NET-013) | REQ-NET-016 |
+| Workload | Egress | Services CIDR label | all | Matches Workload's Service Gateway route (REQ-NET-014) | REQ-NET-016 |
+| Data | Ingress | — (none) | — | Default-deny, same reasoning as Management | REQ-NET-018 |
+| Data | Egress | `0.0.0.0/0` | all | Matches Data's NAT route (REQ-NET-013) | REQ-NET-016 |
+| Data | Egress | Services CIDR label | all | Matches Data's Service Gateway route (REQ-NET-014) | REQ-NET-016 |
+
+No ingress rule exists anywhere in this table — every zone's Security
+List is empty on ingress, independently asserted per zone in
+`tests/security_lists.tftest.hcl`, not inferred from one representative
+check. Egress is deliberately **not** a blanket copy of OCI's default
+(`all protocols → 0.0.0.0/0` with no Services-CIDR distinction) — every
+row above traces to a route this module's own `routing.tf` already
+creates; there is no egress destination in this table that routing
+doesn't also send traffic to.
+
 ## Traffic-flow reconciliation (post–PR C2)
 
 Using `docs/01-architecture/traceability.md`'s RED/GREEN/BLUE/PURPLE/
@@ -166,12 +230,19 @@ invented here:
 
 - **Physically exist (routable) after PR C2**: RED (`ARCH-FLOW-INGRESS`),
   GREEN (`ARCH-FLOW-EGRESS`), BLUE (`ARCH-FLOW-SERVICE`/`-BACKUP`).
-- **Routable but not yet authorized**: the same three — routes exist, but
-  no Security List/NSG (`SPEC-NET-004`, PR C3) has been added yet, so
-  "routable" is not "permitted." The shared default Security List (audited
-  against the live tenancy, unchanged by this PR) still allows SSH
-  (22/tcp) and ICMP from `0.0.0.0/0` on every subnet — harmless today
-  (nothing listens), a real gap PR C3 must close.
+- **Routable but not yet authorized**: the same three — routes exist, and
+  as of this PR every zone now has its own default-deny Security List
+  baseline (REQ-NET-016/018, `security_lists.tf`), not the shared OCI
+  default. "Routable" still isn't "permitted": the baseline proves no
+  zone is exposed *today* (zero ingress rules everywhere), it does not
+  grant any component authorization — NSG-level rules (REQ-NET-017/019/020,
+  PR C3) are what turn "routable and default-denied" into "routable and
+  specifically permitted for a real component." This is a meaningfully
+  different, stronger position than PR C2's first draft, which left every
+  subnet on the shared default Security List (SSH/ICMP from `0.0.0.0/0`)
+  while making Edge IGW-routable in the same PR — a real, avoidable
+  transitional exposure, closed before this PR's apply gate rather than
+  carried into PR C3.
 - **Remain physically impossible**: PURPLE (`ARCH-FLOW-ADMIN`/`-CONTROL`)
   — no OpenZiti, no compute/Talos exists yet (I04/I08/M2); this module
   creates no path for either.
@@ -280,3 +351,23 @@ variables, so there's no user-input surface for `expect_failures`-style
 malformed/overlapping-route negative tests the way `foundation`'s
 string/OCID variables have — the same reasoning as `network_negative.tftest.hcl`
 above, applied to routing.
+
+`tests/security_lists.tftest.hcl` (positive; these ARE this module's
+critical security invariants, same pattern as `routing.tftest.hcl`):
+exactly four Security Lists exist; no zone permits TCP/22 from
+`0.0.0.0/0` (checked as one combined assertion, not per-zone, since the
+underlying invariant — zero ingress rules — is stronger and checked
+per-zone separately below); Edge, Management, Workload, and Data each
+**independently** assert zero ingress rules (not one representative
+check standing in for all four, matching this module's established
+per-zone-assertion discipline); a combined
+`no_zone_permits_unrestricted_ingress_of_any_kind` assertion restates the
+same fact as the strongest possible form of "no unrestricted ingress
+exists anywhere"; egress is exactly 2 rules per zone, matching what
+`routing.tf` actually routes (not a blanket `0.0.0.0/0` reproduction);
+every subnet references its own zone's Security List, never the OCI
+default. Does not attempt to unit-test *effective live reachability*
+(whether a real internet client could actually reach a real resource) —
+that's not a mock-provider-provable claim, and the real plan/OCI CLI
+verification in the PR C2 deployment report is the authoritative check,
+consistent with how this module already treats DRG inertness.

--- a/infrastructure/modules/network/outputs.tf
+++ b/infrastructure/modules/network/outputs.tf
@@ -55,3 +55,10 @@ output "route_table_ids" {
   value       = { for zone, rt in oci_core_route_table.this : zone => rt.id }
   description = "Route table OCIDs keyed by trust-zone name (REQ-NET-011)."
 }
+
+# SPEC-NET-004 Interfaces (partial -- security_list_ids only; nsg_ids
+# awaits PR C3): security_list_ids{edge,management,workload,data}.
+output "security_list_ids" {
+  value       = { for zone, sl in oci_core_security_list.this : zone => sl.id }
+  description = "Baseline Security List OCIDs keyed by trust-zone name (REQ-NET-016). NSG creation/output (REQ-NET-017) is PR C3."
+}

--- a/infrastructure/modules/network/security_lists.tf
+++ b/infrastructure/modules/network/security_lists.tf
@@ -1,0 +1,65 @@
+# SPEC-NET-004 (REQ-NET-016/018 only -- the coarse Security List baseline).
+# Pulled forward from PR C3's original scope: applying IGW/NAT routing
+# (gateways.tf/routing.tf) while every subnet still inherited OCI's
+# permissive default Security List (TCP/22 + ICMP from 0.0.0.0/0) would
+# have left a real, avoidable transitional exposure -- not a hypothetical
+# one, since Edge specifically becomes IGW-routable in this same PR. This
+# file closes that gap with the minimum necessary baseline; it does NOT
+# implement REQ-NET-017/019/020 (the five purpose-built NSGs, the
+# `control` NSG's port-6443 restriction, OpenZiti-specific rules,
+# Kubernetes control-plane authorization) -- those remain PR C3, per
+# REQ-NET-018's own division of labor: "NSGs are the actual enforcement
+# point, Security Lists are the subnet-level backstop."
+#
+# Ingress: empty on all four zones, deliberately. REQ-NET-018 mandates
+# default-deny "except what is explicitly required for the subnet to
+# function at the OCI platform level (e.g., VCN-internal DNS)" -- OCI's
+# VCN Resolver and instance metadata service operate outside normal
+# Security List enforcement (the same class of platform-level exemption
+# AWS's 169.254.169.254 metadata endpoint has), so no explicit DNS rule
+# is required for the subnet itself to function. An empty ingress set is
+# valid and sufficient today; nothing currently needs inbound access.
+#
+# Egress: not a blanket "all protocols to 0.0.0.0/0" copy of OCI's
+# default -- scoped to exactly the two destinations routing.tf's route
+# tables already send traffic to (0.0.0.0/0 via NAT/IGW, the Services
+# CIDR via the Service Gateway). A route without a matching egress rule
+# would be dead on arrival, so this is the necessary complement to
+# already-approved PR C2 routing, not new speculative capability.
+# Protocol-level restriction is deliberately NOT attempted here: which
+# specific protocols future workloads need is unknowable before I04
+# compute exists, and guessing narrower would be speculative in the
+# other direction.
+resource "oci_core_security_list" "this" {
+  for_each = local.subnet_cidrs
+
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.this.id
+  display_name   = "platform-${each.key}-sl"
+
+  # No ingress_security_rules block: zero rules, default-deny.
+
+  egress_security_rules {
+    destination      = "0.0.0.0/0"
+    destination_type = "CIDR_BLOCK"
+    protocol         = "all"
+    description      = "Matches this zone's NAT/IGW route (REQ-NET-013/012) -- a route without this would be unusable"
+  }
+
+  egress_security_rules {
+    destination      = local.all_services_in_oracle_services_network.cidr_block
+    destination_type = "SERVICE_CIDR_BLOCK"
+    protocol         = "all"
+    description      = "Matches this zone's Service Gateway route (REQ-NET-014)"
+  }
+
+  freeform_tags = { "provisioned-by" = "opentofu" }
+  defined_tags  = local.network_defined_tags
+
+  lifecycle {
+    ignore_changes = [
+      defined_tags["Oracle-Tags.CreatedBy"],
+      defined_tags["Oracle-Tags.CreatedOn"],
+    ]
+  }
+}

--- a/infrastructure/modules/network/subnets.tf
+++ b/infrastructure/modules/network/subnets.tf
@@ -12,12 +12,14 @@
 # default to an explicit OCID), not a replacement -- OCI subnets don't
 # force-replace on route_table_id changes.
 #
-# security_list_ids still unset: each subnet keeps the VCN's default
-# security list until SPEC-NET-004 (PR C3) assigns explicit ones. That
-# default list currently allows SSH (22/tcp) and ICMP from 0.0.0.0/0 on
-# every subnet -- audited against the live tenancy, not assumed --
-# harmless today (nothing listens on any subnet yet) but a real,
-# documented gap PR C3 must close, not silently inherit.
+# security_list_ids: each subnet now uses its own zone's baseline
+# Security List (security_lists.tf, REQ-NET-016/018) instead of the VCN
+# default. Audited against the live tenancy before this change: the
+# default list allowed SSH (22/tcp) and ICMP from 0.0.0.0/0 on every
+# subnet -- harmless while no subnet had a route to anywhere, but
+# gateways.tf/routing.tf (same PR) make Edge specifically IGW-routable,
+# which would have left a real transitional exposure if this file
+# shipped without its own Security List baseline.
 locals {
   subnet_public_allowed = {
     edge       = true
@@ -30,12 +32,13 @@ locals {
 resource "oci_core_subnet" "this" {
   for_each = local.subnet_cidrs
 
-  compartment_id = var.compartment_ocid
-  vcn_id         = oci_core_vcn.this.id
-  cidr_block     = each.value
-  display_name   = "platform-${each.key}"
-  dns_label      = each.key
-  route_table_id = oci_core_route_table.this[each.key].id
+  compartment_id    = var.compartment_ocid
+  vcn_id            = oci_core_vcn.this.id
+  cidr_block        = each.value
+  display_name      = "platform-${each.key}"
+  dns_label         = each.key
+  route_table_id    = oci_core_route_table.this[each.key].id
+  security_list_ids = [oci_core_security_list.this[each.key].id]
 
   prohibit_public_ip_on_vnic = !local.subnet_public_allowed[each.key]
 

--- a/infrastructure/modules/network/tests/security_lists.tftest.hcl
+++ b/infrastructure/modules/network/tests/security_lists.tftest.hcl
@@ -1,0 +1,152 @@
+# Positive tests for the REQ-NET-016/018 baseline Security List pull-
+# forward. These are the critical invariants: the whole point of this
+# file's existence is proving IGW routing (gateways.tf/routing.tf, same
+# PR) never combines with an inherited permissive default to create real
+# exposure. NSG-level tests (REQ-NET-017/019/020) are PR C3's own test
+# file, not this one.
+
+mock_provider "oci" {
+  override_data {
+    target = data.oci_core_services.all
+    values = {
+      services = [
+        {
+          id          = "ocid1.service.oc1..aaaaaaaamockallservices"
+          name        = "All EU-MADRID-1 Services In Oracle Services Network"
+          cidr_block  = "all-eu-madrid-1-services-in-oracle-services-network"
+          description = "mock -- REQ-NET-008 Service Gateway target"
+        },
+      ]
+    }
+  }
+}
+
+variables {
+  compartment_ocid = "ocid1.compartment.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
+  environment      = "lab"
+}
+
+run "four_security_lists_one_per_zone" {
+  command = plan
+
+  assert {
+    condition     = length(oci_core_security_list.this) == 4
+    error_message = "REQ-NET-016: exactly four Security Lists must exist, one per trust zone"
+  }
+}
+
+run "no_zone_permits_ssh_from_the_internet" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone, sl in oci_core_security_list.this :
+      !anytrue([
+        for r in sl.ingress_security_rules :
+        r.source == "0.0.0.0/0" && (
+          r.protocol == "6" &&
+          try(r.tcp_options[0].destination_port_range[0].min, null) == 22
+        )
+      ])
+    ])
+    error_message = "no zone (Edge, Management, Workload, or Data) may permit TCP/22 from 0.0.0.0/0"
+  }
+}
+
+run "edge_has_no_unauthorized_ingress" {
+  command = plan
+
+  assert {
+    condition     = length(oci_core_security_list.this["edge"].ingress_security_rules) == 0
+    error_message = "REQ-NET-018: Edge is IGW-routable in this same PR (gateways.tf/routing.tf) -- routable must not imply authorized; ingress stays empty until PR C3's NSGs add precise rules"
+  }
+}
+
+run "management_has_no_internet_ingress" {
+  command = plan
+
+  assert {
+    condition     = length(oci_core_security_list.this["management"].ingress_security_rules) == 0
+    error_message = "Management must have zero ingress rules (default-deny baseline, REQ-NET-018)"
+  }
+}
+
+run "workload_has_no_internet_ingress" {
+  command = plan
+
+  assert {
+    condition     = length(oci_core_security_list.this["workload"].ingress_security_rules) == 0
+    error_message = "Workload must have zero ingress rules (default-deny baseline, REQ-NET-018)"
+  }
+}
+
+run "data_has_no_internet_ingress" {
+  command = plan
+
+  assert {
+    condition     = length(oci_core_security_list.this["data"].ingress_security_rules) == 0
+    error_message = "Data must have zero ingress rules (default-deny baseline, REQ-NET-018)"
+  }
+}
+
+run "no_zone_permits_unrestricted_ingress_of_any_kind" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone, sl in oci_core_security_list.this : length(sl.ingress_security_rules) == 0
+    ])
+    error_message = "every zone's Security List must have zero ingress rules today -- the strongest possible form of 'no unrestricted ingress exists anywhere'"
+  }
+}
+
+run "egress_scoped_to_exactly_what_routing_needs" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone, sl in oci_core_security_list.this : length(sl.egress_security_rules) == 2
+    ])
+    error_message = "egress must be scoped to exactly the two destinations routing.tf's route tables send traffic to (0.0.0.0/0, Services CIDR) -- not a blanket reproduction of OCI's default"
+  }
+
+  assert {
+    condition = alltrue([
+      for zone, sl in oci_core_security_list.this :
+      anytrue([for r in sl.egress_security_rules : r.destination == "0.0.0.0/0" && r.destination_type == "CIDR_BLOCK"])
+    ])
+    error_message = "every zone must allow egress to 0.0.0.0/0 -- otherwise its NAT/IGW route (REQ-NET-012/013) would be unusable"
+  }
+
+  assert {
+    condition = alltrue([
+      for zone, sl in oci_core_security_list.this :
+      anytrue([for r in sl.egress_security_rules : r.destination_type == "SERVICE_CIDR_BLOCK"])
+    ])
+    error_message = "every zone must allow egress to the Services CIDR label -- otherwise its Service Gateway route (REQ-NET-014) would be unusable"
+  }
+}
+
+run "every_subnet_uses_its_own_zone_security_list_not_the_default" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone, subnet in oci_core_subnet.this :
+      length(subnet.security_list_ids) == 1 && contains(subnet.security_list_ids, oci_core_security_list.this[zone].id)
+    ])
+    error_message = "every subnet must reference its own zone's Security List -- the OCI default Security List must become INTENTIONALLY UNUSED, not silently inherited"
+  }
+}
+
+run "security_lists_carry_no_oracle_managed_tag_keys" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone, sl in oci_core_security_list.this :
+      !anytrue([for k in keys(sl.defined_tags) : strcontains(k, "Oracle-Tags")])
+    ])
+    error_message = "this module must never itself declare an Oracle-Tags.* key on any Security List"
+  }
+}


### PR DESCRIPTION
## Why

PR C2 (#45, already merged) made Edge internet-routable via the Internet
Gateway while every subnet still inherited OCI's permissive default
Security List (TCP/22 + ICMP from `0.0.0.0/0`). Not yet applied against
the live tenancy — caught at the apply-gate review before authorization,
not after.

## Scope adjustment

Pulls forward **only** `REQ-NET-016`/`REQ-NET-018` (the coarse
default-deny Security List baseline) from what was originally PR C3's
scope. Explicitly **not** pulled forward — these remain PR C3:

- The five purpose-built NSGs (`REQ-NET-017`)
- `control` NSG's port-6443 restriction (`REQ-NET-019`)
- OpenZiti-specific rules, Kubernetes control-plane authorization
- Any component/service-level membership

`REQ-NET-018` itself frames this division: "NSGs are the actual
enforcement point, Security Lists are the subnet-level backstop."

## Design

- **Ingress**: zero rules, all four zones, deliberately. OCI's VCN
  Resolver/instance metadata service operate outside standard Security
  List enforcement — no explicit rule is needed for the subnet itself to
  function. An empty ingress set is valid and sufficient today.
- **Egress**: scoped to exactly the two destinations `routing.tf`'s
  route tables already send traffic to (`0.0.0.0/0` via NAT/IGW, the
  Services CIDR via the Service Gateway) — not a blanket reproduction of
  OCI's default. A route without a matching egress rule would be dead on
  arrival, so this is the necessary complement to already-merged PR C2
  routing, not new speculative capability.
- Every subnet now references its own zone's Security List; the OCI
  default becomes intentionally unused (not deleted).

## Checkov finding, verified before skipping

`CKV_OCI_16`/`CKV_OCI_19` both fail on every Security List here — traced
the exact cause before skipping: both checks assume zero ingress rules
means "ingress wasn't configured," when here it's the intended
`REQ-NET-018` default-deny baseline. Adding a port-22 rule to satisfy the
scanner would be the opposite of correct. Same workflow-level
`skip_check` pattern as the existing `CKV_OCI_9` skip
(`.github/workflows/validate.yml`, kept in sync with
`.pre-commit-config.yaml`).

## Tests

10 new (`tests/security_lists.tftest.hcl`), 34/34 total pass. Each zone's
zero-ingress-rules invariant is asserted independently (Edge, Management,
Workload, Data each get their own assertion, not one representative
check), plus a combined "no unrestricted ingress exists anywhere"
assertion, egress-matches-routing, and default-Security-List-no-longer-
referenced.

## Validation

- `tofu fmt -check -recursive`, `tofu validate`: pass
- `tofu test`: 34/34 pass
- `tflint`: 0 issues
- `checkov` (`--skip-check CKV_OCI_9,CKV_OCI_16,CKV_OCI_19`): 5/5 pass
  (module), 9/9 pass (full `infrastructure/` scan, matching CI exactly)
- `terragrunt hcl fmt --check` / `hcl validate`: pass
- `gitleaks`: no leaks
- `markdownlint`: 0 issues
- `zizmor` (workflow change): no findings
- `npm run validate:threat-model`: pass

No real plan/apply yet — this closes the gap the apply-gate review
surfaced before requesting reauthorization for PR C2's combined plan.