### PR TITLE
feat(threat-model): add deployed-observation evidence source type

### DIFF
--- a/docs/03-threat-model/model/instances/network.yaml
+++ b/docs/03-threat-model/model/instances/network.yaml
@@ -209,38 +209,34 @@ components:
     component_type: network-gateway
     description: >-
       Edge zone's sole internet-facing ingress point. Deployed object
-      confirmed via independent OCI CLI query (`oci network
-      internet-gateway list`, state AVAILABLE) against the live tenancy,
-      2026-08-18 -- not yet referenced by any route table, so its
-      functional role (actual Edge traffic path) is not yet active; only
-      the object's existence is implemented. Verification method
-      recorded here in prose because the schema's evidence.source_type
-      enum (spec/adr/arch-view/roadmap/contributing/security-md) has no
-      value for "verified against live infrastructure" -- a real gap,
-      not routed around with an invented enum value; see this Spec's own
-      threat-model reconciliation report for the flag.
+      confirmed via independent OCI CLI query against the live tenancy --
+      not yet referenced by any route table, so its functional role
+      (actual Edge traffic path) is not yet active; only the object's
+      existence is implemented.
     trust_zone_ref: ARCH-NET-VCN
     state: implemented
     evidence:
-      - { source_type: spec, ref: "SPEC-NET-002.md", status: implemented }
-      - { source_type: arch-view, ref: ARCH-GW-IGW, status: implemented }
+      - { source_type: spec, ref: "SPEC-NET-002.md", status: specified }
+      - { source_type: arch-view, ref: ARCH-GW-IGW, status: specified }
+      - { source_type: deployed-observation, mechanism: oci-api, ref: "oci network internet-gateway list, 2026-08-18, state=AVAILABLE", status: implemented }
 
   - id: COMP-DRG
     name: Dynamic Routing Gateway
     component_type: network-gateway
     description: >-
       Reserved for I21 hybrid connectivity (ADR-0008). Deployed object
-      confirmed via independent OCI CLI query (state AVAILABLE) against
-      the live tenancy, 2026-08-18 -- not yet attached to the VCN (the
-      DRG attachment failed during PR C2's apply on an unrelated OCI
-      service-limit block, see GAP-NET-004), so only the DRG object's own
-      existence is implemented, not the REQ-NET-009 "attached and inert"
-      requirement in full.
+      confirmed via independent OCI CLI query against the live tenancy --
+      not yet attached to the VCN (the DRG attachment failed during PR
+      C2's apply on an unrelated OCI service-limit block, see
+      GAP-NET-004), so only the DRG object's own existence is
+      implemented, not the REQ-NET-009 "attached and inert" requirement
+      in full.
     trust_zone_ref: ARCH-NET-VCN
     state: implemented
     evidence:
-      - { source_type: spec, ref: "SPEC-NET-002.md#REQ-NET-009", status: implemented }
-      - { source_type: adr, ref: ADR-0008, status: implemented }
+      - { source_type: spec, ref: "SPEC-NET-002.md#REQ-NET-009", status: specified }
+      - { source_type: adr, ref: ADR-0008, status: specified }
+      - { source_type: deployed-observation, mechanism: oci-api, ref: "oci network drg list, 2026-08-18, state=AVAILABLE", status: implemented }
 
   - id: COMP-NAT-GATEWAY
     name: NAT Gateway
@@ -345,18 +341,22 @@ controls:
       Security Lists provide a default-deny ingress baseline per
       trust-zone subnet; NSGs are the actual fine-grained enforcement
       point (REQ-NET-016/018). The four Security List objects exist as
-      deployed OCI resources (confirmed via independent CLI query,
-      state AVAILABLE, 2026-08-18) but are not yet associated with any
-      managed subnet -- all four subnets still use the OCI account
-      default Security List, pending the same PR C2 apply that's
-      currently blocked on NAT/SGW/DRG service limits. State stays
-      `specified`, not `implemented`, because the control's actual
-      protective function (per-zone baseline in effect) is not yet
-      active -- object existence alone is not this control's claim.
+      deployed OCI resources but are not yet associated with any managed
+      subnet -- all four subnets still use the OCI account default
+      Security List, pending the same PR C2 apply that's currently
+      blocked on NAT/SGW/DRG service limits. State stays `specified`,
+      not `implemented`, because the control's actual protective
+      function (per-zone baseline in effect) is not yet active — object
+      existence alone is not this control's claim; the
+      deployed-observation evidence below asserts only the objects'
+      existence, deliberately with status=specified (not implemented),
+      to keep that distinction visible in the evidence itself, not just
+      the description.
     state: specified
     evidence:
       - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-016", status: specified }
       - { source_type: spec, ref: "SPEC-NET-004.md#REQ-NET-018", status: specified }
+      - { source_type: deployed-observation, mechanism: oci-api, ref: "oci network security-list list, 2026-08-18: 4 objects AVAILABLE, 0 subnet associations", status: specified }
 
   - id: CTRL-K8S-API-INGRESS-RESTRICTION
     name: Kubernetes API ingress restriction to ziti+worker NSGs only

--- a/docs/03-threat-model/model/schema/threat-model.schema.json
+++ b/docs/03-threat-model/model/schema/threat-model.schema.json
@@ -71,12 +71,18 @@
       "properties": {
         "source_type": {
           "type": "string",
-          "enum": ["spec", "adr", "arch-view", "roadmap", "contributing", "security-md"]
+          "enum": ["spec", "adr", "arch-view", "roadmap", "contributing", "security-md", "deployed-observation"],
+          "description": "Document sources (spec/adr/arch-view/roadmap/contributing/security-md) assert intent. 'deployed-observation' asserts fact — something was actually checked against live infrastructure — and MUST be paired with `mechanism` saying how (enforced by validate-threat-model.mjs, not expressible in JSON Schema alone)."
+        },
+        "mechanism": {
+          "type": "string",
+          "enum": ["oci-api", "opentofu-state", "opentofu-plan"],
+          "description": "Required when source_type=deployed-observation; MUST be omitted for document-based source_types."
         },
         "ref": {
           "type": "string",
           "minLength": 1,
-          "description": "e.g. 'SPEC-NET-004.md#REQ-NET-019', 'ADR-0003', 'ARCH-FLOW-ADMIN', 'roadmap.md#I05'."
+          "description": "e.g. 'SPEC-NET-004.md#REQ-NET-019', 'ADR-0003', 'ARCH-FLOW-ADMIN', 'roadmap.md#I05'. For deployed-observation, a human-readable pointer to what was checked, e.g. 'oci network internet-gateway list, 2026-08-18'."
         },
         "status": {
           "type": "string",

--- a/scripts/validate-threat-model.mjs
+++ b/scripts/validate-threat-model.mjs
@@ -202,6 +202,25 @@ async function main() {
     }
   }
 
+  // Pass 5b: evidence.mechanism required iff source_type=deployed-observation
+  // (JSON Schema can't express a same-object conditional-required field
+  // without an if/then that would apply to every evidence entry regardless
+  // of source_type, so this stays a validator-script check).
+  for (const { file, doc } of perFileDocs) {
+    for (const key of collectionKeys(doc)) {
+      for (const item of doc[key]) {
+        for (const e of item.evidence || []) {
+          if (e.source_type === "deployed-observation" && !e.mechanism) {
+            errors.push(`FAILED (missing mechanism) - ${file}: ${item.id} has a deployed-observation evidence entry (ref='${e.ref}') with no mechanism`);
+          }
+          if (e.source_type !== "deployed-observation" && e.mechanism) {
+            errors.push(`FAILED (unexpected mechanism) - ${file}: ${item.id} has a ${e.source_type} evidence entry (ref='${e.ref}') with a mechanism field, only valid for deployed-observation`);
+          }
+        }
+      }
+    }
+  }
+
   // Pass 5: state=decision-pending requires a gaps[] entry naming this element.
   const gapSubjects = new Set();
   for (const { doc } of perFileDocs) {

--- a/scripts/validate-threat-model.test.mjs
+++ b/scripts/validate-threat-model.test.mjs
@@ -227,5 +227,43 @@ gaps:
       - { source_type: spec, ref: "SPEC-TEST.md", status: decision-pending }`)
 );
 
+// 11. deployed-observation evidence WITH mechanism -> passes.
+runCase(
+  "deployed-observation with mechanism",
+  0,
+  fixtureHeader(`actors:
+  - id: ACTOR-TEST
+    name: Test actor
+    actor_type: human
+    description: fixture
+    state: implemented
+    evidence:
+      - { source_type: deployed-observation, mechanism: oci-api, ref: "oci test-command, 2026-01-01", status: implemented }`)
+);
+
+// 12. deployed-observation evidence with NO mechanism -> fails.
+runCase(
+  "deployed-observation missing mechanism",
+  1,
+  fixtureHeader(`actors:
+  - id: ACTOR-TEST
+    name: Test actor
+    actor_type: human
+    description: fixture
+    state: implemented
+    evidence:
+      - { source_type: deployed-observation, ref: "oci test-command, 2026-01-01", status: implemented }`)
+);
+
+// 13. mechanism on a non-deployed-observation source -> fails.
+runCase(
+  "mechanism on document source",
+  1,
+  fixtureHeader(`actors:${BASE_ACTOR.replace(
+    '{ source_type: spec, ref: "SPEC-TEST.md", status: specified }',
+    '{ source_type: spec, mechanism: oci-api, ref: "SPEC-TEST.md", status: specified }'
+  )}`)
+);
+
 console.log(`\n${PASS} passed, ${FAIL} failed`);
 process.exit(FAIL === 0 ? 0 : 1);


### PR DESCRIPTION
## Schema Before/After

Before: `evidence.source_type` enum = `spec, adr, arch-view, roadmap, contributing, security-md` — document sources only, no way to cite "verified against live infrastructure."

After: adds `deployed-observation`, paired with a new required-when-used `mechanism` field (`oci-api, opentofu-state, opentofu-plan`).

## Evidence Source Model

Two separate questions, not conflated: **what kind of evidence** (`source_type`) vs **how was it observed** (`mechanism`, only meaningful for `deployed-observation`).

## Validator Changes

New pass in `validate-threat-model.mjs`: `mechanism` required iff `source_type=deployed-observation`, forbidden otherwise — not expressible as a clean JSON Schema conditional, same pattern as the existing implemented/decision-pending passes.

## Corpus Migration

`network.yaml`'s `COMP-INTERNET-GATEWAY`/`COMP-DRG` (PR #47) had to describe OCI CLI verification in prose because the schema had nowhere else to put it — migrated to real structured `deployed-observation` evidence entries. Added one to `CTRL-DEFAULT-DENY-SECURITY-LIST` too, deliberately `status: specified` (not `implemented`) — the four Security List objects exist but aren't associated with any subnet yet, so the control's actual protective claim isn't true.

## Tests

3 new self-test cases: valid `deployed-observation` + `mechanism` (pass), missing `mechanism` (fail), `mechanism` on a document source (fail). 13/13 pass.

## Compatibility

Backward compatible — existing document-sourced evidence entries are untouched; the new `source_type` value and `mechanism` field are additive.

- `npm run test:threat-model`: 13/13 pass
- `npm run validate:threat-model`: 44 corpus IDs, all invariants hold