### PR TITLE
feat(claude): add .claude/** agent scaffold and wire it into CI/pre-commit

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,19 @@
+# .claude/ — tooling, not source of truth
+
+The canonical AI-operating doc for this repo is the root [AGENTS.md](../AGENTS.md)
+(symlinked as `CLAUDE.md`) — its source-of-truth order, ownership boundaries, and
+routing model apply in full. Nothing here restates or supersedes it.
+
+This directory supplies tooling only:
+
+- `agents/` — subagents for IaC planning, state/secrets auditing, docs
+  governance, and PR readiness. See each agent's frontmatter for scope.
+- `skills/` — procedural knowledge (how to run Terragrunt, research OCI
+  provider behavior, check the secrets boundary, etc.) and operator
+  commands (`/validate`, `/pr-ready`, ...). Each skill links to canonical
+  docs rather than duplicating them.
+- `hooks/` — deterministic defense-in-depth around destructive commands
+  and a session-end reflection prompt. The hard security boundary is
+  `permissions.deny` in `settings.json`, not the hooks.
+- `settings.json` — least-privilege Bash permissions and sandbox config.
+  This file is the actual enforcement layer for this directory.

--- a/.claude/agents/docs-governance-auditor.md
+++ b/.claude/agents/docs-governance-auditor.md
@@ -1,0 +1,64 @@
+---
+name: docs-governance-auditor
+description: Validates Mermaid diagrams, ADR shape/traceability, and the threat-model corpus against their own governing schema/convention; may edit docs/** to fix validated findings, never infrastructure or application code.
+model: sonnet
+tools: Read, Grep, Glob, Edit, Write, Bash
+disallowedTools: NotebookEdit
+permissionMode: acceptEdits
+skills: [mermaid-diagram-validation, adr-authoring, threat-model-corpus]
+memory: project
+maxTurns: 40
+effort: medium
+---
+
+You validate this repo's documentation governance surface — Mermaid diagrams,
+ADRs, and the threat-model corpus — against their own schemas/conventions.
+You may fix validated findings under `docs/**`. You never touch
+`infrastructure/**`, `.github/workflows/**`, or `scripts/**` — those are
+code/CI, not docs governance, even if a fix looks trivial.
+
+## MAY
+
+- Run `npm run validate:mermaid`, `npm run validate:threat-model`,
+  `npm run test:threat-model`, `npx markdownlint-cli2 ...`.
+- Edit or create files under `docs/**` to fix a validated lint/schema/
+  traceability finding.
+- Read `docs/01-architecture/traceability.md`, `docs/01-architecture/views.md`,
+  and the ADR shape guidance in `docs/02-decisions/README.md`.
+
+## MUST
+
+- Re-run the relevant validator after any edit before reporting done.
+- Preserve `ARCH-*` concept-ID traceability rather than renaming Mermaid
+  nodes ad hoc.
+- Keep ADR field-shape consistent with the light-vs-full distinction
+  documented in `docs/02-decisions/README.md`.
+
+## MUST NOT
+
+- Edit anything under `infrastructure/**`, `.github/workflows/**`, or
+  `scripts/**` — this agent has no legitimate reason to touch code or CI,
+  and doing so is out of scope regardless of how the task is framed.
+- Introduce new threat-model corpus elements without a matching `gaps[]`
+  entry for anything `state: decision-pending`.
+
+## INPUT
+
+A docs change request, a validator failure, or a periodic governance sweep
+request.
+
+## OUTPUT
+
+A validated docs diff plus validator pass confirmation, or a findings list
+if it can't safely auto-fix something.
+
+## STOP CONDITIONS
+
+Stop and hand back to the main thread (central-orchestration tier) if a
+Mermaid/ADR/threat-model change would imply a real architecture or
+trust-boundary decision, not just a formatting or traceability fix.
+
+## DELEGATION TRIGGERS
+
+Any task touching `.mmd` files, `docs/02-decisions/`, or
+`docs/03-threat-model/model/`.

--- a/.claude/agents/iac-planner.md
+++ b/.claude/agents/iac-planner.md
@@ -1,0 +1,71 @@
+---
+name: iac-planner
+description: Scopes and plans OpenTofu/Terragrunt infrastructure changes against SPEC-OCI/NET-* and ADR-0006/0007/0008, running read-only fmt/validate/plan. Never applies, destroys, or mutates state.
+model: sonnet
+tools: Read, Grep, Glob, Bash
+disallowedTools: Write, Edit, NotebookEdit
+permissionMode: plan
+skills: [terragrunt-workflow, oci-provider-research, secrets-boundary-check]
+memory: project
+maxTurns: 40
+effort: high
+---
+
+You scope and plan OpenTofu/Terragrunt infrastructure changes for a
+zero-trust Kubernetes platform on OCI Always Free Tier. You never apply,
+destroy, or mutate remote state — you produce a plan a human executes.
+
+## MAY
+
+- Read `docs/specs/SPEC-OCI-*`, `docs/specs/SPEC-NET-*`,
+  `docs/02-decisions/ADR-0006/0007/0008`, `infrastructure/modules/**`,
+  `infrastructure/live/**`.
+- Run `tofu fmt -check`, `tofu validate`, `terragrunt plan` (via
+  `infrastructure/live/scripts/tg` for credentials — never bypass it),
+  `terragrunt hcl fmt --check`.
+- Invoke the `oci-provider-research` skill for provider/resource facts.
+- Invoke the `secrets-boundary-check` skill before finishing, if the plan
+  touches backend or credential config.
+
+## MUST
+
+- Cite the governing Spec/ADR for every proposed resource.
+- State whether the change fits inside an existing Terragrunt unit
+  (`00-foundation`, `10-network`) or requires a new one, per ADR-0007's
+  boundary rules.
+- Flag explicitly if a change would populate the DRG route table (inert
+  until initiative I21 per ADR-0008) or otherwise reach beyond the current
+  roadmap milestone (`docs/00-overview/roadmap.md`).
+
+## MUST NOT
+
+- Run `tofu apply`, `tofu destroy`, `tofu import`, `tofu state *`,
+  `tofu force-unlock`, `terragrunt apply`, `terragrunt destroy`, or any
+  command that mutates OCI or the remote state bucket.
+- Write or edit any file — output the plan as text for a human or a
+  follow-up step to act on.
+- Read `.oci/` material, kubeconfigs, or anything matching the never-commit
+  list in `AGENTS.md`.
+
+## INPUT
+
+A described infrastructure change, or a spec/ADR reference to implement.
+
+## OUTPUT
+
+A scoped implementation plan: files to touch, module/unit boundaries,
+resources, provider citations, and `terragrunt plan` output. Explicitly call
+out anything that needs `state-safety-auditor` sign-off before a human
+applies it.
+
+## STOP CONDITIONS
+
+Stop and hand back to the main thread (central-orchestration tier, per
+`AGENTS.md`'s routing model) if the plan would require touching
+`infrastructure/live/root.hcl`'s backend config, state surgery, or resources
+not covered by any Spec/ADR.
+
+## DELEGATION TRIGGERS
+
+Any infrastructure design task spanning more than one file, or requiring
+cross-referencing a Spec/ADR before proceeding.

--- a/.claude/agents/pr-readiness-auditor.md
+++ b/.claude/agents/pr-readiness-auditor.md
@@ -1,0 +1,65 @@
+---
+name: pr-readiness-auditor
+description: Pre-PR gate combining implementation review, test/validation verification, and git/DCO/GPG/CODEOWNERS hygiene checks. Read-only; reports pass/fail, never fixes or commits.
+model: sonnet
+tools: Read, Grep, Bash
+disallowedTools: Write, Edit, NotebookEdit
+permissionMode: plan
+skills: [secrets-boundary-check]
+memory: project
+maxTurns: 30
+effort: medium
+---
+
+You are the pre-PR gate for this repo. You report whether a change is ready
+to open a PR — implementation quality, validation status, and git/DCO/GPG
+hygiene. You are read-only: you report findings, you never fix, commit, or
+push anything yourself.
+
+## MAY
+
+- Run `git status`, `git diff`, `git log`, `git show`, `pre-commit run
+  --all-files`, `npm run validate:mermaid`/`validate:threat-model`/
+  `test:threat-model`, `scripts/check-gpg-signing.sh`.
+- Read `.githooks/commit-msg` and check the current commit message(s)
+  against its `Signed-off-by:` requirement.
+- Read `CODEOWNERS` to confirm the right reviewers would be tagged.
+- Delegate correctness/simplification findings on the diff to the
+  globally-available `code-review` skill, if present.
+
+## MUST
+
+- Confirm Conventional Commit style, DCO `Signed-off-by` presence, GPG
+  signing configuration, feature/fix/docs branch naming convention, and that
+  the change links the relevant spec/ADR/issue — per `CONTRIBUTING.md` and
+  `AGENTS.md`'s "Git and PR expectations."
+- Surface a found secret prominently (see the `secrets-boundary-check`
+  skill) rather than treating it as a routine finding.
+
+## MUST NOT
+
+- Commit, push, amend, stage, or modify any file.
+- Run any git command that mutates history or the working tree — `git
+  clean -n` (dry run) is fine, `git clean -f` is not; nothing destructive,
+  ever, even if the user seems to be asking for it directly (redirect them
+  to run it themselves).
+
+## INPUT
+
+"Is this ready for a PR" — usually invoked at the end of a task.
+
+## OUTPUT
+
+A structured pass/fail checklist (implementation review findings, validation
+results, git/DCO/GPG hygiene) for a human to act on before opening the PR.
+
+## STOP CONDITIONS
+
+None that require escalation beyond reporting clearly — this agent's job is
+to report, not gate. If it finds something security-relevant, surface it
+prominently and stop there; don't attempt remediation.
+
+## DELEGATION TRIGGERS
+
+Invoked before opening a PR, or directly whenever the user asks if a change
+is ready.

--- a/.claude/agents/state-safety-auditor.md
+++ b/.claude/agents/state-safety-auditor.md
@@ -1,0 +1,68 @@
+---
+name: state-safety-auditor
+description: Audits Terragrunt/OpenTofu remote-state backend configuration and the tg credential wrapper for regressions against the documented provider-boundary and reference-not-value guarantees. Read-only; never touches state or secrets.
+model: sonnet
+tools: Read, Grep, Bash
+disallowedTools: Write, Edit, NotebookEdit
+permissionMode: plan
+skills: [secrets-boundary-check]
+memory: project
+maxTurns: 25
+effort: medium
+---
+
+You audit this repo's remote-state backend configuration and credential
+wrapper for regressions. You are read-only and never touch state or secret
+values — you report findings for a human to act on.
+
+## MAY
+
+- Read `infrastructure/live/root.hcl`, `infrastructure/live/scripts/tg`,
+  `infrastructure/live/scripts/tg.test.sh`, and any module's backend block.
+- Run `tg.test.sh` (stub-based, no real Proton Pass/OCI access needed).
+- Run `terragrunt state list` **read-only**, and only if explicitly asked —
+  never `state show` on anything that could echo a secret-shaped attribute.
+
+## MUST
+
+- Verify `access_key`/`secret_key` remain absent from `root.hcl` (never
+  literal) — this exact mistake already leaked a Customer Secret Key into a
+  stale `.terragrunt-cache/backend.tf` once; that incident is why the
+  current design exists.
+- Verify `shared_credentials_files`/`shared_config_files` still point at
+  nonexistent paths (stopping AWS SDK credential-chain fallback).
+- Verify `resolve_backend_credentials_proton_pass()` in `tg` still only
+  produces `pass://` reference strings, and `run_with_backend_credentials()`
+  still injects credentials only into the child process's environment, never
+  into `tg`'s own process, a log, or a file.
+
+## MUST NOT
+
+- Retrieve, print, or persist an actual secret value from Proton Pass or
+  anywhere else.
+- Run `pass-cli run` interactively.
+- Run any command that mutates state: `apply`, `import`, `state rm`,
+  `state push`, `state mv`, `force-unlock`.
+
+## INPUT
+
+A proposed change to `tg`, `root.hcl`, or credential-handling code, or a
+periodic "audit current state" request.
+
+## OUTPUT
+
+Pass/fail against the documented guarantees, with file:line citations. Note
+explicitly if the reserved-but-unimplemented `resolve_backend_credentials_openbao()`
+swap point (named in `tg`'s own comments, for the future Proton Pass →
+OpenBao migration) is relevant to the finding.
+
+## STOP CONDITIONS
+
+Any finding that a secret value has already leaked into a tracked file, log,
+or terminal history — stop immediately and escalate. This is a security
+incident, not a normal finding; do not attempt remediation yourself.
+
+## DELEGATION TRIGGERS
+
+Before any change to `tg`, `root.hcl`, or credential-resolution code, and
+before or after any step toward the OpenBao migration.

--- a/.claude/hooks/block-destructive-commands.sh
+++ b/.claude/hooks/block-destructive-commands.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# PreToolUse hook on Bash. DEFENSE-IN-DEPTH ONLY — the hard boundary is
+# .claude/settings.json's permissions.deny list. Claude Code's own docs
+# document the hook "if" matcher as best-effort and fails open on
+# unparseable commands, so this script parses tool_input.command itself
+# (not the matcher's "if" field) rather than relying on that. If this
+# script is ever removed, misconfigured, or fails to run, the deny rules
+# in settings.json still block every pattern below on their own — this
+# script only adds a clearer explanation than the default permission
+# denial message. Keep REQUIRED_DENY_PATTERNS below in sync by hand with
+# .claude/settings.json's permissions.deny and
+# .claude/tests/settings-permissions.test.sh's REQUIRED_DENY array.
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT="$(cat)"
+COMMAND="$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null || true)"
+[[ -n "$COMMAND" ]] || exit 0
+
+# Extended-regex patterns mirroring settings.json's permissions.deny Bash
+# rules. Anchored loosely (not to command start) because commands can be
+# wrapped (e.g. "cd x && tofu apply ...", "env FOO=bar terragrunt destroy").
+DENY_PATTERNS=(
+  'tofu[[:space:]]+apply'
+  'tofu[[:space:]]+destroy'
+  'tofu[[:space:]]+import'
+  'tofu[[:space:]]+state[[:space:]]'
+  'tofu[[:space:]]+force-unlock'
+  'terragrunt[[:space:]]+apply'
+  'terragrunt[[:space:]]+destroy'
+  'terragrunt[[:space:]]+run-all[[:space:]]+apply'
+  'terragrunt[[:space:]]+run-all[[:space:]]+destroy'
+  'git[[:space:]]+push[[:space:]].*(--force|-f)([[:space:]]|$)'
+  'git[[:space:]]+reset[[:space:]]+--hard'
+  'git[[:space:]]+clean[[:space:]]+-f'
+  'git[[:space:]]+branch[[:space:]]+-D'
+  'pass-cli[[:space:]]+run'
+)
+
+for pattern in "${DENY_PATTERNS[@]}"; do
+  if [[ "$COMMAND" =~ $pattern ]]; then
+    jq -n \
+      --arg reason "Blocked by .claude/hooks/block-destructive-commands.sh: this repo requires state-mutating tofu/terragrunt commands, destructive git history rewrites, and direct pass-cli invocation to be run by a human, not an agent. Terraform/OCI applies go through infrastructure/live/scripts/tg manually — see infrastructure/README.md. This is a defense-in-depth message; the actual boundary is .claude/settings.json's permissions.deny list." \
+      '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+    exit 0
+  fi
+done
+
+exit 0

--- a/.claude/hooks/block-destructive-commands.test.sh
+++ b/.claude/hooks/block-destructive-commands.test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Deterministic tests for block-destructive-commands.sh. Feeds fixture
+# tool_input.command strings on stdin and asserts the JSON decision —
+# no real Bash execution, no real tool calls, following the same
+# self-test pattern as scripts/check-gpg-signing.test.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/block-destructive-commands.sh"
+
+command -v jq >/dev/null 2>&1 || {
+  echo "ERROR: jq is required to run this test" >&2
+  exit 1
+}
+
+PASS=0
+FAIL=0
+
+# run_case NAME COMMAND EXPECTED_DECISION
+# EXPECTED_DECISION is "deny" or "none" (no hookSpecificOutput at all).
+run_case() {
+  local name="$1" command="$2" expected="$3"
+  local input output decision
+  input="$(jq -n --arg cmd "$command" '{tool_name:"Bash", tool_input:{command:$cmd}}')"
+  output="$("$HOOK" <<<"$input")"
+
+  if [[ "$expected" == "none" ]]; then
+    if [[ -z "$output" ]] || ! jq -e '.hookSpecificOutput' <<<"$output" >/dev/null 2>&1; then
+      echo "PASS: $name (no deny, as expected)"
+      PASS=$((PASS + 1))
+    else
+      echo "FAIL: $name (expected no deny, got: $output)" >&2
+      FAIL=$((FAIL + 1))
+    fi
+    return
+  fi
+
+  decision="$(jq -r '.hookSpecificOutput.permissionDecision // empty' <<<"$output" 2>/dev/null || true)"
+  if [[ "$decision" == "$expected" ]]; then
+    echo "PASS: $name (decision=$decision)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (expected decision=$expected, got '$decision', output: $output)" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Destructive commands — must all be denied.
+run_case "tofu apply" "tofu apply -auto-approve" "deny"
+run_case "tofu destroy" "tofu destroy" "deny"
+run_case "tofu import" "tofu import oci_core_drg.this ocid1.drg.oc1..xxx" "deny"
+run_case "tofu state rm" "tofu state rm oci_core_drg.this" "deny"
+run_case "tofu force-unlock" "tofu force-unlock 12345" "deny"
+run_case "terragrunt apply" "terragrunt apply" "deny"
+run_case "terragrunt destroy" "terragrunt destroy" "deny"
+run_case "terragrunt run-all apply" "terragrunt run-all apply" "deny"
+run_case "git push --force" "git push --force origin main" "deny"
+run_case "git push -f short flag" "git push -f origin main" "deny"
+run_case "git reset --hard" "git reset --hard HEAD~1" "deny"
+run_case "git clean -f" "git clean -f -d" "deny"
+run_case "git branch -D" "git branch -D old-branch" "deny"
+run_case "pass-cli run" "pass-cli run -- terragrunt plan" "deny"
+run_case "wrapped destructive command" "cd infrastructure && tofu apply -auto-approve" "deny"
+
+# Safe commands — must not be denied.
+run_case "tofu plan" "tofu plan" "none"
+run_case "tofu validate" "tofu validate" "none"
+run_case "tofu fmt check" "tofu fmt -check -recursive" "none"
+run_case "terragrunt plan" "terragrunt plan" "none"
+run_case "git status" "git status" "none"
+run_case "git push non-force" "git push origin feature-branch" "none"
+run_case "unrelated command mentioning apply in a string" "echo 'do not run tofu apply here'" "deny"
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/.claude/hooks/propose-system-updates.sh
+++ b/.claude/hooks/propose-system-updates.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Stop hook. Implements the "system evolution" practice: one reflection
+# pass per session on whether anything that happened reveals a gap in
+# AGENTS.md, an agent's MUST/MUST NOT list, or a skill. Advisory only —
+# this script has no Write/Edit capability and never touches
+# AGENTS.md/.claude/** itself; it only asks Claude to propose a change,
+# which a human then accepts or discards.
+#
+# Claude Code's own hooks docs do not document a "stop_hook_active" field
+# or any built-in repeat-call guard for Stop hooks (confirmed against
+# code.claude.com/docs/en/hooks at authoring time — see TODO(system-
+# evolution) in the design plan). This script implements its own one-shot
+# guard with a session_id-keyed marker file so it fires exactly once per
+# session instead of blocking every Stop attempt forever.
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT="$(cat)"
+SESSION_ID="$(jq -r '.session_id // empty' <<<"$INPUT" 2>/dev/null || true)"
+[[ -n "$SESSION_ID" ]] || exit 0
+
+MARKER_DIR="${TMPDIR:-/tmp}/claude-system-evolution"
+MARKER="$MARKER_DIR/$SESSION_ID"
+mkdir -p "$MARKER_DIR"
+
+if [[ -e "$MARKER" ]]; then
+  # Already reflected once this session — let the stop proceed.
+  exit 0
+fi
+
+touch "$MARKER"
+
+REASON='Before this session ends: did anything happen that reveals a gap in AGENTS.md, an agent'"'"'s MUST/MUST NOT list, or a skill — a correction from the user, a repeated mistake, a validation step run too late? If so, propose (do not apply) one specific, concrete addition: quote the exact wording and name the target file. If nothing qualifies, say so in one sentence and finish. This reflection runs once per session — do not repeat it.'
+
+jq -n --arg reason "$REASON" '{continue: false, stopReason: $reason}'
+exit 0

--- a/.claude/hooks/propose-system-updates.test.sh
+++ b/.claude/hooks/propose-system-updates.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Deterministic tests for propose-system-updates.sh's one-shot guard.
+# Uses a scratch TMPDIR so this never touches a real session's marker
+# file, and never depends on an actual session transcript.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/propose-system-updates.sh"
+
+command -v jq >/dev/null 2>&1 || {
+  echo "ERROR: jq is required to run this test" >&2
+  exit 1
+}
+
+PASS=0
+FAIL=0
+SCRATCH_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH_TMPDIR"' EXIT
+
+check() {
+  local name="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (expected '$expected', got '$actual')" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+SESSION_ID="test-session-$$"
+INPUT="$(jq -n --arg sid "$SESSION_ID" '{session_id:$sid, hook_event_name:"Stop"}')"
+
+# 1. First Stop this session: must block with continue:false and a reason.
+OUTPUT_1="$(TMPDIR="$SCRATCH_TMPDIR" "$HOOK" <<<"$INPUT")"
+CONTINUE_1="$(jq -r '.continue' <<<"$OUTPUT_1" 2>/dev/null || echo "MISSING")"
+REASON_1="$(jq -r '.stopReason // empty' <<<"$OUTPUT_1" 2>/dev/null || true)"
+check "first Stop blocks (continue=false)" "$CONTINUE_1" "false"
+[[ -n "$REASON_1" ]] && { echo "PASS: first Stop includes a stopReason"; PASS=$((PASS + 1)); } || {
+  echo "FAIL: first Stop missing stopReason" >&2
+  FAIL=$((FAIL + 1))
+}
+
+# 2. Second Stop, same session: must allow (no continue:false).
+OUTPUT_2="$(TMPDIR="$SCRATCH_TMPDIR" "$HOOK" <<<"$INPUT")"
+if [[ -z "$OUTPUT_2" ]]; then
+  echo "PASS: second Stop in same session produces no output (allows stop)"
+  PASS=$((PASS + 1))
+else
+  CONTINUE_2="$(jq -r '.continue // "true"' <<<"$OUTPUT_2" 2>/dev/null || echo "true")"
+  check "second Stop in same session allows (continue != false)" "$CONTINUE_2" "true"
+fi
+
+# 3. A different session_id: must block again (independent marker).
+OTHER_SESSION_ID="test-session-other-$$"
+OTHER_INPUT="$(jq -n --arg sid "$OTHER_SESSION_ID" '{session_id:$sid, hook_event_name:"Stop"}')"
+OUTPUT_3="$(TMPDIR="$SCRATCH_TMPDIR" "$HOOK" <<<"$OTHER_INPUT")"
+CONTINUE_3="$(jq -r '.continue' <<<"$OUTPUT_3" 2>/dev/null || echo "MISSING")"
+check "different session gets its own first-Stop block" "$CONTINUE_3" "false"
+
+# 4. Missing session_id: must no-op (exit 0, no output) rather than error.
+NO_SID_INPUT='{"hook_event_name":"Stop"}'
+OUTPUT_4="$(TMPDIR="$SCRATCH_TMPDIR" "$HOOK" <<<"$NO_SID_INPUT")"
+if [[ -z "$OUTPUT_4" ]]; then
+  echo "PASS: missing session_id no-ops safely"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: missing session_id should no-op, got: $OUTPUT_4" >&2
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/.claude/hooks/remind-docs-validation.sh
+++ b/.claude/hooks/remind-docs-validation.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PostToolUse hook on Edit|Write. Pure convenience — cannot block (the
+# tool already ran) and has zero security consequence if removed or
+# misconfigured. Nudges toward the matching validator immediately, instead
+# of only discovering a validator failure at commit time via pre-commit.
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT="$(cat)"
+FILE_PATH="$(jq -r '.tool_input.file_path // empty' <<<"$INPUT" 2>/dev/null || true)"
+[[ -n "$FILE_PATH" ]] || exit 0
+
+MESSAGE=""
+if [[ "$FILE_PATH" == *.mmd ]]; then
+  MESSAGE="You just edited a Mermaid diagram ($FILE_PATH). Run: npm run validate:mermaid — before considering this edit done."
+elif [[ "$FILE_PATH" == *docs/03-threat-model/model/* ]]; then
+  MESSAGE="You just edited the threat-model corpus ($FILE_PATH). Run: npm run validate:threat-model — before considering this edit done."
+fi
+
+[[ -n "$MESSAGE" ]] || exit 0
+
+jq -n --arg msg "$MESSAGE" '{systemMessage: $msg}'
+exit 0

--- a/.claude/hooks/remind-docs-validation.test.sh
+++ b/.claude/hooks/remind-docs-validation.test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Deterministic tests for remind-docs-validation.sh — fixture tool_input
+# paths in, assert the reminder fires only for the intended path shapes.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/remind-docs-validation.sh"
+
+command -v jq >/dev/null 2>&1 || {
+  echo "ERROR: jq is required to run this test" >&2
+  exit 1
+}
+
+PASS=0
+FAIL=0
+
+# run_case NAME FILE_PATH EXPECT_MESSAGE(0/1) [SUBSTRING]
+run_case() {
+  local name="$1" file_path="$2" expect="$3" substr="${4:-}"
+  local input output msg
+  input="$(jq -n --arg fp "$file_path" '{tool_name:"Edit", tool_input:{file_path:$fp}}')"
+  output="$("$HOOK" <<<"$input")"
+  msg="$(jq -r '.systemMessage // empty' <<<"$output" 2>/dev/null || true)"
+
+  if [[ "$expect" == "1" ]]; then
+    if [[ -n "$msg" ]] && { [[ -z "$substr" ]] || grep -qF "$substr" <<<"$msg"; }; then
+      echo "PASS: $name (message present)"
+      PASS=$((PASS + 1))
+    else
+      echo "FAIL: $name (expected a message containing '$substr', got: '$msg')" >&2
+      FAIL=$((FAIL + 1))
+    fi
+  else
+    if [[ -z "$msg" ]]; then
+      echo "PASS: $name (no message, as expected)"
+      PASS=$((PASS + 1))
+    else
+      echo "FAIL: $name (expected no message, got: '$msg')" >&2
+      FAIL=$((FAIL + 1))
+    fi
+  fi
+}
+
+run_case "mermaid diagram edited" \
+  "docs/01-architecture/network/l2-vcn.mmd" 1 "validate:mermaid"
+run_case "threat-model instance edited" \
+  "docs/03-threat-model/model/instances/network.yaml" 1 "validate:threat-model"
+run_case "unrelated docs file edited" \
+  "docs/00-overview/roadmap.md" 0
+run_case "infrastructure file edited" \
+  "infrastructure/modules/network/gateways.tf" 0
+run_case "mmd file outside docs/01-architecture (legacy docs/arch/)" \
+  "docs/arch/cloud-deployment.mmd" 1 "validate:mermaid"
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(tofu fmt*)",
+      "Bash(tofu validate*)",
+      "Bash(terragrunt plan*)",
+      "Bash(terragrunt hcl fmt --check*)",
+      "Bash(tflint*)",
+      "Bash(checkov*)",
+      "Bash(pre-commit run*)",
+      "Bash(npm run validate:*)",
+      "Bash(npm run test:*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git show*)",
+      "Bash(oci os ns get*)"
+    ],
+    "ask": [
+      "Bash(tofu plan*)",
+      "Bash(terragrunt state list*)",
+      "Bash(git push*)"
+    ],
+    "deny": [
+      "Bash(tofu apply*)",
+      "Bash(tofu destroy*)",
+      "Bash(tofu import*)",
+      "Bash(tofu state *)",
+      "Bash(tofu force-unlock*)",
+      "Bash(terragrunt apply*)",
+      "Bash(terragrunt destroy*)",
+      "Bash(terragrunt run-all apply*)",
+      "Bash(terragrunt run-all destroy*)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)",
+      "Bash(git branch -D*)",
+      "Bash(pass-cli run*)",
+      "Read(**/.oci/**)",
+      "Read(**/*.kubeconfig)",
+      "Read(**/kubeconfig*)",
+      "Read(**/*.env)",
+      "Read(**/*.env.*)",
+      "Read(**/id_rsa*)",
+      "Read(**/id_ed25519*)",
+      "Read(**/*talos*secret*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-destructive-commands.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/remind-docs-validation.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/propose-system-updates.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": false,
+    "allowUnsandboxedCommands": false,
+    "filesystem": {
+      "denyRead": [
+        "~/.ssh",
+        "~/.aws/credentials",
+        "./.env",
+        "./.env.*",
+        "./**/*.kubeconfig",
+        "./**/kubeconfig*"
+      ]
+    },
+    "credentials": {
+      "files": [
+        { "path": "~/.aws/credentials", "mode": "deny" },
+        { "path": "~/.ssh", "mode": "deny" }
+      ]
+    }
+  }
+}

--- a/.claude/settings.local.json.example
+++ b/.claude/settings.local.json.example
@@ -1,0 +1,5 @@
+{
+  "//": "Copy to settings.local.json (gitignored) for personal overrides only.",
+  "//_never": "Never put credentials, loosened deny rules, or machine-specific secrets here — permission rules merge across scopes, so this file cannot weaken .claude/settings.json's deny list.",
+  "model": "sonnet"
+}

--- a/.claude/skills/adr-authoring/SKILL.md
+++ b/.claude/skills/adr-authoring/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: adr-authoring
+description: How to write or edit an ADR under docs/02-decisions/ — when to use the light vs full shape, required sections, and updating the ADR index. Use when creating or editing a decision record.
+when_to_use: A task creates a new docs/02-decisions/ADR-*.md file, edits an existing one, or needs to determine whether a change is ADR-worthy at all.
+allowed-tools: Read, Grep, Glob
+---
+
+# ADR authoring
+
+## Is this even ADR-worthy?
+
+Per `AGENTS.md`'s central-orchestration tier: changes to network design,
+identity, secrets, trust zones, platform ownership, or anything with broad
+blast radius should get an ADR. A narrow implementation choice inside an
+already-decided boundary usually doesn't need one — check
+[docs/02-decisions/README.md](../../../docs/02-decisions/README.md)'s own
+guidance before drafting.
+
+## Shape: light vs. full
+
+`docs/02-decisions/README.md` documents two ADR shapes. Read it before
+drafting — the shape choice depends on decision weight (a reversible,
+narrow decision can use the light shape; a decision that constrains future
+architecture, like ADR-0006's trust-zone segmentation or ADR-0007's state
+boundaries, needs the full shape). Match the existing ADRs' shape for
+similar-weight decisions rather than inventing a new structure.
+
+## Required housekeeping
+
+After adding or editing an ADR:
+
+1. Update the index table in `docs/02-decisions/README.md` — a new ADR that
+   isn't indexed is effectively invisible to the source-of-truth chain.
+2. Check whether the decision affects any `docs/01-architecture/**/*.mmd`
+   diagram's traceability (see the `mermaid-diagram-validation` skill) or
+   the roadmap (`docs/00-overview/roadmap.md`) — an ADR that changes scope
+   without a corresponding roadmap update creates exactly the kind of
+   roadmap-reality drift `AGENTS.md` warns against.
+
+## What NOT to do
+
+Don't retroactively edit an already-Accepted ADR's decision content to match
+new reality — that's what a new, superseding ADR is for. A correction to a
+factual claim inside an ADR (not the decision itself) is fine; changing the
+decision after the fact is not.

--- a/.claude/skills/mermaid-diagram-validation/SKILL.md
+++ b/.claude/skills/mermaid-diagram-validation/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: mermaid-diagram-validation
+description: Runs and interprets npm run validate:mermaid, and checks ARCH-* traceability for edited diagrams. Use whenever a .mmd file under docs/01-architecture/ (or docs/arch/) is touched.
+when_to_use: Any Edit or Write to a *.mmd file, or a review pass over docs/01-architecture/**.
+allowed-tools: Bash(npm run validate:mermaid), Read, Grep, Glob
+---
+
+# Mermaid diagram validation
+
+## The command
+
+```sh
+npm run validate:mermaid
+```
+
+This renders every `.mmd` file under `docs/` via `mmdc`
+(`scripts/validate-mermaid.sh`), using `docs/mermaid-puppeteer-config.json`
+for headless-Chromium flags. A render failure means the diagram has invalid
+Mermaid syntax — fix the syntax, don't work around the validator.
+
+## Traceability (not enforced by the validator — check by hand)
+
+Diagrams are projections, not independent truth (per `AGENTS.md`'s core
+operating rules). Every node that represents an architectural concept should
+trace back to an `ARCH-*` concept ID documented in
+[docs/01-architecture/traceability.md](../../../docs/01-architecture/traceability.md).
+Read [docs/01-architecture/views.md](../../../docs/01-architecture/views.md)
+for the L0-L4 view catalog before adding a new diagram, to confirm it belongs
+in an existing view rather than introducing a parallel one.
+
+## What NOT to do
+
+Don't rename or restructure diagram nodes to "clean them up" without checking
+whether other diagrams or `traceability.md` reference the same node by its
+current label — an unrelated-looking Mermaid diff can silently break
+traceability elsewhere.

--- a/.claude/skills/oci-provider-research/SKILL.md
+++ b/.claude/skills/oci-provider-research/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: oci-provider-research
+description: Bounded procedure for researching OCI Terraform/OpenTofu provider resource behavior and citing findings accurately. Use when a plan needs facts about an OCI resource's schema, defaults, quota behavior, or import semantics.
+when_to_use: iac-planner needs an authoritative answer about how an oci_core_* (or other OCI provider) resource actually behaves before proposing it in a plan.
+allowed-tools: WebFetch, WebSearch, Read
+---
+
+# OCI provider research
+
+This is a research procedure, not a knowledge base — it does not cache OCI
+provider facts, because those facts belong to the provider's own docs and
+should always be looked up fresh.
+
+## Where to look, in order
+
+1. **OpenTofu/Terraform OCI provider registry docs** —
+   `registry.terraform.io/providers/oracle/oci/latest/docs/resources/<resource>`
+   for the resource's exact schema (required/optional args, computed
+   attributes, known limitations).
+2. **OCI's own API reference** (docs.oracle.com/en-us/iaas/api/) only when the
+   provider docs are ambiguous about underlying service behavior (e.g.,
+   whether a resource has an implicit default sub-resource created by the
+   platform, not the provider).
+3. **This repo's own prior art** — grep `infrastructure/modules/**/*.tf` for
+   an existing use of the same resource type before assuming novel behavior;
+   the repo may already have discovered and documented a quirk (see e.g. the
+   DRG-inert-route-table pattern in `gateways.tf`).
+
+## Console vs. provider-managed defaults
+
+These are not the same thing and mixing them up produces wrong plans:
+
+- OCI's web console sometimes auto-creates or auto-populates a sub-resource
+  (a default route table, a default security list) when you create a parent
+  resource through the console.
+- The Terraform/OpenTofu provider does **not** replicate this — creating a
+  parent resource via the provider does not implicitly create or manage that
+  default sub-resource unless you also declare it explicitly. Always check
+  the provider resource docs for "default resource" language before assuming
+  parity with console behavior.
+
+## Citation format
+
+When reporting a finding back to `iac-planner`, cite the exact doc URL and
+quote the specific line/argument, not just "the docs say." A plan citing
+"per `oci_core_drg_route_table`'s `import_drg_route_distribution_id`
+argument (optional, no propagation if unset)" is verifiable; a plan citing
+"OCI docs say DRG route tables need this" is not.
+
+## Import-block limitation to flag
+
+OpenTofu's `import` block currently only works in the **root module** — if a
+resource under consideration lives inside a nested module
+(`infrastructure/modules/**`), flag this constraint explicitly in the plan
+rather than silently proposing an import that won't work as declared.

--- a/.claude/skills/plan-change/SKILL.md
+++ b/.claude/skills/plan-change/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: plan-change
+description: Wraps iac-planner to scope and plan an infrastructure change, requiring a governing spec/ADR citation before proceeding.
+when_to_use: Any request to design or plan an infrastructure change under infrastructure/**.
+argument-hint: "<spec or change description>"
+agent: iac-planner
+---
+
+# /plan-change
+
+Before delegating, confirm the invocation includes either a spec ID
+(`SPEC-OCI-*`/`SPEC-NET-*`), an ADR reference, or a specific enough change
+description that `iac-planner` can find the governing spec/ADR itself. If
+none of these is present, ask for one rather than delegating a vague
+request — `iac-planner`'s own MUST clauses require citing a governing
+Spec/ADR for every proposed resource, so a vague request just produces a
+STOP CONDITIONS bounce back to the main thread.
+
+Once delegated, present `iac-planner`'s plan output verbatim, including any
+explicit call-outs that need `state-safety-auditor` sign-off before a human
+applies it.

--- a/.claude/skills/pr-ready/SKILL.md
+++ b/.claude/skills/pr-ready/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: pr-ready
+description: Invokes the pr-readiness-auditor agent to check whether the current change is ready to open a PR — implementation review, validation status, git/DCO/GPG hygiene.
+when_to_use: Before opening a PR, or whenever a structured pass/fail checklist for the current diff is needed.
+disable-model-invocation: true
+user-invocable: true
+agent: pr-readiness-auditor
+---
+
+# /pr-ready
+
+Delegate to the `pr-readiness-auditor` agent with no special input — it
+inspects the live git state itself (`git status`/`diff`/`log`), runs the
+repo's validation commands, and checks DCO/GPG/branch-naming/CODEOWNERS
+hygiene. Present its structured pass/fail checklist back to the user
+verbatim; don't summarize away specific findings.

--- a/.claude/skills/repo-audit/SKILL.md
+++ b/.claude/skills/repo-audit/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: repo-audit
+description: Runs docs-governance-auditor and state-safety-auditor in sequence and aggregates their findings into one report.
+when_to_use: A periodic, deliberate governance sweep across docs and state/secrets safety — not for routine single-file tasks, which should delegate to the individual agents directly.
+disable-model-invocation: true
+user-invocable: true
+---
+
+# /repo-audit
+
+This is real multi-agent orchestration, not an alias for a single agent —
+run both audits and combine their output:
+
+1. Invoke the `docs-governance-auditor` agent for a governance sweep across
+   Mermaid diagrams, ADRs, and the threat-model corpus.
+2. Invoke the `state-safety-auditor` agent for a read-only audit of the
+   Terragrunt/OpenTofu backend config and the `tg` credential wrapper.
+3. Combine both agents' findings into one report, clearly attributed to
+   which agent produced which finding. Don't run them in a way that lets
+   one agent's output influence the other's — they're independent checks
+   over unrelated parts of the repo, so run them in parallel if the
+   orchestration mechanism available to you supports it.
+
+If either agent reports a security-relevant finding (a leaked secret, a
+regression in the credential-reference-not-value pattern), surface it first
+and prominently, ahead of routine docs-governance findings.

--- a/.claude/skills/secrets-boundary-check/SKILL.md
+++ b/.claude/skills/secrets-boundary-check/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: secrets-boundary-check
+description: Checklist for verifying no secret value has landed in a diff, log, or persisted file, and that credential resolution still follows the reference-not-value pattern. Use before finishing any task that touched credential/backend config or produced a diff.
+when_to_use: Before iac-planner, state-safety-auditor, or pr-readiness-auditor report a task complete, if the task touched infrastructure/live/scripts/tg, infrastructure/live/root.hcl, or any file that could plausibly contain credential material.
+allowed-tools: Read, Grep, Bash(git diff*), Bash(git status*)
+---
+
+# Secrets boundary check
+
+## Never-commit list (from AGENTS.md)
+
+Credentials, `.oci` material, Talos secrets, kubeconfigs, `.env` files,
+unencrypted SOPS files. Run `git diff --cached` (or `git diff` for unstaged
+work) and grep the output for these shapes before calling anything done:
+
+```sh
+git diff --cached -- . ':!*.lock' | grep -inE 'BEGIN (RSA|OPENSSH|PGP) PRIVATE KEY|aws_secret|AKIA[0-9A-Z]{16}|-----BEGIN'
+```
+
+This is a spot check, not a replacement for gitleaks (already wired into
+`.pre-commit-config.yaml` and `.github/workflows/security.yml`) — if
+`gitleaks` is on `PATH`, prefer running it directly:
+
+```sh
+gitleaks protect --staged -v   # staged changes only, no history rewrite
+```
+
+## The reference-not-value pattern (tg)
+
+`infrastructure/live/scripts/tg` resolves Proton Pass credentials as
+`pass://Vault/Item/field` **reference strings**, not values — the actual
+secret is only ever materialized inside `pass-cli run`'s child process
+environment, never in `tg`'s own bash process, never printed, never written
+to disk. If a diff to `tg`, `root.hcl`, or any Terragrunt/OpenTofu backend
+config would cause a real value (not a `pass://` reference) to appear in:
+
+- a shell variable that gets echoed or logged,
+- a file written to disk (including a `.terragrunt-cache/**/backend.tf` —
+  this exact failure mode already happened once, see `root.hcl`'s own
+  comments),
+- or a command's argument list (visible via `ps`),
+
+that is a regression, not a normal finding — stop and flag it, don't try to
+fix it silently.
+
+## What "not applicable" looks like
+
+Most tasks touch no secret material at all. Report "not applicable, no
+credential/backend config touched" rather than forcing a finding — a
+false-positive here erodes trust in the check faster than an occasional
+skipped one.

--- a/.claude/skills/state-audit/SKILL.md
+++ b/.claude/skills/state-audit/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: state-audit
+description: Invokes the state-safety-auditor agent for a deliberate, explicit-only audit of the Terragrunt/OpenTofu backend config and the tg credential wrapper.
+when_to_use: Before or after any change to tg, root.hcl, or credential-resolution code, or as a periodic standalone security check.
+disable-model-invocation: true
+user-invocable: true
+agent: state-safety-auditor
+---
+
+# /state-audit
+
+Delegate to the `state-safety-auditor` agent. This is explicit-only
+(`disable-model-invocation: true`) deliberately — it's a security-sensitive
+audit the user should trigger consciously, not something the model decides
+to run on its own judgment. Present the agent's pass/fail findings verbatim,
+with file:line citations intact.

--- a/.claude/skills/terragrunt-workflow/SKILL.md
+++ b/.claude/skills/terragrunt-workflow/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: terragrunt-workflow
+description: How to run Terragrunt/OpenTofu safely in this repo — unit boundaries, the tg credential wrapper, and what never to touch directly. Use when planning, scoping, or reasoning about any change under infrastructure/live/** or infrastructure/modules/**.
+when_to_use: Any infrastructure change-design task, or a question about which Terragrunt unit/OpenTofu module owns a given resource.
+allowed-tools: Read, Grep, Glob, Bash(tofu fmt*), Bash(tofu validate*), Bash(terragrunt plan*), Bash(terragrunt hcl fmt --check*)
+---
+
+# Terragrunt workflow
+
+This is a navigational skill: it tells you where the facts live and the exact
+commands to run. It does not restate the facts themselves — read the linked
+docs for those.
+
+## Unit boundaries (read first)
+
+Read [docs/02-decisions/ADR-0007](../../../docs/02-decisions) before proposing
+any change that might need a new Terragrunt unit. As of M1 there are exactly
+two live units under `infrastructure/live/oci/eu-madrid-1/lab/`:
+`00-foundation` and `10-network`. `40-storage` and `90-hybrid` are named but
+deferred — do not create them speculatively. A change belongs in an existing
+unit unless ADR-0007's Option-C boundary rules say otherwise.
+
+## Never touch these directly
+
+- `infrastructure/live/root.hcl`'s backend block (`access_key`/`secret_key`
+  intentionally absent, `shared_credentials_files`/`shared_config_files`
+  pointed at nonexistent paths, `use_lockfile = false`) — any proposed change
+  here is `state-safety-auditor`'s job, not a plan-only change. Read
+  `infrastructure/README.md`'s secrets/credentials section for why each of
+  these exists before touching any of them.
+- The DRG route table under `infrastructure/modules/network/gateways.tf` —
+  it is deliberately inert (`import_drg_route_distribution_id` unset) per
+  [ADR-0008](../../../docs/02-decisions) until initiative I21. A plan that
+  populates it is out of scope for M0/M1.
+
+## How to run things
+
+Always go through `infrastructure/live/scripts/tg` for anything that needs
+real backend credentials — never invoke `pass-cli` directly, and never assume
+`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are already set in the shell.
+
+```sh
+# format/validate — no credentials needed
+tofu fmt -check -recursive infrastructure/modules/<module>
+cd infrastructure/live/oci/eu-madrid-1/lab/<unit> && tofu init -backend=false && tofu validate
+
+# plan — needs credentials, goes through tg
+infrastructure/live/scripts/tg plan   # run from the unit's terragrunt.hcl directory
+```
+
+`terragrunt hcl fmt --check` is safe to run directly (no credentials).
+
+## What a plan must cite
+
+Every proposed resource needs a governing Spec (`docs/specs/SPEC-OCI-*` or
+`SPEC-NET-*`) or ADR citation. If you can't find one, that's a signal the
+change belongs in central-orchestration (per `AGENTS.md`'s routing model),
+not a plan-only task.

--- a/.claude/skills/threat-model-corpus/SKILL.md
+++ b/.claude/skills/threat-model-corpus/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: threat-model-corpus
+description: How to run and interpret the threat-model corpus validator, and the corpus's own invariants (no duplicate IDs, refs resolve, gaps[] required for decision-pending elements). Use when touching docs/03-threat-model/model/**.
+when_to_use: Any Edit or Write under docs/03-threat-model/model/, or a question about threat-model corpus state.
+allowed-tools: Bash(npm run validate:threat-model), Bash(npm run test:threat-model), Read, Grep, Glob
+---
+
+# Threat-model corpus
+
+## Current scope — Phase 3A only
+
+The corpus is schema + one validated instance
+(`docs/03-threat-model/model/instances/network.yaml`), proof-of-concept for
+the tooling. DFDs, attack paths, and the risk register (Phase 3B+) do not
+exist yet. Don't imply Phase 3B work exists or is in progress — that's
+exactly the kind of roadmap-reality drift `AGENTS.md` warns against. For
+genuine STRIDE/attack-path analysis beyond corpus validation, that's a
+separate, heavier exercise — not this skill's job.
+
+## The commands
+
+```sh
+npm run validate:threat-model   # schema validation, scripts/validate-threat-model.mjs
+npm run test:threat-model       # validator's own self-test, fixture-based
+```
+
+## Corpus invariants (enforced by the validator — know them before editing)
+
+- No duplicate element IDs across the corpus.
+- Every `*_ref` field must resolve to a real element, an `ARCH-*` concept ID,
+  or the literal `EXTERNAL`. The validator checks ref *existence*, not ref
+  *type* — a ref that resolves to the wrong kind of element won't be caught
+  automatically, so check it by eye.
+- No conflicting `same_principal` identity claims.
+- Every element with `state: implemented` needs at least one
+  `status: implemented` evidence entry.
+- Every element with `state: decision-pending` needs at least one matching
+  `gaps[]` entry — don't leave a decision-pending element without a
+  documented gap.
+
+## Read first
+
+[docs/03-threat-model/README.md](../../../docs/03-threat-model/README.md) for
+the overall pipeline (architecture corpus → normalized model → DFDs →
+STRIDE/LINDDUN → attack trees → risk/controls), and
+[docs/03-threat-model/model/README.md](../../../docs/03-threat-model/model/README.md)
+for the schema itself — this skill doesn't restate either.

--- a/.claude/skills/validate/SKILL.md
+++ b/.claude/skills/validate/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: validate
+description: Runs the narrow validation commands AGENTS.md prescribes for docs/infra changes in one shot — Mermaid validation, markdownlint, and the full pre-commit suite.
+when_to_use: Before finishing any task that touched docs or infra behavior, or whenever you want one deterministic pass over the repo's own gates.
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: Bash(npm run validate:mermaid), Bash(npx markdownlint-cli2*), Bash(pre-commit run --all-files)
+---
+
+# /validate
+
+Run exactly the three commands `AGENTS.md`'s "Validation workflow" section
+prescribes, in order, and report pass/fail for each — don't deduplicate them
+against each other even though `pre-commit run --all-files` overlaps with
+the first two, since that overlap is what the source-of-truth document
+itself specifies:
+
+```sh
+npm run validate:mermaid
+npx markdownlint-cli2 --config .markdownlint-cli2.yaml "docs/**/*.md" "*.md" ".github/**/*.md"
+pre-commit run --all-files
+```
+
+If any command fails, report the failure output and stop — don't attempt to
+silently fix issues found this way; that's a separate task.

--- a/.claude/tests/fixtures/settings-bad-missing-deny.json
+++ b/.claude/tests/fixtures/settings-bad-missing-deny.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(tofu fmt*)",
+      "Bash(tofu validate*)",
+      "Bash(terragrunt plan*)",
+      "Bash(terragrunt hcl fmt --check*)",
+      "Bash(tflint*)",
+      "Bash(checkov*)",
+      "Bash(pre-commit run*)",
+      "Bash(npm run validate:*)",
+      "Bash(npm run test:*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git show*)",
+      "Bash(oci os ns get*)"
+    ],
+    "ask": [
+      "Bash(tofu plan*)",
+      "Bash(terragrunt state list*)",
+      "Bash(git push*)"
+    ],
+    "deny": [
+      "Bash(tofu destroy*)",
+      "Bash(tofu import*)",
+      "Bash(tofu state *)",
+      "Bash(tofu force-unlock*)",
+      "Bash(terragrunt apply*)",
+      "Bash(terragrunt destroy*)",
+      "Bash(terragrunt run-all apply*)",
+      "Bash(terragrunt run-all destroy*)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)",
+      "Bash(git branch -D*)",
+      "Bash(pass-cli run*)",
+      "Read(**/.oci/**)",
+      "Read(**/*.kubeconfig)",
+      "Read(**/kubeconfig*)",
+      "Read(**/*.env)",
+      "Read(**/*.env.*)",
+      "Read(**/id_rsa*)",
+      "Read(**/id_ed25519*)",
+      "Read(**/*talos*secret*)"
+    ]
+  },
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": false,
+    "allowUnsandboxedCommands": false,
+    "filesystem": {
+      "denyRead": [
+        "~/.ssh",
+        "~/.aws/credentials",
+        "./.env",
+        "./.env.*",
+        "./**/*.kubeconfig",
+        "./**/kubeconfig*"
+      ]
+    },
+    "credentials": {
+      "files": [
+        {
+          "path": "~/.aws/credentials",
+          "mode": "deny"
+        },
+        {
+          "path": "~/.ssh",
+          "mode": "deny"
+        }
+      ]
+    }
+  }
+}

--- a/.claude/tests/fixtures/settings-good.json
+++ b/.claude/tests/fixtures/settings-good.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(tofu fmt*)",
+      "Bash(tofu validate*)",
+      "Bash(terragrunt plan*)",
+      "Bash(terragrunt hcl fmt --check*)",
+      "Bash(tflint*)",
+      "Bash(checkov*)",
+      "Bash(pre-commit run*)",
+      "Bash(npm run validate:*)",
+      "Bash(npm run test:*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git show*)",
+      "Bash(oci os ns get*)"
+    ],
+    "ask": [
+      "Bash(tofu plan*)",
+      "Bash(terragrunt state list*)",
+      "Bash(git push*)"
+    ],
+    "deny": [
+      "Bash(tofu apply*)",
+      "Bash(tofu destroy*)",
+      "Bash(tofu import*)",
+      "Bash(tofu state *)",
+      "Bash(tofu force-unlock*)",
+      "Bash(terragrunt apply*)",
+      "Bash(terragrunt destroy*)",
+      "Bash(terragrunt run-all apply*)",
+      "Bash(terragrunt run-all destroy*)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)",
+      "Bash(git branch -D*)",
+      "Bash(pass-cli run*)",
+      "Read(**/.oci/**)",
+      "Read(**/*.kubeconfig)",
+      "Read(**/kubeconfig*)",
+      "Read(**/*.env)",
+      "Read(**/*.env.*)",
+      "Read(**/id_rsa*)",
+      "Read(**/id_ed25519*)",
+      "Read(**/*talos*secret*)"
+    ]
+  },
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": false,
+    "allowUnsandboxedCommands": false,
+    "filesystem": {
+      "denyRead": [
+        "~/.ssh",
+        "~/.aws/credentials",
+        "./.env",
+        "./.env.*",
+        "./**/*.kubeconfig",
+        "./**/kubeconfig*"
+      ]
+    },
+    "credentials": {
+      "files": [
+        {
+          "path": "~/.aws/credentials",
+          "mode": "deny"
+        },
+        {
+          "path": "~/.ssh",
+          "mode": "deny"
+        }
+      ]
+    }
+  }
+}

--- a/.claude/tests/settings-permissions.test.sh
+++ b/.claude/tests/settings-permissions.test.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Regression guard for the hard security boundary in ../settings.json:
+# permissions.deny. This is deliberately a hardcoded copy of the required
+# pattern list, not something derived cleverly from the file under test —
+# a diff in this list is meant to be a visible, reviewable event. See
+# .claude/agents/*.md and docs/02-decisions/ADR-0007/ADR-0008 for why each
+# pattern is here: state-mutating tofu/terragrunt subcommands, destructive
+# git history rewrites, and bare pass-cli invocation (secret resolution
+# must stay inside infrastructure/live/scripts/tg's own exec chain).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAL_SETTINGS="$SCRIPT_DIR/../settings.json"
+
+command -v jq >/dev/null 2>&1 || {
+  echo "ERROR: jq is required to run this test" >&2
+  exit 1
+}
+
+# The exact deny patterns settings.json must contain. Kept in sync by hand
+# with .claude/settings.json and (once it exists) the pattern list parsed
+# by .claude/hooks/block-destructive-commands.sh — see TODO(consistency)
+# in the design plan for automating that second cross-check.
+REQUIRED_DENY=(
+  "Bash(tofu apply*)"
+  "Bash(tofu destroy*)"
+  "Bash(tofu import*)"
+  "Bash(tofu state *)"
+  "Bash(tofu force-unlock*)"
+  "Bash(terragrunt apply*)"
+  "Bash(terragrunt destroy*)"
+  "Bash(terragrunt run-all apply*)"
+  "Bash(terragrunt run-all destroy*)"
+  "Bash(git push --force*)"
+  "Bash(git push -f*)"
+  "Bash(git reset --hard*)"
+  "Bash(git clean -f*)"
+  "Bash(git branch -D*)"
+  "Bash(pass-cli run*)"
+  "Read(**/.oci/**)"
+  "Read(**/*.kubeconfig)"
+  "Read(**/kubeconfig*)"
+  "Read(**/*.env)"
+  "Read(**/*.env.*)"
+  "Read(**/id_rsa*)"
+  "Read(**/id_ed25519*)"
+  "Read(**/*talos*secret*)"
+)
+
+PASS=0
+FAIL=0
+
+# Prints (to stdout) the count of REQUIRED_DENY patterns missing from
+# $1's permissions.deny array.
+count_missing_deny() {
+  local settings_file="$1" pattern missing=0
+  for pattern in "${REQUIRED_DENY[@]}"; do
+    jq -e --arg p "$pattern" '.permissions.deny // [] | index($p) != null' \
+      "$settings_file" >/dev/null 2>&1 || missing=$((missing + 1))
+  done
+  echo "$missing"
+}
+
+# Prints (to stdout) the count of REQUIRED_DENY patterns that also appear
+# verbatim in $1's permissions.allow array (a pasted-in-the-wrong-list bug).
+count_allow_deny_overlap() {
+  local settings_file="$1" pattern overlap=0
+  for pattern in "${REQUIRED_DENY[@]}"; do
+    jq -e --arg p "$pattern" '.permissions.allow // [] | index($p) != null' \
+      "$settings_file" >/dev/null 2>&1 && overlap=$((overlap + 1))
+  done
+  echo "$overlap"
+}
+
+check() {
+  local name="$1" actual="$2" expected="$3"
+  if [[ "$actual" -eq "$expected" ]]; then
+    echo "PASS: $name (got $actual, expected $expected)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (got $actual, expected $expected)" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# String-equality counterpart to check() — check() uses -eq (numeric) and
+# must not be reused for string values like a permissionDecision.
+check_str() {
+  local name="$1" actual="$2" expected="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "PASS: $name (got '$actual', expected '$expected')"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (got '$actual', expected '$expected')" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "--- known-good fixture: full deny coverage, no overlap ---"
+check "good fixture has zero missing deny patterns" \
+  "$(count_missing_deny "$SCRIPT_DIR/fixtures/settings-good.json")" 0
+check "good fixture has zero allow/deny overlaps" \
+  "$(count_allow_deny_overlap "$SCRIPT_DIR/fixtures/settings-good.json")" 0
+
+echo ""
+echo "--- known-bad fixture: self-test must actually detect the break ---"
+BAD_MISSING="$(count_missing_deny "$SCRIPT_DIR/fixtures/settings-bad-missing-deny.json")"
+if [[ "$BAD_MISSING" -gt 0 ]]; then
+  echo "PASS: bad fixture's missing 'tofu apply' deny was detected ($BAD_MISSING missing)"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: bad fixture should be missing at least one deny pattern but wasn't detected" >&2
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "--- real .claude/settings.json: the actual security boundary ---"
+check "real settings.json has zero missing deny patterns" \
+  "$(count_missing_deny "$REAL_SETTINGS")" 0
+check "real settings.json has zero allow/deny overlaps" \
+  "$(count_allow_deny_overlap "$REAL_SETTINGS")" 0
+
+# TODO(consistency), resolved: cross-check that
+# hooks/block-destructive-commands.sh (defense-in-depth) actually denies a
+# representative command for every settings.json deny pattern, so the two
+# independently-maintained layers can't silently drift apart. This is a
+# behavioral check (run the hook, read its decision), not a textual diff,
+# so it survives the hook script's regex being phrased differently from
+# settings.json's glob syntax.
+HOOK="$SCRIPT_DIR/../hooks/block-destructive-commands.sh"
+if [[ -x "$HOOK" ]] && command -v jq >/dev/null 2>&1; then
+  echo ""
+  echo "--- hook/settings.json cross-check: every Bash deny pattern is also caught by the hook ---"
+  # One representative real command per Bash deny pattern (Read(...) deny
+  # patterns aren't Bash commands, so they're out of scope for this hook).
+  declare -A REPRESENTATIVE_COMMAND=(
+    ["Bash(tofu apply*)"]="tofu apply -auto-approve"
+    ["Bash(tofu destroy*)"]="tofu destroy"
+    ["Bash(tofu import*)"]="tofu import oci_core_drg.this ocid1.drg.oc1..xxx"
+    ["Bash(tofu state *)"]="tofu state rm oci_core_drg.this"
+    ["Bash(tofu force-unlock*)"]="tofu force-unlock 12345"
+    ["Bash(terragrunt apply*)"]="terragrunt apply"
+    ["Bash(terragrunt destroy*)"]="terragrunt destroy"
+    ["Bash(terragrunt run-all apply*)"]="terragrunt run-all apply"
+    ["Bash(terragrunt run-all destroy*)"]="terragrunt run-all destroy"
+    ["Bash(git push --force*)"]="git push --force origin main"
+    ["Bash(git push -f*)"]="git push -f origin main"
+    ["Bash(git reset --hard*)"]="git reset --hard HEAD~1"
+    ["Bash(git clean -f*)"]="git clean -f -d"
+    ["Bash(git branch -D*)"]="git branch -D old-branch"
+    ["Bash(pass-cli run*)"]="pass-cli run -- terragrunt plan"
+  )
+  for pattern in "${REQUIRED_DENY[@]}"; do
+    [[ "$pattern" == Bash\(* ]] || continue
+    cmd="${REPRESENTATIVE_COMMAND[$pattern]:-}"
+    if [[ -z "$cmd" ]]; then
+      echo "FAIL: no representative command registered for deny pattern: $pattern" >&2
+      FAIL=$((FAIL + 1))
+      continue
+    fi
+    hook_input="$(jq -n --arg cmd "$cmd" '{tool_name:"Bash", tool_input:{command:$cmd}}')"
+    hook_output="$("$HOOK" <<<"$hook_input")"
+    decision="$(jq -r '.hookSpecificOutput.permissionDecision // empty' <<<"$hook_output" 2>/dev/null || true)"
+    check_str "hook denies representative command for $pattern" "$decision" "deny"
+  done
+else
+  echo ""
+  echo "SKIP: hooks/block-destructive-commands.sh not present yet or jq missing — cross-check skipped"
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: davidanson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
         with:
           config: .markdownlint-cli2.yaml
-          globs: "docs/**/*.md README.md SECURITY.md CONTRIBUTING.md AGENTS.md infrastructure/**/*.md .github/**/*.md"
+          globs: "docs/**/*.md README.md SECURITY.md CONTRIBUTING.md AGENTS.md infrastructure/**/*.md .github/**/*.md .claude/**/*.md"
           no-ignore: true
 
   mermaid:

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ build/
 coverage/
 *.test
 *.out
+
+# Claude Code — personal/runtime-only, not shared project config
+.claude/settings.local.json
+.claude/agent-memory/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,3 +83,17 @@ repos:
         entry: .githooks/commit-msg
         language: system
         stages: [commit-msg]
+
+      - id: claude-settings-permissions
+        name: Claude Code settings.json permission-boundary check
+        entry: .claude/tests/settings-permissions.test.sh
+        language: system
+        files: '^\.claude/(settings\.json|hooks/block-destructive-commands\.sh|tests/settings-permissions\.test\.sh|tests/fixtures/settings-.*\.json)$'
+        pass_filenames: false
+
+      - id: claude-hooks-selftest
+        name: Claude Code hooks self-tests
+        entry: bash -c 'status=0; for t in .claude/hooks/*.test.sh; do "$t" || status=1; done; exit $status'
+        language: system
+        files: '^\.claude/hooks/'
+        pass_filenames: false


### PR DESCRIPTION
## Summary

Adds a least-privilege `.claude/**` Claude Code configuration sized to the repo's actual M0/M1 state (OpenTofu/Terragrunt/OCI networking, docs/threat-model governance) — no Kubernetes/Cilium/Talos/OpenZiti/SPIFFE-SPIRE/OpenBao/Kyverno tooling, since none of that exists in the tree yet.

- **4 agents** (`iac-planner`, `state-safety-auditor`, `docs-governance-auditor`, `pr-readiness-auditor`) — each READ ONLY or docs-only, none can apply/destroy infra or mutate state.
- **11 skills** — 6 knowledge skills (Terragrunt workflow, OCI provider research, secrets-boundary check, Mermaid/ADR/threat-model validation) + 5 operator commands (`/repo-audit`, `/plan-change`, `/state-audit`, `/validate`, `/pr-ready`).
- **`settings.json`** — the actual hard boundary: `permissions.deny` blocks `tofu apply/destroy/import/state`, `terragrunt apply/destroy`, destructive git history rewrites, and bare `pass-cli` invocation; sandbox config deliberately excludes `~/.oci` and `AWS_*` env vars since those are `tg`'s legitimate credential path, not a leak to plug.
- **3 hooks** — a `PreToolUse` defense-in-depth block on destructive Bash commands (the real boundary is the deny rule above; hook `if`-matchers are documented as best-effort/fails-open), a `PostToolUse` docs-validation nudge, and a `Stop` hook implementing a one-shot per-session "system evolution" reflection practice.
- **`.claude/tests/`** — self-tests for the permission boundary and every hook, following the repo's existing `check-gpg-signing.sh`+`.test.sh` convention.
- **CI/pre-commit wiring** — two new local pre-commit hooks scoped to `.claude/` changes, and `.claude/**/*.md` added to `docs.yml`'s markdownlint glob (which turned out to be an explicit file list, not the `*.md` wildcard `AGENTS.md` documents locally — corrected here).

Design was researched and written up separately before any file was created (current official Claude Code docs, not assumed from memory), then implemented milestone by milestone with verification at each step — see Test plan.

## Test plan

- [x] `.claude/tests/settings-permissions.test.sh` — 20/20 (5 core checks + 15 hook/settings.json cross-checks)
- [x] All 3 hook self-tests — 22/22, 5/5, 5/5
- [x] Deliberately broke `settings.json` (removed `tofu apply` deny) and confirmed the new pre-commit hook actually fails; restored and confirmed it passes again
- [x] `markdownlint-cli2` over the full updated `docs.yml` glob (59 files) — 0 issues
- [x] `gitleaks` over the entire `.claude/**` tree — no leaks
- [x] `pre-commit run --all-files` — full repo, all hooks pass
- [x] Agent frontmatter parses and every `skills:` reference resolves to a real `SKILL.md`
- [x] Ran `iac-planner` against the already-merged DRG work (PR #45) as a retrospective acceptance check — independently reached the correct conclusions (route table inert per ADR-0008, no import blocks, correct Terragrunt unit per ADR-0007)