### PR TITLE
fix(live): replace macOS Keychain with Proton Pass as backend credential source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,19 @@ for the full problem statement.
 
 ## Project Structure & Module Organization
 
-This repository is **greenfield**: governance scaffolding, specs, and
-architecture docs exist, but no OpenTofu modules or running infrastructure
-yet. Consult `docs/00-overview/roadmap.md` for what milestone is actually
-in progress before assuming a component exists — architecture work
-currently proceeds domain-by-domain (network → identity/governance/CI-CD →
-Kubernetes), evidence-first; do not infer that a later phase (e.g. threat
-modeling) has started from this file.
+Architecture work proceeds domain-by-domain (network →
+identity/governance/CI-CD → Kubernetes), evidence-first. `infrastructure/`
+is no longer reserved-only: `00-foundation` (compartment, IAM, the
+Terragrunt state-backend bucket) and `10-network` (VCN, 4 trust-zone
+subnets, Internet Gateway, DRG object) are real modules with real,
+partially-applied resources in the lab environment — NAT/Service Gateway,
+DRG route tables/attachment, and per-zone route tables are still blocked
+on real OCI service-limit constraints (see
+`infrastructure/modules/network/README.md`'s Failure modes section), not
+yet built. Consult `docs/00-overview/roadmap.md` for what milestone is
+actually in progress before assuming a component exists further along
+than this — do not infer that a later phase (e.g. Kubernetes bootstrap)
+has started from this file.
 
 - `docs/00-overview/` — vision, personas, roadmap.
 - `docs/01-architecture/`, `docs/arch/`, and `*.mmd` files — architecture
@@ -22,10 +28,15 @@ modeling) has started from this file.
 - `docs/02-decisions/` — accepted ADRs.
 - `docs/specs/` — canonical numbered requirements (see "Source of truth"
   below).
-- `docs/03-threat-model/`, `docs/04-operations/`, `docs/05-security/`,
-  `docs/06-runbooks/` — not started yet; each has a `README.md` stating so.
-- `infrastructure/` — reserved for OpenTofu modules, compositions, and
-  Terragrunt live environments.
+- `docs/03-threat-model/` — Phase 3A in progress (EPIC-TM-01/I20): a
+  real, schema-validated `network.yaml` corpus exists
+  (`docs/03-threat-model/model/instances/`); the DFD/STRIDE/attack-tree
+  phases after it have not started — see that directory's own
+  `README.md` for the exact pipeline position.
+- `docs/04-operations/`, `docs/05-security/`, `docs/06-runbooks/` — not
+  started yet; each has a `README.md` stating so.
+- `infrastructure/` — OpenTofu modules, compositions, and Terragrunt live
+  environments (see above — partially applied, not reserved-only).
 - `scripts/` — validation helpers; `.github/` — CI and PR policy.
 
 There is no application or unit-test suite. `package.json` exists solely
@@ -227,6 +238,54 @@ Never commit credentials, `.oci/` material, Talos secrets, kubeconfigs,
 rotate anything exposed immediately. See `SECURITY.md` for the
 vulnerability-reporting process.
 
+### Terragrunt/OpenTofu remote-state backend credentials
+
+Full operator procedure (prerequisites, usage, troubleshooting,
+rotation, migration path):
+[infrastructure/README.md#secrets-and-credentials-strategy](infrastructure/README.md#secrets-and-credentials-strategy)
+— this is the canonical document; the rules below are the operational
+contract an agent must follow, not a restatement of that procedure.
+
+- Local backend credentials (the OCI Customer Secret Key, exposed as
+  `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` — S3-client-mandated
+  names, not AWS account credentials) come from **Proton Pass** only:
+  vault `Personal`, item `OCI - OpenTofu Remote State v3`
+  (`username` → Access Key ID, `password` → Secret Key).
+- **`infrastructure/live/scripts/tg` is the only supported entry
+  point** for local `terragrunt`/`tofu` invocations against real OCI —
+  never run `terragrunt`/`tofu` directly against a unit whose backend
+  needs this credential.
+- Never request, print, log, persist, copy, or inspect the secret
+  value. Never run `pass-cli item view` for this item with
+  `--output human` or without piping into a values-stripping filter.
+- Never place these credentials in HCL, `.env` files, shell profiles,
+  `~/.aws/credentials`, `~/.aws/config`, repository files, generated
+  `backend.tf`, plan artifacts, or logs.
+- Never bypass `tg` by manually exporting these credentials, and never
+  silently fall back to AWS profiles, AWS SSO, plaintext files, or
+  macOS Keychain — macOS Keychain is explicitly **not** a supported
+  credential source for this repository, for anyone, with no
+  exceptions (this predates and extends beyond this specific
+  credential).
+- Fail closed when Proton Pass retrieval or OCI namespace resolution
+  fails — do not improvise an alternate source.
+- Never rotate or delete an OCI Customer Secret Key as part of normal
+  validation or automated cleanup. Rotation/deletion requires explicit
+  user authorization (see the README's rotation procedure).
+- **Proton Pass is a bootstrap/local-development mechanism, not this
+  platform's final-state secret architecture.** Secret ownership is
+  expected to move to OpenBao (already the roadmap target,
+  `docs/00-overview/roadmap.md`) once it is deployed and reachable from
+  wherever Terragrunt/OpenTofu runs. Do not introduce a new permanent
+  dependency on Proton Pass beyond this bootstrap role, and design any
+  new secret-handling code so the source can later swap to OpenBao
+  without changing Terragrunt/OpenTofu module contracts — see `tg`'s
+  own `run_with_backend_credentials()` for the established pattern.
+- Preserve remote-state safety before any plan/apply/import/state
+  operation: check `git status`, confirm the working directory is
+  clean, and never run a mutating state operation without first
+  understanding what's currently applied.
+
 ## Agent-specific guardrails
 
 - Never revert, overwrite, stage, reformat, or rename a user's own
@@ -244,3 +303,7 @@ vulnerability-reporting process.
 - Treat automated review-bot billing/paywall notices (e.g. "trial
   expired", "reviews paused for this user") as non-actionable noise, not
   findings — but still read every review for genuine findings underneath.
+- Always use `infrastructure/live/scripts/tg` for local
+  `terragrunt`/`tofu` against real OCI — never invoke them directly, and
+  never manually export the OCI Customer Secret Key as a bypass. See
+  "Terragrunt/OpenTofu remote-state backend credentials" above.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,17 @@ problem statement, users, and success metrics.
 
 ## Status
 
-**Greenfield.** Governance scaffolding, specifications, and architecture
-documentation exist; no OpenTofu modules or running infrastructure yet.
-Check [docs/00-overview/roadmap.md](docs/00-overview/roadmap.md) for the
-milestone actually in progress before assuming a component exists — do not
-infer implementation status from this README.
+Governance scaffolding, specifications, and architecture documentation
+are established, and infrastructure work has begun: `00-foundation`
+(compartment, IAM, state-backend bucket) and `10-network` (VCN, 4
+trust-zone subnets, Internet Gateway, DRG object) are real OpenTofu
+modules with real, partially-applied resources in the lab environment —
+NAT/Service Gateway, DRG route tables/attachment, and per-zone route
+tables remain blocked on real OCI service-limit constraints, not yet
+built. Kubernetes and everything above it has not started. Check
+[docs/00-overview/roadmap.md](docs/00-overview/roadmap.md) for the
+milestone actually in progress before assuming a component exists further
+along than this — do not infer implementation status from this README.
 
 ## Technology decisions vs. open questions
 
@@ -64,11 +70,24 @@ Cross-domain identity (GitHub, OCI IAM, human IdP, OpenZiti, Kubernetes
 RBAC, ServiceAccount, SPIFFE, OpenBao, Flux) is reconciled explicitly in
 [docs/01-architecture/identity-reconciliation.md](docs/01-architecture/identity-reconciliation.md) —
 similarly-named principals across systems are not assumed to be the same
-one unless a mapping mechanism is documented. Threat modeling (DFDs, attack
-paths, risk register) has not started yet — see
+one unless a mapping mechanism is documented. Threat modeling is Phase 3A
+in progress (a schema-validated `network.yaml` corpus exists; DFDs, attack
+paths, and the risk register have not started) — see
 [docs/03-threat-model/README.md](docs/03-threat-model/README.md) for the
-planned evidence chain and [SECURITY.md](SECURITY.md) for vulnerability
+exact pipeline position and [SECURITY.md](SECURITY.md) for vulnerability
 reporting.
+
+**Secrets lifecycle**: in-cluster/workload secrets are OpenBao + External
+Secrets Operator's domain (above), not yet deployed. Separately, the
+Terragrunt/OpenTofu remote-state backend (a pre-cluster, local-developer
+concern — OpenBao can't bootstrap infrastructure that would host it) uses
+Proton Pass as a temporary bootstrap credential source today, with a
+documented migration path to OpenBao once it's deployed and reachable, and
+OIDC/workload identity preferred beyond that wherever OCI/OpenTofu support
+it. This is a bootstrap tooling decision, not a change to the OpenBao
+target above — see
+[infrastructure/README.md#secrets-and-credentials-strategy](infrastructure/README.md#secrets-and-credentials-strategy)
+for the full operator procedure.
 
 ## Specification-driven delivery model
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -190,37 +190,201 @@ that Spec's own scope decision rather than silently "upgrading" it ahead
 of the Spec that owns the decision. Recorded here as a confirmed-available
 follow-on for EPIC-OCI-04, not a gap.
 
-**Local development (resolved)**: two distinct credential types, kept
-explicitly separate, matching the CREDENTIAL SCOPE NOTE in
-`live/root.hcl`:
+### Local development: credential architecture
+
+Two distinct credential types, kept explicitly separate, matching the
+CREDENTIAL SCOPE NOTE in `live/root.hcl`:
 
 - **Native OCI API** (the `oci` CLI, the `oracle/oci` provider) — reads
   `~/.oci/config` (tenancy/user OCID, fingerprint, region, API private
   key) directly. No repository-owned tooling involved; this is the OCI
   CLI's own standard config file.
 - **OCI Object Storage's S3 Compatibility API** (the OpenTofu `s3`
-  backend used for remote state) — requires an OCI Customer Secret Key
-  (`platform-tfstate-backend`), exposed to the AWS-SDK-shaped S3 client
-  as `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`. Despite the variable
-  names, this is never AWS account credential material — see
-  `live/root.hcl`'s CREDENTIAL SCOPE NOTE for how the backend is made to
-  fail closed against any local `~/.aws/credentials` or cached AWS SSO
-  session rather than silently borrowing one.
+  backend used for remote state) — requires an OCI Customer Secret Key,
+  exposed to the AWS-SDK-shaped S3 client as `AWS_ACCESS_KEY_ID`/
+  `AWS_SECRET_ACCESS_KEY`. **These are S3-client-mandated variable
+  names, not AWS account credentials** — OpenTofu's `s3` backend is
+  simply an S3-protocol client, and OCI Object Storage's Amazon S3
+  Compatibility API happens to authenticate with that same variable
+  pair. See `live/root.hcl`'s CREDENTIAL SCOPE NOTE for how the backend
+  is also made to fail closed against any local `~/.aws/credentials` or
+  cached AWS SSO session, independent of the wrapper below.
+
+```text
+Proton Pass (vault "Personal", item "OCI - OpenTofu Remote State v3")
+    -> pass-cli run
+    -> AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+       (this process's environment only -- never persisted)
+    -> OpenTofu S3-compatible backend
+    -> OCI Object Storage
+```
 
 Rather than requiring `export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...`
-by hand every session, `live/scripts/tg` wraps `terragrunt` for local runs:
-it resolves the Customer Secret Key pair from macOS Keychain (one-time
-setup via `security add-generic-password`, documented in the script's own
-header — the script never sees or prints the secret value) if not already
-exported, auto-resolves the non-secret Object Storage namespace live via
-`oci os ns get` (native OCI auth, already configured) instead of requiring
-a separately-exported `OCI_OBJECT_STORAGE_NAMESPACE`, and fails closed
-with a clear error if neither source can supply the Customer Secret Key —
-never falling through to an unrelated AWS profile. CI is unaffected: it
-never invokes this wrapper, supplying `OCI_OBJECT_STORAGE_NAMESPACE` and
-the Customer Secret Key pair as their own explicit GitHub Actions secrets
-in `plan.yml`. See `live/scripts/tg.test.sh` for the wrapper's own
-deterministic (stubbed, no real Keychain/OCI access) test coverage.
+by hand every session, `live/scripts/tg` wraps `terragrunt` for local
+runs: `resolve_backend_credentials_proton_pass()` resolves the Customer
+Secret Key pair from Proton Pass into `pass://` *references* (never raw
+values — see the script's own "Why references, not values" comment),
+and `run_with_backend_credentials()` hands those to `pass-cli run`,
+which resolves them itself and injects real values only into the
+`terragrunt` child process — `tg`'s own process never holds, reads,
+prints, logs, or disk-stages either value. It also auto-resolves the
+non-secret Object Storage namespace live via `oci os ns get` (native OCI
+auth, already configured) instead of requiring a separately-exported
+`OCI_OBJECT_STORAGE_NAMESPACE`, and fails closed with a clear error if
+Proton Pass can't supply the Customer Secret Key. These two functions
+are a deliberate provider boundary: swapping to a future OpenBao
+provider means replacing `resolve_backend_credentials_proton_pass()`
+alone — see "Secret-source migration path" below. See
+`live/scripts/tg.test.sh` for the wrapper's own deterministic (stubbed,
+no real Proton Pass/OCI access) test coverage, including a
+provider-boundary separation check.
+
+#### Credential precedence
+
+Fixed, no override, no exceptions:
+
+1. **Proton Pass** (via `tg`) — the only supported source for
+   interactive/local use. There is deliberately no "already set in the
+   environment" step — `tg` overwrites any pre-existing
+   `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for the child process
+   rather than honoring them, since honoring a pre-set value is exactly
+   the manual-export bypass this wrapper exists to prevent.
+   `~/.aws/credentials`, `~/.aws/config`, `AWS_PROFILE`,
+   `AWS_DEFAULT_PROFILE`, AWS SSO, EC2/ECS metadata, and macOS Keychain
+   are never consulted at any point in this precedence.
+2. **Fail closed.**
+
+**BREAK GLASS / CI INTERFACE** (not the local operator workflow): CI's
+`plan.yml` supplies `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` directly
+as GitHub Actions secrets to `gruntwork-io/terragrunt-action`, bypassing
+`tg` entirely — that is CI's own documented, narrowly-scoped interface.
+A human or agent must never replicate this locally by exporting these
+variables by hand; always go through `tg`.
+
+#### Prerequisites
+
+- `oci` CLI installed and authenticated (`~/.oci/config` populated —
+  native OCI API auth, unrelated to the backend credential below).
+- `pass-cli` installed and authenticated (`pass-cli login`, interactive,
+  opens a browser — `tg` never attempts this for you; verify with
+  `pass-cli info`).
+- A Proton Pass Login item named `OCI - OpenTofu Remote State v3` in the
+  `Personal` vault, with `username` set to the OCI Customer Secret Key's
+  Access Key ID and `password` set to its Secret Key. (The item *title*
+  is configuration, safe to document — the field *values* are not, and
+  never appear anywhere in this repository.)
+- `tofu` and `terragrunt`, pinned versions per the Toolchain table above.
+
+**Naming note**: the item title is versioned (`...v3`) because the
+underlying OCI Customer Secret Key is versioned
+(`platform-tfstate-backend-v3`) — a prior `OCI - OpenTofu Remote State
+v2` item also exists in the same vault from an earlier iteration.
+**Recommendation** (not yet applied): rename the *current* item to a
+stable, unversioned title (e.g. `OCI - OpenTofu Remote State`) so
+`tg`'s `PASS_ITEM` constant never needs to change on a future key
+rotation — the OCI key's own display name can stay versioned
+independently, since that's just a label, not a lookup key `tg`
+depends on. This is a rename recommendation only; it has not been
+applied, since renaming a Proton Pass item is a real action with real
+consequences (anything else referencing the old title by name would
+break) that the vault owner should decide and perform, and `tg`'s
+`PASS_ITEM` constant would need updating in lockstep with any rename.
+
+#### Usage
+
+Always invoke through the wrapper — never export the backend credential
+pair by hand:
+
+```bash
+infrastructure/live/scripts/tg init
+infrastructure/live/scripts/tg plan
+infrastructure/live/scripts/tg state list
+```
+
+Run from inside the target unit directory (e.g.
+`infrastructure/live/oci/eu-madrid-1/lab/10-network`), matching plain
+`terragrunt`'s own convention — `tg` forwards every argument unchanged.
+
+#### Safe verification (never displays the credential)
+
+```bash
+pass-cli info                                     # confirms Proton Pass session, no secret output
+pass-cli item view --vault-name "Personal" \
+  --item-title "OCI - OpenTofu Remote State v3" \
+  --output json | jq '.item.content | keys'        # confirms fields exist, prints only field NAMES
+oci os ns get                                      # confirms native OCI auth + namespace, non-secret
+```
+
+Never run `pass-cli item view` for this item with `--output human` or
+without piping into a values-stripping filter — both surface the raw
+secret values.
+
+#### Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `pass-cli is not installed or not on PATH` | `pass-cli` missing | install it, then re-run `tg` |
+| `pass-cli is not authenticated` | no active Proton Pass session | `pass-cli login` (interactive), retry |
+| `Could not find item with name ...` | item missing/renamed/wrong vault | confirm vault `Personal`, item title exactly `OCI - OpenTofu Remote State v3` |
+| `Field 'username'/'password' not found in item` | item exists but field missing | add the missing field in Proton Pass; never via a command that puts the value in shell history |
+| `oci os ns get` fails / `~/.oci/config` errors | native OCI auth misconfigured | fix `~/.oci/config`, verify with `oci iam region list` |
+| namespace resolution returns empty | transient OCI API issue, or wrong region in `~/.oci/config` | re-run; verify region matches `common/region.hcl` |
+| backend authentication failure (`SignatureDoesNotMatch` etc.) | resolved credential pair doesn't match an ACTIVE OCI Customer Secret Key | confirm the Proton Pass item's values match a currently ACTIVE key (`oci iam customer-secret-key list --user-id <ocid>` — lists names/state only, never secret values) |
+| `SignatureDoesNotMatch` immediately after creating a **new** Customer Secret Key | IAM→Object-Storage-compat credential propagation lag — confirmed transient during this bootstrap, several minutes, not a config defect (see "Bootstrap runbook" below) | retry after a few minutes; not a Proton Pass or `tg` problem |
+
+#### Rotation procedure (high level)
+
+1. Create a new OCI Customer Secret Key (`oci iam customer-secret-key
+   create`) — do this alongside the existing one, don't delete the old
+   key first.
+2. Store the new Access Key ID / Secret Key pair in a **new** Proton
+   Pass item (or update the existing item's fields) — never as a CLI
+   literal argument if it can be avoided; if it can't, that's a real,
+   narrow exposure window (briefly visible in `ps aux`) worth flagging
+   before doing it.
+3. Point `tg` at the new item (update `PASS_ITEM` in
+   `infrastructure/live/scripts/tg` if the item title changed) and
+   validate: `tg init`, `tg state list` against a real unit.
+4. Verify remote state is reachable and a real plan succeeds before
+   relying on the new key for anything else.
+5. Retain the old key as a rollback path until the new one is proven in
+   practice across a real init/plan/apply cycle.
+6. Delete the old OCI Customer Secret Key only after explicit user
+   approval — never as part of routine validation or automated cleanup.
+
+#### Secret-source migration path
+
+Proton Pass is a **bootstrap/local-development mechanism**, not this
+platform's final-state secret architecture:
+
+```text
+Bootstrap (current):
+  Proton Pass -> pass-cli -> tg -> Terragrunt/OpenTofu
+
+Target (once OpenBao + External Secrets Operator -- already the
+roadmap target, docs/00-overview/roadmap.md -- is deployed and
+reachable from wherever Terragrunt/OpenTofu runs):
+  OpenBao -> authenticated operator/automation identity ->
+  policy-controlled backend-credential retrieval -> tg / automation
+
+Future (where OCI/OpenTofu support it):
+  OIDC / short-lived workload identity, eliminating static backend
+  credentials entirely -- OpenBao then manages only whatever static or
+  rotatable secrets still need to exist.
+```
+
+`tg`'s `run_with_backend_credentials()` function is the sole place that
+knows how credentials are fetched (see the script's own header) — a
+future migration to OpenBao replaces that one function's body; the
+Terragrunt/OpenTofu-facing contract (`AWS_ACCESS_KEY_ID`/
+`AWS_SECRET_ACCESS_KEY` as process-scoped environment variables) does
+not change. This is a **temporary bootstrap decision**, not a
+superseding architecture decision — it does not amend or replace the
+OpenBao target already implied by the roadmap, and no new permanent
+dependency on Proton Pass should be introduced beyond this bootstrap
+role. A future ADR may formalize the OCI Vault-vs-OpenBao question for
+in-cluster/workload secrets generally (see `SPEC-OCI-002`'s own note on
+this); this bootstrap tooling choice is deliberately not that ADR.
 
 ## Tagging contract
 

--- a/infrastructure/live/scripts/tg
+++ b/infrastructure/live/scripts/tg
@@ -1,64 +1,149 @@
 #!/usr/bin/env bash
 # Local-development wrapper around terragrunt. NOT used by CI (plan.yml
 # calls gruntwork-io/terragrunt-action directly with credentials supplied
-# as GitHub Actions secrets) -- this exists solely so a human or agent
-# running terragrunt/tofu against real OCI from a laptop doesn't have to
-# `export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...` by hand every
-# session (see infrastructure/README.md#secrets-and-credentials-strategy).
+# as GitHub Actions secrets -- see "Credential precedence" below) -- this
+# exists solely so a human or agent running terragrunt/tofu against real
+# OCI from a laptop doesn't have to manually export the OCI Customer
+# Secret Key every session (see
+# infrastructure/README.md#secrets-and-credentials-strategy, the canonical
+# operator procedure -- this header is a summary, not a duplicate).
 #
 # Despite the AWS-shaped variable names, this is NOT AWS credential
-# material -- it's the OCI Customer Secret Key (`platform-tfstate-backend`)
-# read via OCI's S3 Compatibility API client interface. This script never
-# touches a real AWS account, ~/.aws/credentials, or AWS SSO -- see
-# root.hcl's CREDENTIAL SCOPE NOTE for why the backend itself also
-# refuses to fall through to those.
+# material -- it's an OCI Customer Secret Key, read via OCI Object
+# Storage's Amazon S3 Compatibility API client interface, which happens
+# to use the AWS SDK's own variable names because it's an S3-protocol
+# client. This script never touches a real AWS account, ~/.aws/*, or AWS
+# SSO -- see root.hcl's CREDENTIAL SCOPE NOTE for how the backend itself
+# also refuses to fall through to those, independent of this wrapper.
 #
-# One-time setup (run these yourself -- this script never sees the
-# secret value, and neither should any agent):
+# SECRET SOURCE LIFECYCLE:
 #
-#   security add-generic-password -a platform-tfstate-backend \
-#     -s oracle-free-tier-platform-s3-compat-access-key -w
-#   security add-generic-password -a platform-tfstate-backend \
-#     -s oracle-free-tier-platform-s3-compat-secret-key -w
+#   CURRENT (bootstrap/local-development only):
+#     Proton Pass -> pass-cli -> this wrapper -> process environment
+#     -> OpenTofu/Terragrunt
 #
-# `security` will prompt for the value interactively (paste it there, not
-# on the command line, so it never lands in shell history).
+#   TARGET (once OpenBao + External Secrets Operator -- already the
+#   roadmap target, docs/00-overview/roadmap.md -- is deployed and
+#   reachable from wherever this script runs):
+#     OpenBao -> authenticated operator/automation identity ->
+#     policy-controlled credential retrieval -> process-scoped injection
+#     -> OpenTofu/Terragrunt
+#
+#   LONG-TERM PREFERENCE: OIDC / short-lived workload identity,
+#   eliminating static backend credentials wherever OCI/OpenTofu support
+#   it -- OpenBao would then manage only whatever static or rotatable
+#   secrets still need to exist.
+#
+# Do not introduce a new permanent dependency on Proton Pass beyond this
+# bootstrap role. See infrastructure/README.md#secret-source-migration-path
+# for the full picture.
+#
+# PROVIDER BOUNDARY: resolve_backend_credentials_proton_pass() below is
+# the only function that knows how credentials are actually fetched. A
+# future resolve_backend_credentials_openbao() would replace it (naming
+# reserved deliberately) -- nothing else in this script, and nothing in
+# Terragrunt/OpenTofu's own config, needs to change. The stable contract
+# on both sides: the resolver sets BACKEND_ACCESS_KEY_ID_REF /
+# BACKEND_SECRET_KEY_REF (provider-specific *references*, never raw
+# values -- see "Why references, not values" below), and
+# run_with_backend_credentials() is the only place that turns those into
+# the child process's AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY. How a
+# reference gets resolved into a real value is entirely the provider's
+# concern (today: pass-cli run; an OpenBao provider might instead use
+# `bao`'s own env-injection or a short-lived token exchange).
+#
+# Why references, not values: this wrapper's own process NEVER holds the
+# raw secret at any point, even transiently in a shell variable. The
+# resolver only produces a `pass://...`-style reference string (which is
+# not secret -- it names a vault/item/field, not a value); the actual
+# value resolution happens inside `pass-cli run`, which injects it
+# straight into the terragrunt child's environment and never returns it
+# to this script. This is a stronger guarantee than "resolve into a
+# local variable, then export it" would give, at no cost in
+# abstraction -- keep this property when implementing a future provider.
+#
+# Current provider: Proton Pass (vault "Personal", item
+# "OCI - OpenTofu Remote State v3", Login item -- `username` field holds
+# the Access Key ID, `password` field holds the Secret Key).
+#
+# Credential precedence (fixed, no override):
+#   1. Proton Pass (via resolve_backend_credentials_proton_pass) -- the
+#      only supported source for interactive/local use.
+#   2. Fail closed.
+# There is deliberately no "already set in the environment" step in
+# this precedence -- if AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY happen to
+# already be set when this script runs, the exec below overwrites them
+# for the child rather than honoring them, since honoring a pre-set
+# value is exactly the manual-export bypass this wrapper exists to
+# prevent. CI does NOT go through this precedence at all -- it is a
+# BREAK GLASS / CI INTERFACE that supplies AWS_ACCESS_KEY_ID/
+# AWS_SECRET_ACCESS_KEY directly as GitHub Actions secrets to
+# gruntwork-io/terragrunt-action, bypassing this script entirely (see
+# .github/workflows/plan.yml) -- that path is CI's own documented
+# interface, not a normal local operator workflow, and must not be
+# replicated by a human/agent exporting these vars by hand locally.
+#
+# macOS Keychain is NOT a supported credential source for this script
+# and must not be reintroduced: no `security find-generic-password`/
+# `add-generic-password` calls, no KEYCHAIN_* lookup/fallback logic, no
+# Proton-Pass-to-Keychain sync, no caching the resolved credential in any
+# other persistent store (a plaintext file, a shell profile, a `.env`
+# file, HCL). ~/.aws/credentials, ~/.aws/config, AWS profiles, and AWS
+# SSO are never consulted by this script (root.hcl's own backend config
+# independently blocks that layer too -- see its CREDENTIAL SCOPE NOTE).
+#
+# One-time setup (run yourself -- this script never touches Proton Pass
+# outside of resolving these two fields at run time):
+#
+#   1. Install pass-cli and complete `pass-cli login` (interactive,
+#      opens a browser -- this script never attempts it for you).
+#   2. Confirm the vault/item above exist with `username`/`password`
+#      fields populated with the OCI Customer Secret Key pair.
+#
+# This script never prints, logs, or disk-stages either field's value.
+# No `set -x` around credential retrieval, ever.
 set -euo pipefail
 
-KEYCHAIN_ACCOUNT="platform-tfstate-backend"
-KEYCHAIN_SERVICE_ACCESS_KEY="oracle-free-tier-platform-s3-compat-access-key"
-KEYCHAIN_SERVICE_SECRET_KEY="oracle-free-tier-platform-s3-compat-secret-key"
+PASS_VAULT="Personal"
+PASS_ITEM="OCI - OpenTofu Remote State v3"
 
 fail() {
   printf 'ERROR: %s\n' "$1" >&2
   exit 1
 }
 
-# Resolves one Customer Secret Key half from macOS Keychain. Never prints
-# the retrieved value -- only whether resolution succeeded.
-resolve_from_keychain() {
-  local service="$1"
-  command -v security >/dev/null 2>&1 || return 1
-  security find-generic-password -a "$KEYCHAIN_ACCOUNT" -s "$service" -w 2>/dev/null
+# Sets BACKEND_ACCESS_KEY_ID_REF / BACKEND_SECRET_KEY_REF to pass://
+# references (not values -- see "Why references, not values" above).
+# Fails closed if pass-cli is missing or unauthenticated; does NOT
+# attempt interactive login itself.
+resolve_backend_credentials_proton_pass() {
+  export PROTON_PASS_KEY_PROVIDER=fs
+
+  command -v pass-cli >/dev/null 2>&1 ||
+    fail "pass-cli is not installed or not on PATH. Backend credentials come from Proton Pass only -- see infrastructure/README.md#secrets-and-credentials-strategy."
+
+  pass-cli info >/dev/null 2>&1 ||
+    fail "pass-cli is not authenticated. Run 'pass-cli login' yourself (interactive, opens a browser) and retry -- tg never attempts login on your behalf."
+
+  BACKEND_ACCESS_KEY_ID_REF="pass://${PASS_VAULT}/${PASS_ITEM}/username"
+  BACKEND_SECRET_KEY_REF="pass://${PASS_VAULT}/${PASS_ITEM}/password"
+  printf 'tg: resolving OCI Customer Secret Key from Proton Pass (vault=%s, item=%s)\n' "$PASS_VAULT" "$PASS_ITEM" >&2
 }
 
-if [[ -z "${AWS_ACCESS_KEY_ID:-}" ]]; then
-  if value="$(resolve_from_keychain "$KEYCHAIN_SERVICE_ACCESS_KEY")" && [[ -n "$value" ]]; then
-    export AWS_ACCESS_KEY_ID="$value"
-    printf 'tg: AWS_ACCESS_KEY_ID resolved from Keychain\n' >&2
-  else
-    fail "AWS_ACCESS_KEY_ID not set and not found in Keychain (service=$KEYCHAIN_SERVICE_ACCESS_KEY, account=$KEYCHAIN_ACCOUNT). Export it, or run the one-time 'security add-generic-password' setup (see this script's header)."
-  fi
-fi
-
-if [[ -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
-  if value="$(resolve_from_keychain "$KEYCHAIN_SERVICE_SECRET_KEY")" && [[ -n "$value" ]]; then
-    export AWS_SECRET_ACCESS_KEY="$value"
-    printf 'tg: AWS_SECRET_ACCESS_KEY resolved from Keychain\n' >&2
-  else
-    fail "AWS_SECRET_ACCESS_KEY not set and not found in Keychain (service=$KEYCHAIN_SERVICE_SECRET_KEY, account=$KEYCHAIN_ACCOUNT). Export it, or run the one-time 'security add-generic-password' setup (see this script's header)."
-  fi
-fi
+# Runs "$@" (terragrunt and its arguments) with the backend credential
+# pair injected as AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY -- the only
+# place those names are ever set. Resolution happens inside `pass-cli
+# run` itself; this script's own environment never holds the value.
+# Missing item/field failures surface as pass-cli's own clear,
+# non-secret-leaking error text (e.g. "Field 'x' not found in item 'y'"
+# / "Could not find item with name y") -- verified live, not duplicated
+# here.
+run_with_backend_credentials() {
+  exec env \
+    "AWS_ACCESS_KEY_ID=${BACKEND_ACCESS_KEY_ID_REF}" \
+    "AWS_SECRET_ACCESS_KEY=${BACKEND_SECRET_KEY_REF}" \
+    pass-cli run -- "$@"
+}
 
 # Object Storage namespace is account data, not a secret -- safe to
 # auto-resolve live from the already-configured OCI CLI/API key profile
@@ -74,4 +159,5 @@ if [[ -z "${OCI_OBJECT_STORAGE_NAMESPACE:-}" ]]; then
   printf 'tg: OCI_OBJECT_STORAGE_NAMESPACE resolved from OCI API (namespace=%s)\n' "$namespace" >&2
 fi
 
-exec terragrunt "$@"
+resolve_backend_credentials_proton_pass
+run_with_backend_credentials terragrunt "$@"

--- a/infrastructure/live/scripts/tg.test.sh
+++ b/infrastructure/live/scripts/tg.test.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-# Deterministic tests for tg. Never touches a real Keychain entry or real
-# OCI credentials -- each case builds an isolated PATH with stub
-# `security`/`oci`/`terragrunt` executables (mirroring
+# Deterministic tests for tg. Never touches the real Proton Pass session
+# or real OCI credentials -- each case builds an isolated PATH with stub
+# `pass-cli`/`oci`/`terragrunt` executables (mirroring
 # scripts/check-gpg-signing.test.sh's isolate-don't-mock pattern) so the
 # wrapper's resolution/fail-closed logic is exercised for real, without
-# ever handling a real secret value.
+# ever handling a real secret value. The stub pass-cli simulates just
+# enough of `pass-cli info` and `pass-cli run -- <cmd>` (resolving
+# pass:// env-var references itself, same as the real binary) to drive
+# every branch in tg.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -15,15 +18,22 @@ FAIL=0
 LAST_OUT=""
 LAST_STATUS=0
 
-# Builds an isolated stub bin/ dir. Args: dir, then any of
-# "security:<0|1>:<value>" / "oci:<0|1>:<value>" to install a stub that
-# exits with the given code and prints the given value on success.
-# terragrunt is always stubbed to print a sentinel and exit 0, proving
-# whether the wrapper actually reached `exec terragrunt "$@"`.
+# Builds an isolated stub bin/ dir. PASS_CLI_STUB_MODE controls the stub
+# pass-cli's behavior (exported into the invoked env, read by the stub):
+#   ok                 -- info succeeds, run resolves both fields to
+#                         PASS_CLI_STUB_USERNAME/PASSWORD_VALUE
+#   not_authenticated  -- `pass-cli info` fails
+#   item_missing       -- `pass-cli run` fails resolving (item not found)
+#   username_missing   -- `pass-cli run` fails resolving the username field
+#   password_missing   -- `pass-cli run` fails resolving the password field
+#   username_empty     -- resolves username to an empty string
+#   password_empty     -- resolves password to an empty string
+# oci_mode controls the stub oci CLI: ok | fail | empty | absent (absent
+# = no oci stub installed at all).
 make_stub_bin() {
-  local dir="$1"
-  shift
+  local dir="$1" oci_mode="$2"
   mkdir -p "$dir"
+
   cat >"$dir/terragrunt" <<'EOF'
 #!/usr/bin/env bash
 echo "TERRAGRUNT_INVOKED $*"
@@ -33,27 +43,94 @@ echo "OCI_OBJECT_STORAGE_NAMESPACE=$OCI_OBJECT_STORAGE_NAMESPACE"
 EOF
   chmod +x "$dir/terragrunt"
 
-  for spec in "$@"; do
-    local name rest code value
-    name="${spec%%:*}"
-    rest="${spec#*:}"
-    code="${rest%%:*}"
-    value="${rest#*:}"
-    cat >"$dir/$name" <<EOF
+  cat >"$dir/pass-cli" <<'STUBEOF'
 #!/usr/bin/env bash
-if [[ $code -eq 0 ]]; then
-  printf '%s' "$value"
-  exit 0
-else
-  exit 1
-fi
+case "$1" in
+  info)
+    [[ "${PASS_CLI_STUB_MODE:-ok}" != "not_authenticated" ]]
+    exit $?
+    ;;
+  run)
+    shift
+    [[ "$1" == "--" ]] && shift
+    mode="${PASS_CLI_STUB_MODE:-ok}"
+
+    resolve_field() {
+      local field="$1"
+      case "$mode" in
+        item_missing)
+          echo "Error: Failed to resolve secrets" >&2
+          echo "Caused by: Could not find item with name X" >&2
+          return 1
+          ;;
+        username_missing)
+          if [[ "$field" == "username" ]]; then
+            echo "Error: Field 'username' not found in item" >&2
+            return 1
+          fi
+          echo -n "$PASS_CLI_STUB_VALUE"
+          ;;
+        password_missing)
+          if [[ "$field" == "password" ]]; then
+            echo "Error: Field 'password' not found in item" >&2
+            return 1
+          fi
+          echo -n "$PASS_CLI_STUB_VALUE"
+          ;;
+        username_empty)
+          if [[ "$field" == "username" ]]; then echo -n ""; else echo -n "$PASS_CLI_STUB_VALUE"; fi
+          ;;
+        password_empty)
+          if [[ "$field" == "password" ]]; then echo -n ""; else echo -n "$PASS_CLI_STUB_VALUE"; fi
+          ;;
+        *)
+          echo -n "$PASS_CLI_STUB_VALUE"
+          ;;
+      esac
+    }
+
+    if [[ "${AWS_ACCESS_KEY_ID:-}" == pass://* ]]; then
+      resolved="$(resolve_field username)" || exit 1
+      export AWS_ACCESS_KEY_ID="$resolved"
+    fi
+    if [[ "${AWS_SECRET_ACCESS_KEY:-}" == pass://* ]]; then
+      resolved="$(resolve_field password)" || exit 1
+      export AWS_SECRET_ACCESS_KEY="$resolved"
+    fi
+    exec "$@"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+STUBEOF
+  chmod +x "$dir/pass-cli"
+
+  case "$oci_mode" in
+    ok)
+      cat >"$dir/oci" <<'EOF'
+#!/usr/bin/env bash
+printf '%s' "ax4ugzw7dvvm"
 EOF
-    chmod +x "$dir/$name"
-  done
+      ;;
+    fail)
+      cat >"$dir/oci" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+      ;;
+    empty)
+      cat >"$dir/oci" <<'EOF'
+#!/usr/bin/env bash
+printf ''
+EOF
+      ;;
+    absent) ;; # no stub installed -- command not found
+  esac
+  [[ "$oci_mode" == "absent" ]] || chmod +x "$dir/oci"
 }
 
-# Runs tg in an isolated env; sets LAST_OUT/LAST_STATUS. Does not assert --
-# callers check LAST_OUT/LAST_STATUS themselves.
+# Runs tg in an isolated env; sets LAST_OUT/LAST_STATUS.
 invoke_tg() {
   local dir="$1"
   shift
@@ -66,113 +143,218 @@ pass() {
   PASS=$((PASS + 1))
 }
 
-fail() {
+fail_case() {
   echo "FAIL: $1"
   echo "$LAST_OUT"
   FAIL=$((FAIL + 1))
 }
 
-# 1. No env vars, no Keychain entries -> fails closed, never invokes terragrunt.
+# 1. Everything resolves -> success, values flow through to terragrunt.
 dir="$(mktemp -d)"
-make_stub_bin "$dir" "security:1:"
-invoke_tg "$dir"
+make_stub_bin "$dir" ok
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=ok PASS_CLI_STUB_VALUE=resolved-value
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" == *"TERRAGRUNT_INVOKED plan"* && "$LAST_OUT" == *"AWS_ACCESS_KEY_ID=resolved-value"* && "$LAST_OUT" == *"OCI_OBJECT_STORAGE_NAMESPACE=ax4ugzw7dvvm"* ]]; then
+  pass "Proton Pass item exists -> success, both fields + namespace flow through"
+else
+  fail_case "Proton Pass item exists -> success (status=$LAST_STATUS)"
+fi
+
+# 2. pass-cli not authenticated -> fail closed, never invokes terragrunt.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" ok
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=not_authenticated
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 1 && "$LAST_OUT" != *"TERRAGRUNT_INVOKED"* && "$LAST_OUT" == *"not authenticated"* ]]; then
+  pass "pass-cli not authenticated -> fail closed"
+else
+  fail_case "pass-cli not authenticated -> fail closed (status=$LAST_STATUS)"
+fi
+
+# 3. Proton Pass item missing -> fail closed, never invokes terragrunt.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" ok
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=item_missing
+rm -rf "$dir"
+if [[ $LAST_STATUS -ne 0 && "$LAST_OUT" != *"TERRAGRUNT_INVOKED"* ]]; then
+  pass "Proton Pass item missing -> fail closed"
+else
+  fail_case "Proton Pass item missing -> fail closed (status=$LAST_STATUS)"
+fi
+
+# 4. username field missing -> fail closed.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" ok
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=username_missing PASS_CLI_STUB_VALUE=x
+rm -rf "$dir"
+if [[ $LAST_STATUS -ne 0 && "$LAST_OUT" != *"TERRAGRUNT_INVOKED"* ]]; then
+  pass "username field missing -> fail closed"
+else
+  fail_case "username field missing -> fail closed (status=$LAST_STATUS)"
+fi
+
+# 5. password field missing -> fail closed.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" ok
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=password_missing PASS_CLI_STUB_VALUE=x
+rm -rf "$dir"
+if [[ $LAST_STATUS -ne 0 && "$LAST_OUT" != *"TERRAGRUNT_INVOKED"* ]]; then
+  pass "password field missing -> fail closed"
+else
+  fail_case "password field missing -> fail closed (status=$LAST_STATUS)"
+fi
+
+# 6. username resolves empty -> terragrunt sees an empty value, not a
+#    fabricated one (tg does not itself validate non-emptiness of
+#    resolved secret fields -- that's pass-cli/OCI's own concern; this
+#    documents actual behavior rather than asserting an unenforced
+#    invariant).
+dir="$(mktemp -d)"
+make_stub_bin "$dir" ok
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=username_empty PASS_CLI_STUB_VALUE=x
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" == *"AWS_ACCESS_KEY_ID="$'\n'* ]]; then
+  pass "username resolves empty -> passed through empty, not fabricated"
+else
+  fail_case "username resolves empty -> passed through empty (status=$LAST_STATUS)"
+fi
+
+# 7. password resolves empty -> same as above for the secret half.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" ok
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=password_empty PASS_CLI_STUB_VALUE=x
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" == *"AWS_SECRET_ACCESS_KEY="$'\n'* ]]; then
+  pass "password resolves empty -> passed through empty, not fabricated"
+else
+  fail_case "password resolves empty -> passed through empty (status=$LAST_STATUS)"
+fi
+
+# 8. Unrelated AWS_PROFILE present -> tg ignores it entirely, still
+#    resolves via Proton Pass normally.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" ok
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=ok PASS_CLI_STUB_VALUE=resolved-value AWS_PROFILE=some-unrelated-sso-profile
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" == *"AWS_ACCESS_KEY_ID=resolved-value"* ]]; then
+  pass "unrelated AWS_PROFILE present -> ignored, Proton Pass resolution unaffected"
+else
+  fail_case "unrelated AWS_PROFILE present -> ignored (status=$LAST_STATUS)"
+fi
+
+# 9. Pre-set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY (simulating a stale
+#    AWS SSO-style manual export) -> tg overwrites them via Proton Pass
+#    rather than honoring the pre-set values (no bypass escape hatch).
+dir="$(mktemp -d)"
+make_stub_bin "$dir" ok
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=ok PASS_CLI_STUB_VALUE=resolved-value AWS_ACCESS_KEY_ID=stale-sso-value AWS_SECRET_ACCESS_KEY=stale-sso-secret
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" == *"AWS_ACCESS_KEY_ID=resolved-value"* && "$LAST_OUT" != *"stale-sso"* ]]; then
+  pass "pre-set/expired-SSO-style env vars are overwritten by Proton Pass, not honored"
+else
+  fail_case "pre-set env vars overwritten by Proton Pass (status=$LAST_STATUS)"
+fi
+
+# 10. No AWS-related stub or command exists anywhere on PATH (no aws
+#     CLI, no ~/.aws-reading tool stubbed) -- tg still succeeds purely
+#     via pass-cli + oci, proving it never shells out to anything
+#     AWS-specific.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" ok
+rm -f "$dir/aws" 2>/dev/null
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=ok PASS_CLI_STUB_VALUE=resolved-value
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 0 ]]; then
+  pass "wrapper never depends on an aws CLI or AWS-specific tooling"
+else
+  fail_case "wrapper never depends on an aws CLI or AWS-specific tooling (status=$LAST_STATUS)"
+fi
+
+# 11. Namespace already in env -> wrapper must NOT call oci CLI at all.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" absent
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=ok PASS_CLI_STUB_VALUE=resolved-value OCI_OBJECT_STORAGE_NAMESPACE=preset-ns
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" == *"OCI_OBJECT_STORAGE_NAMESPACE=preset-ns"* ]]; then
+  pass "namespace already set -> oci CLI never consulted (absent from PATH, still succeeds)"
+else
+  fail_case "namespace already set -> oci CLI never consulted (status=$LAST_STATUS)"
+fi
+
+# 12. oci CLI resolves the namespace live (auto-resolution succeeds).
+dir="$(mktemp -d)"
+make_stub_bin "$dir" ok
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=ok PASS_CLI_STUB_VALUE=resolved-value
+rm -rf "$dir"
+if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" == *"OCI_OBJECT_STORAGE_NAMESPACE=ax4ugzw7dvvm"* ]]; then
+  pass "namespace auto-resolution succeeds via oci CLI"
+else
+  fail_case "namespace auto-resolution succeeds via oci CLI (status=$LAST_STATUS)"
+fi
+
+# 13. oci CLI fails -> namespace resolution fails closed.
+dir="$(mktemp -d)"
+make_stub_bin "$dir" fail
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=ok PASS_CLI_STUB_VALUE=resolved-value
 rm -rf "$dir"
 if [[ $LAST_STATUS -eq 1 && "$LAST_OUT" != *"TERRAGRUNT_INVOKED"* ]]; then
-  pass "no credentials anywhere -> fail closed"
+  pass "oci CLI failure -> namespace resolution fails closed"
 else
-  fail "no credentials anywhere -> fail closed (expected exit 1, no invocation; got status=$LAST_STATUS)"
+  fail_case "oci CLI failure -> namespace resolution fails closed (status=$LAST_STATUS)"
 fi
 
-# 2. Keychain has both Customer Secret Key halves + oci CLI resolves namespace -> succeeds, values flow through.
+# 14. oci CLI returns empty namespace -> fails closed.
 dir="$(mktemp -d)"
-make_stub_bin "$dir" "security:0:fake-secret-value" "oci:0:ax4ugzw7dvvm"
-invoke_tg "$dir"
-rm -rf "$dir"
-if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" == *"TERRAGRUNT_INVOKED plan"* && "$LAST_OUT" == *"OCI_OBJECT_STORAGE_NAMESPACE=ax4ugzw7dvvm"* ]]; then
-  pass "keychain + oci resolve everything -> success"
-else
-  fail "keychain + oci resolve everything -> success (status=$LAST_STATUS)"
-fi
-
-# 3. Keychain lookup fails (not found) -> fail closed, never invokes terragrunt.
-dir="$(mktemp -d)"
-make_stub_bin "$dir" "security:1:" "oci:0:ax4ugzw7dvvm"
-invoke_tg "$dir"
+make_stub_bin "$dir" empty
+invoke_tg "$dir" env PASS_CLI_STUB_MODE=ok PASS_CLI_STUB_VALUE=resolved-value
 rm -rf "$dir"
 if [[ $LAST_STATUS -eq 1 && "$LAST_OUT" != *"TERRAGRUNT_INVOKED"* ]]; then
-  pass "keychain entry missing -> fail closed"
+  pass "oci CLI empty namespace -> fails closed"
 else
-  fail "keychain entry missing -> fail closed (status=$LAST_STATUS)"
+  fail_case "oci CLI empty namespace -> fails closed (status=$LAST_STATUS)"
 fi
 
-# 4. Credentials already in env -> wrapper must NOT call security at all (env vars win, no Keychain touch).
+# 15. Secret value itself never appears in tg's own stderr output (only
+#     the child terragrunt process legitimately sees it -- checked here
+#     via tg's stderr specifically, captured separately from the child's
+#     stdout).
 dir="$(mktemp -d)"
-make_stub_bin "$dir" "oci:0:ax4ugzw7dvvm"
-cat >"$dir/security" <<'EOF'
-#!/usr/bin/env bash
-echo "SECURITY_CALLED" >&2
-exit 1
-EOF
-chmod +x "$dir/security"
-invoke_tg "$dir" env AWS_ACCESS_KEY_ID=env-access AWS_SECRET_ACCESS_KEY=env-secret
-rm -rf "$dir"
-if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" != *"SECURITY_CALLED"* && "$LAST_OUT" == *"AWS_ACCESS_KEY_ID=env-access"* ]]; then
-  pass "env vars already set -> Keychain never consulted"
-else
-  fail "env vars already set -> Keychain never consulted (status=$LAST_STATUS)"
-fi
-
-# 5. Namespace already in env -> wrapper must NOT call oci CLI at all.
-dir="$(mktemp -d)"
-make_stub_bin "$dir" "security:0:fake-secret-value"
-cat >"$dir/oci" <<'EOF'
-#!/usr/bin/env bash
-echo "OCI_CALLED" >&2
-exit 1
-EOF
-chmod +x "$dir/oci"
-invoke_tg "$dir" env OCI_OBJECT_STORAGE_NAMESPACE=preset-ns
-rm -rf "$dir"
-if [[ $LAST_STATUS -eq 0 && "$LAST_OUT" != *"OCI_CALLED"* && "$LAST_OUT" == *"OCI_OBJECT_STORAGE_NAMESPACE=preset-ns"* ]]; then
-  pass "namespace already set -> oci CLI never consulted"
-else
-  fail "namespace already set -> oci CLI never consulted (status=$LAST_STATUS)"
-fi
-
-# 6. oci CLI present but returns empty namespace -> fails closed rather than generating a broken endpoint.
-dir="$(mktemp -d)"
-make_stub_bin "$dir" "security:0:fake-secret-value" "oci:0:"
-invoke_tg "$dir"
-rm -rf "$dir"
-if [[ $LAST_STATUS -eq 1 && "$LAST_OUT" != *"TERRAGRUNT_INVOKED"* ]]; then
-  pass "oci returns empty namespace -> fail closed"
-else
-  fail "oci returns empty namespace -> fail closed (status=$LAST_STATUS)"
-fi
-
-# 7. AWS_PROFILE set in ambient env, but no OCI credentials anywhere -> still fails closed
-#    (wrapper does not consult AWS_PROFILE at all; root.hcl's backend config is the real
-#    guard against that layer -- this just proves the wrapper itself doesn't special-case it).
-dir="$(mktemp -d)"
-make_stub_bin "$dir" "security:1:" "oci:0:ax4ugzw7dvvm"
-invoke_tg "$dir" env AWS_PROFILE=some-unrelated-sso-profile
-rm -rf "$dir"
-if [[ $LAST_STATUS -eq 1 && "$LAST_OUT" != *"TERRAGRUNT_INVOKED"* ]]; then
-  pass "unrelated AWS_PROFILE present -> still fails closed"
-else
-  fail "unrelated AWS_PROFILE present -> still fails closed (status=$LAST_STATUS)"
-fi
-
-# 8. Secret value itself never appears in the wrapper's own stderr output.
-dir="$(mktemp -d)"
-make_stub_bin "$dir" "security:0:super-secret-marker-value" "oci:0:ax4ugzw7dvvm"
-LAST_OUT="$(env -i PATH="$dir:/usr/bin:/bin" HOME="$HOME" "$TG" plan 2>&1 >/dev/null)"
+make_stub_bin "$dir" ok
+LAST_OUT="$(env -i PATH="$dir:/usr/bin:/bin" HOME="$HOME" PASS_CLI_STUB_MODE=ok PASS_CLI_STUB_VALUE=super-secret-marker-value "$TG" plan 2>&1 >/dev/null)"
 rm -rf "$dir"
 if [[ "$LAST_OUT" != *"super-secret-marker-value"* ]]; then
-  pass "secret value never printed to stderr"
+  pass "secret value never printed to tg's own stderr"
 else
-  fail "secret value leaked to stderr"
+  fail_case "secret value leaked to tg's own stderr"
 fi
+
+# 16. Provider-boundary separation (source-level invariant, not
+#     runtime-plannable): run_with_backend_credentials must not itself
+#     reference PASS_VAULT/PASS_ITEM -- only
+#     resolve_backend_credentials_proton_pass may, so a future
+#     resolve_backend_credentials_openbao() can replace the resolver
+#     without touching the injection/exec logic at all.
+if ! sed -n '/^run_with_backend_credentials()/,/^}/p' "$TG" | grep -qE 'PASS_VAULT|PASS_ITEM'; then
+  pass "provider boundary: run_with_backend_credentials does not reference Proton-Pass-specific variables"
+else
+  echo "FAIL: provider boundary: run_with_backend_credentials references PASS_VAULT/PASS_ITEM directly"
+  FAIL=$((FAIL + 1))
+fi
+
+# What these tests do NOT and cannot cover:
+# - "backend HCL contains no credential values" -- generated by
+#   Terragrunt against real root.hcl, not by this stubbed terragrunt.
+#   Verified instead by the real fresh-shell audit (grep the generated
+#   backend.tf / .terraform / .terragrunt-cache for access_key=/
+#   secret_key= literals and gitleaks) -- see the B1-closeout gate
+#   report's Secret Persistence Audit section.
+# - "OpenBao provider seam can be substituted later without changing the
+#   downstream backend contract" -- a design property proven by
+#   construction (run_with_backend_credentials only consumes
+#   BACKEND_ACCESS_KEY_ID_REF/BACKEND_SECRET_KEY_REF, never anything
+#   Proton-Pass-specific -- see test 16 above) and by this script's own
+#   header comment, not something a black-box stub test can verify
+#   without literally writing a second provider.
 
 echo
 echo "$PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

`infrastructure/live/scripts/tg` (the local terragrunt wrapper for the OCI Customer Secret Key backend credential) previously used macOS Keychain — unsupported on this machine, with no exceptions. This replaces it with Proton Pass, backed by a real, ACTIVE OCI Customer Secret Key (`platform-tfstate-backend-v3`), with a documented migration path to OpenBao once deployed.

- **`tg`**: rewritten around a small provider boundary — `resolve_backend_credentials_proton_pass()` produces `pass://` *references* (never raw values, so `tg`'s own process never holds the secret even transiently), and `run_with_backend_credentials()` hands those to `pass-cli run`, which resolves them and injects real values only into the `terragrunt` child process. A future OpenBao provider replaces just the resolver — the `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` process-scoped contract doesn't change. All Keychain logic removed, not disabled or synced.
- **Credential precedence**: fixed (Proton Pass → fail closed), no "already set in environment" override — CI's own GitHub-Actions-secrets path is documented as a BREAK GLASS / CI interface, not a pattern to replicate locally.
- **`tg.test.sh`**: 16 deterministic tests (stubbed, no real Proton Pass/OCI access) — success path, unauthenticated, missing item/field, empty fields, unrelated `AWS_PROFILE`/stale-SSO ignored, namespace resolution + failure modes, secret never printed, and a structural provider-boundary-separation check.
- **`infrastructure/README.md`**: full operator procedure (prerequisites, usage, precedence, safe verification, troubleshooting, rotation, item-naming recommendation, secret-source migration path).
- **`AGENTS.md`** (CLAUDE.md's canonical target — symlink unchanged) / **`README.md`**: the agent operational contract, plus a correction to stale "greenfield" and "threat-model not started" language — `00-foundation`/`10-network` now have real applied resources, and threat-modeling is Phase 3A in progress.

## Real finding (verified, remediated)

While auditing for secret persistence during this work, found and deleted a genuine plaintext exposure of the **old** `platform-tfstate-backend` key's Secret Key — a stale local scratch file from earlier bootstrap work (never tracked in git, never shared). Not rotated (consistent with this repo's "don't rotate solely for local/controlled exposure" precedent), but a real point in favor of retiring that key once this migration is fully proven in practice.

## Test plan

- [x] `shellcheck` clean on both scripts
- [x] `bash infrastructure/live/scripts/tg.test.sh` — 16/16 pass
- [x] `pre-commit run --all-files` on changed files — all pass, including secret detection
- [x] Real fresh-shell test against `infrastructure/live/oci/eu-madrid-1/lab/10-network` with `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_PROFILE`/`AWS_DEFAULT_PROFILE`/`OCI_OBJECT_STORAGE_NAMESPACE` all unset and `.terragrunt-cache` removed: `tg init` → "Successfully configured the backend 's3'!" (first real backend success this session), `tg state pull`/`state list` → real remote state read successfully
- [x] Full secret-persistence audit of the real post-init working tree: no `access_key=`/`secret_key=` literals, local `.terraform/terraform.tfstate` backend pointer shows `"access_key": null, "secret_key": null`, `gitleaks` clean
- [x] Old key confirmed still `ACTIVE` via `oci iam customer-secret-key list` (names/state only) — not touched

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>