### PR TITLE
fix(live): fail closed against AWS credential fallback, auto-resolve OCI namespace

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -190,11 +190,37 @@ that Spec's own scope decision rather than silently "upgrading" it ahead
 of the Spec that owns the decision. Recorded here as a confirmed-available
 follow-on for EPIC-OCI-04, not a gap.
 
-Local development authentication strategy (OCI CLI config / API key
-profile vs. session token) is not yet decided — tracked as an open item
-for whichever PR first needs a human to run `tofu`/`terragrunt` locally
-against real OCI (likely `00-foundation`'s own PR, since REQ-OCI-007's
-bootstrap is inherently a local/manual one-time step, not a CI step).
+**Local development (resolved)**: two distinct credential types, kept
+explicitly separate, matching the CREDENTIAL SCOPE NOTE in
+`live/root.hcl`:
+
+- **Native OCI API** (the `oci` CLI, the `oracle/oci` provider) — reads
+  `~/.oci/config` (tenancy/user OCID, fingerprint, region, API private
+  key) directly. No repository-owned tooling involved; this is the OCI
+  CLI's own standard config file.
+- **OCI Object Storage's S3 Compatibility API** (the OpenTofu `s3`
+  backend used for remote state) — requires an OCI Customer Secret Key
+  (`platform-tfstate-backend`), exposed to the AWS-SDK-shaped S3 client
+  as `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`. Despite the variable
+  names, this is never AWS account credential material — see
+  `live/root.hcl`'s CREDENTIAL SCOPE NOTE for how the backend is made to
+  fail closed against any local `~/.aws/credentials` or cached AWS SSO
+  session rather than silently borrowing one.
+
+Rather than requiring `export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...`
+by hand every session, `live/scripts/tg` wraps `terragrunt` for local runs:
+it resolves the Customer Secret Key pair from macOS Keychain (one-time
+setup via `security add-generic-password`, documented in the script's own
+header — the script never sees or prints the secret value) if not already
+exported, auto-resolves the non-secret Object Storage namespace live via
+`oci os ns get` (native OCI auth, already configured) instead of requiring
+a separately-exported `OCI_OBJECT_STORAGE_NAMESPACE`, and fails closed
+with a clear error if neither source can supply the Customer Secret Key —
+never falling through to an unrelated AWS profile. CI is unaffected: it
+never invokes this wrapper, supplying `OCI_OBJECT_STORAGE_NAMESPACE` and
+the Customer Secret Key pair as their own explicit GitHub Actions secrets
+in `plan.yml`. See `live/scripts/tg.test.sh` for the wrapper's own
+deterministic (stubbed, no real Keychain/OCI access) test coverage.
 
 ## Tagging contract
 

--- a/infrastructure/live/root.hcl
+++ b/infrastructure/live/root.hcl
@@ -46,6 +46,46 @@
 #   still required at apply/plan time -- they simply never get rendered
 #   into any file on disk now.
 #
+# CREDENTIAL SCOPE NOTE: despite the AWS-shaped variable names below, this
+# is NOT AWS. It is OCI Object Storage's Amazon S3 Compatibility API,
+# authenticated with an OCI Customer Secret Key. The s3 backend is simply
+# an S3-protocol client, so it borrows the AWS SDK's env var names
+# (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY) as its credential interface
+# -- those values must always be the OCI Customer Secret Key pair
+# (`platform-tfstate-backend`), never real AWS account credentials.
+#
+# [Cause] -> the AWS SDK credential chain this backend relies on does not
+#   stop at environment variables -- if they're unset, it silently walks
+#   on to ~/.aws/credentials, ~/.aws/config (including cached AWS SSO
+#   sessions), then EC2/ECS metadata. Confirmed empirically: a real
+#   `terragrunt init` in an environment with no OCI_* env vars set but an
+#   unrelated AWS SSO profile present in ~/.aws/credentials fell through
+#   to that profile and failed on an expired SSO token, rather than
+#   failing on "no OCI credentials" -- the honest, correct error.
+# [Impact] -> an unrelated AWS account (or a stale/expired one) could
+#   silently satisfy this backend's credential check, masking the real
+#   problem (OCI Customer Secret Key not supplied) with a confusing,
+#   unrelated AWS error -- or worse, could succeed against the wrong
+#   target if such a profile ever pointed at a real AWS S3 bucket sharing
+#   this key/bucket naming.
+# [Remediation] -> shared_credentials_files/shared_config_files below are
+#   pointed at a guaranteed-nonexistent path, per OpenTofu's own S3
+#   backend docs (which default these to ~/.aws/credentials /
+#   ~/.aws/config respectively). NOTE (verified, not assumed): setting
+#   these to an empty list (`[]`) does NOT work -- tested empirically,
+#   OpenTofu's S3 backend treats an empty list as "unset" and silently
+#   re-applies its own default paths, so the SSO fallback still fired.
+#   Only a nonexistent-but-non-empty path list actually suppresses that
+#   layer of the credential chain (confirmed: the next real init attempt
+#   correctly skipped straight past ~/.aws entirely to the EC2 IMDS
+#   layer, which skip_metadata_api_check then correctly blocks).
+#   Combined with skip_metadata_api_check already set and access_key/
+#   secret_key deliberately left unset, the only remaining credential
+#   source is AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY read from the
+#   process environment -- the backend now fails closed with a clear
+#   "no valid credential sources found" error instead of silently
+#   borrowing an unrelated AWS profile.
+#
 # LOCKING NOTE (resolved, PR B): `use_lockfile` was left enabled after PR A
 # pending verification. Now checked against OCI's own S3 Compatibility API
 # reference (docs.oracle.com/en-us/iaas/Content/Object/Tasks/
@@ -101,14 +141,21 @@ remote_state {
 
     # access_key/secret_key deliberately NOT set here -- see CREDENTIAL
     # NOTE above. AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY must still be
-    # exported in the shell running terragrunt/tofu; the S3 backend picks
-    # them up from the process environment automatically.
+    # exported in the shell running terragrunt/tofu (or supplied by
+    # infrastructure/live/scripts/tg -- see CREDENTIAL SCOPE NOTE above); the
+    # S3 backend picks them up from the process environment automatically.
     use_path_style              = true
     skip_region_validation      = true
     skip_credentials_validation = true
     skip_metadata_api_check     = true
     skip_s3_checksum            = true
     use_lockfile                = false # see LOCKING NOTE above — not enabled without verified conditional-write support
+
+    # See CREDENTIAL SCOPE NOTE above: forces the AWS SDK credential
+    # chain to stop at environment variables instead of silently falling
+    # through to a local AWS profile or cached SSO session.
+    shared_credentials_files = ["/dev/null/does-not-exist"]
+    shared_config_files      = ["/dev/null/does-not-exist"]
   }
 }
 

--- a/infrastructure/live/scripts/tg
+++ b/infrastructure/live/scripts/tg
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Local-development wrapper around terragrunt. NOT used by CI (plan.yml
+# calls gruntwork-io/terragrunt-action directly with credentials supplied
+# as GitHub Actions secrets) -- this exists solely so a human or agent
+# running terragrunt/tofu against real OCI from a laptop doesn't have to
+# `export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...` by hand every
+# session (see infrastructure/README.md#secrets-and-credentials-strategy).
+#
+# Despite the AWS-shaped variable names, this is NOT AWS credential
+# material -- it's the OCI Customer Secret Key (`platform-tfstate-backend`)
+# read via OCI's S3 Compatibility API client interface. This script never
+# touches a real AWS account, ~/.aws/credentials, or AWS SSO -- see
+# root.hcl's CREDENTIAL SCOPE NOTE for why the backend itself also
+# refuses to fall through to those.
+#
+# One-time setup (run these yourself -- this script never sees the
+# secret value, and neither should any agent):
+#
+#   security add-generic-password -a platform-tfstate-backend \
+#     -s oracle-free-tier-platform-s3-compat-access-key -w
+#   security add-generic-password -a platform-tfstate-backend \
+#     -s oracle-free-tier-platform-s3-compat-secret-key -w
+#
+# `security` will prompt for the value interactively (paste it there, not
+# on the command line, so it never lands in shell history).
+set -euo pipefail
+
+KEYCHAIN_ACCOUNT="platform-tfstate-backend"
+KEYCHAIN_SERVICE_ACCESS_KEY="oracle-free-tier-platform-s3-compat-access-key"
+KEYCHAIN_SERVICE_SECRET_KEY="oracle-free-tier-platform-s3-compat-secret-key"
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+# Resolves one Customer Secret Key half from macOS Keychain. Never prints
+# the retrieved value -- only whether resolution succeeded.
+resolve_from_keychain() {
+  local service="$1"
+  command -v security >/dev/null 2>&1 || return 1
+  security find-generic-password -a "$KEYCHAIN_ACCOUNT" -s "$service" -w 2>/dev/null
+}
+
+if [[ -z "${AWS_ACCESS_KEY_ID:-}" ]]; then
+  if value="$(resolve_from_keychain "$KEYCHAIN_SERVICE_ACCESS_KEY")" && [[ -n "$value" ]]; then
+    export AWS_ACCESS_KEY_ID="$value"
+    printf 'tg: AWS_ACCESS_KEY_ID resolved from Keychain\n' >&2
+  else
+    fail "AWS_ACCESS_KEY_ID not set and not found in Keychain (service=$KEYCHAIN_SERVICE_ACCESS_KEY, account=$KEYCHAIN_ACCOUNT). Export it, or run the one-time 'security add-generic-password' setup (see this script's header)."
+  fi
+fi
+
+if [[ -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+  if value="$(resolve_from_keychain "$KEYCHAIN_SERVICE_SECRET_KEY")" && [[ -n "$value" ]]; then
+    export AWS_SECRET_ACCESS_KEY="$value"
+    printf 'tg: AWS_SECRET_ACCESS_KEY resolved from Keychain\n' >&2
+  else
+    fail "AWS_SECRET_ACCESS_KEY not set and not found in Keychain (service=$KEYCHAIN_SERVICE_SECRET_KEY, account=$KEYCHAIN_ACCOUNT). Export it, or run the one-time 'security add-generic-password' setup (see this script's header)."
+  fi
+fi
+
+# Object Storage namespace is account data, not a secret -- safe to
+# auto-resolve live from the already-configured OCI CLI/API key profile
+# (~/.oci/config) rather than requiring a separate manually-exported env
+# var. CI does NOT use this path; it supplies OCI_OBJECT_STORAGE_NAMESPACE
+# as its own explicit secret in plan.yml, unrelated to this script.
+if [[ -z "${OCI_OBJECT_STORAGE_NAMESPACE:-}" ]]; then
+  command -v oci >/dev/null 2>&1 || fail "OCI_OBJECT_STORAGE_NAMESPACE not set and the 'oci' CLI is not on PATH to resolve it."
+  namespace="$(oci os ns get --raw-output --query data 2>/dev/null)" ||
+    fail "OCI_OBJECT_STORAGE_NAMESPACE not set and 'oci os ns get' failed -- check ~/.oci/config."
+  [[ -n "$namespace" ]] || fail "OCI_OBJECT_STORAGE_NAMESPACE not set and 'oci os ns get' returned an empty namespace."
+  export OCI_OBJECT_STORAGE_NAMESPACE="$namespace"
+  printf 'tg: OCI_OBJECT_STORAGE_NAMESPACE resolved from OCI API (namespace=%s)\n' "$namespace" >&2
+fi
+
+exec terragrunt "$@"

--- a/infrastructure/live/scripts/tg.test.sh
+++ b/infrastructure/live/scripts/tg.test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Deterministic tests for tg. Never touches a real Keychain entry or real
+# OCI credentials -- each case builds an isolated PATH with stub
+# `security`/`oci`/`terragrunt` executables (mirroring
+# scripts/check-gpg-signing.test.sh's isolate-don't-mock pattern) so the
+# wrapper's resolution/fail-closed logic is exercised for real, without
+# ever handling a real secret value.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TG="$SCRIPT_DIR/tg"
+
+PASS=0
+FAIL=0
+LAST_OUT=""
+LAST_STATUS=0
+
+# Builds an isolated stub bin/ dir. Args: dir, then any of
+# "security:<0|1>:<value>" / "oci:<0|1>:<value>" to install a stub that
+# exits with the given code and prints the given value on success.
+# terragrunt is always stubbed to print a sentinel and exit 0, proving
+# whether the wrapper actually reached `exec terragrunt "$@"`.
+make_stub_bin() {
+  local dir="$1"
+  shift
+  mkdir -p "$dir"
+  cat >"$dir/terragrunt" <<'EOF'
+#!/usr/bin/env bash
+echo "TERRAGRUNT_INVOKED $*"
+echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
+echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+echo "OCI_OBJECT_STORAGE_NAMESPACE=$OCI_OBJECT_STORAGE_NAMESPACE"
+EOF
+  chmod +x "$dir/terragrunt"
+
+  for spec in "$@"; do
+    local name rest code value
+    name="${spec%%:*}"
+    rest="${spec#*:}"
+    code="${rest%%:*}"
+    value="${rest#*:}"
+    cat >"$dir/$name" <<EOF
+#!/usr/bin/env bash
+if [[ $code -eq 0 ]]; then
+  printf '%s' "$value"
+  exit 0
+else
+  exit 1
+fi
+EOF
+    chmod +x "$dir/$name"
+  done
+}
+
+# Runs tg in an isolated env; sets LAST_OUT/LAST_STATUS. Does not assert --
+# callers check LAST_OUT/LAST_STATUS themselves.
+invoke_tg() {
+  local dir="$1"
+  shift
+  LAST_OUT="$(env -i PATH="$dir:/usr/bin:/bin" HOME="$HOME" "$@" "$TG" plan 2>&1)"
+  LAST_STATUS=$?
+}
+
+pass() {
+  echo "PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "FAIL: $1"
+  echo "$LAST_OUT"
+  FAIL=$((FAIL + 1))
+}
+
+# 1. No env vars, no Keychain entries -> fails closed, never invokes terragrunt.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" "security:1:"
+invoke_tg "$dir"
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 1 && "$LAST_OUT" != *"TERRAGRUNT_INVOKED"* ]]; then
+  pass "no credentials anywhere -> fail closed"
+else
+  fail "no credentials anywhere -> fail closed (expected exit 1, no invocation; got status=$LAST_STATUS)"
+fi
+
+# 2. Keychain has both Customer Secret Key halves + oci CLI resolves namespace -> succeeds, values flow through.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" "security:0:fake-secret-value" "oci:0:ax4ugzw7dvvm"
+invoke_tg "$dir"
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" == *"TERRAGRUNT_INVOKED plan"* && "$LAST_OUT" == *"OCI_OBJECT_STORAGE_NAMESPACE=ax4ugzw7dvvm"* ]]; then
+  pass "keychain + oci resolve everything -> success"
+else
+  fail "keychain + oci resolve everything -> success (status=$LAST_STATUS)"
+fi
+
+# 3. Keychain lookup fails (not found) -> fail closed, never invokes terragrunt.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" "security:1:" "oci:0:ax4ugzw7dvvm"
+invoke_tg "$dir"
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 1 && "$LAST_OUT" != *"TERRAGRUNT_INVOKED"* ]]; then
+  pass "keychain entry missing -> fail closed"
+else
+  fail "keychain entry missing -> fail closed (status=$LAST_STATUS)"
+fi
+
+# 4. Credentials already in env -> wrapper must NOT call security at all (env vars win, no Keychain touch).
+dir="$(mktemp -d)"
+make_stub_bin "$dir" "oci:0:ax4ugzw7dvvm"
+cat >"$dir/security" <<'EOF'
+#!/usr/bin/env bash
+echo "SECURITY_CALLED" >&2
+exit 1
+EOF
+chmod +x "$dir/security"
+invoke_tg "$dir" env AWS_ACCESS_KEY_ID=env-access AWS_SECRET_ACCESS_KEY=env-secret
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" != *"SECURITY_CALLED"* && "$LAST_OUT" == *"AWS_ACCESS_KEY_ID=env-access"* ]]; then
+  pass "env vars already set -> Keychain never consulted"
+else
+  fail "env vars already set -> Keychain never consulted (status=$LAST_STATUS)"
+fi
+
+# 5. Namespace already in env -> wrapper must NOT call oci CLI at all.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" "security:0:fake-secret-value"
+cat >"$dir/oci" <<'EOF'
+#!/usr/bin/env bash
+echo "OCI_CALLED" >&2
+exit 1
+EOF
+chmod +x "$dir/oci"
+invoke_tg "$dir" env OCI_OBJECT_STORAGE_NAMESPACE=preset-ns
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" != *"OCI_CALLED"* && "$LAST_OUT" == *"OCI_OBJECT_STORAGE_NAMESPACE=preset-ns"* ]]; then
+  pass "namespace already set -> oci CLI never consulted"
+else
+  fail "namespace already set -> oci CLI never consulted (status=$LAST_STATUS)"
+fi
+
+# 6. oci CLI present but returns empty namespace -> fails closed rather than generating a broken endpoint.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" "security:0:fake-secret-value" "oci:0:"
+invoke_tg "$dir"
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 1 && "$LAST_OUT" != *"TERRAGRUNT_INVOKED"* ]]; then
+  pass "oci returns empty namespace -> fail closed"
+else
+  fail "oci returns empty namespace -> fail closed (status=$LAST_STATUS)"
+fi
+
+# 7. AWS_PROFILE set in ambient env, but no OCI credentials anywhere -> still fails closed
+#    (wrapper does not consult AWS_PROFILE at all; root.hcl's backend config is the real
+#    guard against that layer -- this just proves the wrapper itself doesn't special-case it).
+dir="$(mktemp -d)"
+make_stub_bin "$dir" "security:1:" "oci:0:ax4ugzw7dvvm"
+invoke_tg "$dir" env AWS_PROFILE=some-unrelated-sso-profile
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 1 && "$LAST_OUT" != *"TERRAGRUNT_INVOKED"* ]]; then
+  pass "unrelated AWS_PROFILE present -> still fails closed"
+else
+  fail "unrelated AWS_PROFILE present -> still fails closed (status=$LAST_STATUS)"
+fi
+
+# 8. Secret value itself never appears in the wrapper's own stderr output.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" "security:0:super-secret-marker-value" "oci:0:ax4ugzw7dvvm"
+LAST_OUT="$(env -i PATH="$dir:/usr/bin:/bin" HOME="$HOME" "$TG" plan 2>&1 >/dev/null)"
+rm -rf "$dir"
+if [[ "$LAST_OUT" != *"super-secret-marker-value"* ]]; then
+  pass "secret value never printed to stderr"
+else
+  fail "secret value leaked to stderr"
+fi
+
+echo
+echo "$PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Follow-up correction to #49. That PR removed literal `access_key`/`secret_key` from the S3 backend block, but left the AWS SDK's default credential chain intact — verified empirically that this backend could silently fall through to an unrelated local AWS profile/SSO session instead of failing on the real problem (missing OCI Customer Secret Key). Also fixes a real empty-namespace bug in the generated S3-compatible endpoint.

**This is not AWS.** It's OCI Object Storage's Amazon S3 Compatibility API — the `s3` backend is simply an S3-protocol client, so it borrows AWS SDK env var names (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`) as its credential interface. Those values must always be the OCI Customer Secret Key (`platform-tfstate-backend`), never real AWS account credentials. See `root.hcl`'s new CREDENTIAL SCOPE NOTE.

- `infrastructure/live/root.hcl`: `shared_credentials_files`/`shared_config_files` now point at a guaranteed-nonexistent path. **Verified empirically, not assumed**: an empty list (`[]`) does *not* suppress the AWS SDK's `~/.aws/credentials`/SSO fallback layer — OpenTofu's S3 backend treats it as unset and silently reapplies its own default. Only a nonexistent path actually works. Combined with the already-set `skip_metadata_api_check` and unset `access_key`/`secret_key`, the backend now fails closed with `No valid credential sources found` instead of borrowing an unrelated AWS profile.
- `infrastructure/live/scripts/tg`: new local-only wrapper around `terragrunt` (CI is unaffected — `plan.yml` supplies its own explicit secrets and never invokes this). Resolves the Customer Secret Key pair from macOS Keychain and the non-secret Object Storage namespace live via `oci os ns get` when not already exported. Fails closed with a clear error if the Keychain/env don't supply the secret pair. Never prints secret values.
- `infrastructure/live/scripts/tg.test.sh`: 8 deterministic test cases (stubbed `security`/`oci`/`terragrunt`, no real Keychain/OCI access) covering fail-closed paths, Keychain/OCI-CLI resolution, and that already-set env vars take precedence without touching Keychain or the OCI CLI.
- `infrastructure/README.md`: resolves the previously-open "local development authentication strategy... not yet decided" item.

## Test plan

- [x] `terragrunt hcl fmt --check` / `terragrunt hcl validate` pass from `infrastructure/live/`
- [x] `shellcheck` clean on both new scripts
- [x] `bash infrastructure/live/scripts/tg.test.sh` — 8/8 pass
- [x] `pre-commit run --all-files` on changed files — all pass, including secret detection
- [x] Real (non-stubbed) verification against live OCI: `oci os ns get` confirms namespace `ax4ugzw7dvvm`; a real `tg init` with no Keychain entry and no env vars fails closed at the Keychain-lookup step (never reaches terragrunt); a real `tg init` with dummy S3-compat credentials correctly auto-resolves the namespace into the endpoint (`https://ax4ugzw7dvvm.compat.objectstorage.eu-madrid-1.oci.customer-oci.com`) and gets a real, on-target `SignatureDoesNotMatch` from OCI Object Storage (proving the full chain reaches the right service, not AWS)
- [x] Grepped the entire regenerated `.terragrunt-cache` tree for `access_key=`/`secret_key=` literals and any leaked value — none found

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>