### PR TITLE
feat(network): count-gate NAT/SGW behind deployment flags for software-NAT path

### DIFF
--- a/infrastructure/modules/network/README.md
+++ b/infrastructure/modules/network/README.md
@@ -40,6 +40,18 @@ PR C3 exactly as originally scoped.
 | `compartment_ocid` | string | yes | must match `^ocid1\.compartment\.` |
 | `environment` | string | yes | one of `lab`, `staging`, `prod` |
 | `platform_name` | string | no (default `"oracle-free-tier-platform"`) | — |
+| `use_managed_nat` | bool | no (default `false`) | — |
+| `use_managed_service_gateway` | bool | no (default `false`) | — |
+| `nat_egress_target_ocid` | string | no (default `null`) | — |
+
+`use_managed_nat`/`use_managed_service_gateway` default to `false` because
+this Always Free account has a hard limit of 0 NAT gateways and 0 service
+gateways — the managed resources cannot be the real egress path. The
+software-NAT instance (I04/compute `micro-nat`) is the default egress
+target, resolved at runtime by freeform tag (`data.tf`), not by a
+cross-unit Terragrunt dependency — see "Software-NAT discovery" below.
+`nat_egress_target_ocid` is the explicit escape hatch: set it to pin the
+egress target and bypass tag discovery.
 
 No CIDR variables. REQ-NET-001/REQ-NET-002 mandate exact values, and
 ADR-0006 is explicit they're fixed absent a superseding ADR — see
@@ -62,14 +74,17 @@ hardcoded constants, not tunables.
 ## Resource ownership
 
 `oci_core_vcn` (1), `oci_core_subnet` (4, one per trust zone, via
-`for_each`), `oci_core_internet_gateway` (1), `oci_core_nat_gateway` (1),
-`oci_core_service_gateway` (1), `oci_core_drg` (1),
+`for_each`), `oci_core_internet_gateway` (1), `oci_core_nat_gateway` (0–1,
+count-gated by `use_managed_nat`), `oci_core_service_gateway` (0–1,
+count-gated by `use_managed_service_gateway`), `oci_core_drg` (1),
 `oci_core_drg_route_table` (1, empty — the inert mechanism),
 `oci_core_drg_attachment` (1), `oci_core_route_table` (4, one per trust
 zone, via `for_each`), `oci_core_security_list` (4, one per trust zone,
 via `for_each` — baseline only, REQ-NET-016/018),
 `data.oci_core_services` (1, read-only — resolves the region's Services
-Network CIDR label).
+Network CIDR label), `data.oci_core_instances` (1, read-only — software-NAT
+tag discovery), `data.oci_core_private_ips` (1, read-only — resolves the
+discovered instance's private IP for the egress route).
 
 **Not owned here**: NSGs (`SPEC-NET-004`'s remaining scope,
 REQ-NET-017/019/020), DNS/DHCP options (`SPEC-NET-006`), compute
@@ -78,6 +93,36 @@ creates the DRG attached-but-empty, never populates it). Subnets no
 longer use OCI's default route table or default Security List — each has
 its own zone-specific pair now (`routing.tf`, `security_lists.tf`); the
 OCI defaults become intentionally unused, not deleted.
+
+## Software-NAT discovery
+
+The Always Free account cannot hold a managed NAT gateway (quota: 0), so
+egress for Management/Workload/Data zones must target the `micro-nat`
+compute instance instead. To keep `10-network` and `30-compute` as
+independent Terragrunt state units — no circular dependency — the network
+module discovers the instance at plan time by its freeform tag
+(`role = "software-nat"`), never by importing `30-compute`'s outputs:
+
+- `data.oci_core_instances.software_nat` lists instances in the
+  compartment filtered by `freeform_tags."role" = "software-nat"`
+  (defensive `try()`/`one()` so a tag never missing is not a hard error at
+  plan time — an empty result is simply `null`).
+- `data.oci_core_private_ips.software_nat` resolves that instance's VNIC
+  private IP by `ip_address` alone (no `subnet_id` filter — the private-IP
+  lookup must not read the route table it feeds, which would re-introduce
+  a cycle through `oci_core_subnet`).
+- `local.nat_egress_target`/`local.nat_egress_target_ocid` resolve to the
+  explicit `nat_egress_target_ocid` when set, otherwise to the managed NAT
+  when `use_managed_nat` is set, otherwise to the discovered instance.
+
+Resolution order (first match wins):
+
+| Source | Condition |
+| --- | --- |
+| `nat_egress_target_ocid` | non-null (explicit escape hatch) |
+| `oci_core_nat_gateway.this[0]` | `use_managed_nat` |
+| discovered `micro-nat` instance | tag match present |
+| none | egress route is `null` (no `0.0.0.0/0` rule) |
 
 ## Security invariants
 
@@ -184,17 +229,23 @@ REQ-NET-017/019/020 explicitly out of scope — see Purpose).
 | --- | --- | --- | --- | --- | --- | --- |
 | Edge | Internet | Internet Gateway | `0.0.0.0/0` | RED (INGRESS)/GREEN (EGRESS) | REQ-NET-012 | Yes |
 | Edge | OCI services | Service Gateway | Services Network CIDR label | BLUE (SERVICE) | REQ-NET-014 | Yes |
-| Management | Internet (egress only) | NAT Gateway | `0.0.0.0/0` | GREEN (EGRESS) | REQ-NET-013 | Yes |
+| Management | Internet (egress only) | software-NAT instance (or managed NAT if enabled) | `0.0.0.0/0` | GREEN (EGRESS) | REQ-NET-013 | Yes |
 | Management | OCI services | Service Gateway | Services Network CIDR label | BLUE (SERVICE) | REQ-NET-014 | Yes |
 | Management | future on-prem/other-cloud | DRG | (reserved, unpopulated) | ORANGE (HYBRID) | REQ-NET-015 | No — I21 |
-| Workload | Internet (egress only) | NAT Gateway | `0.0.0.0/0` | GREEN (EGRESS) | REQ-NET-013 | Yes |
+| Workload | Internet (egress only) | software-NAT instance (or managed NAT if enabled) | `0.0.0.0/0` | GREEN (EGRESS) | REQ-NET-013 | Yes |
 | Workload | OCI services | Service Gateway | Services Network CIDR label | BLUE (SERVICE) | REQ-NET-014 | Yes |
-| Data | Internet (egress only) | NAT Gateway | `0.0.0.0/0` | GREEN (EGRESS) | REQ-NET-013 | Yes |
+| Data | Internet (egress only) | software-NAT instance (or managed NAT if enabled) | `0.0.0.0/0` | GREEN (EGRESS) | REQ-NET-013 | Yes |
 | Data | OCI services (incl. backup) | Service Gateway | Services Network CIDR label | BLUE (SERVICE)/BLUE (BACKUP) | REQ-NET-014 | Yes |
+
+The Management/Workload/Data egress target resolves via "Software-NAT
+discovery" below: explicit `nat_egress_target_ocid` → managed NAT →
+tag-discovered `micro-nat` → no rule. The interim state (no target yet)
+is a deliberate `null` — the rule is absent, not broken.
 
 No unexplained `0.0.0.0/0` — every occurrence above is either Edge→IGW
 (REQ-NET-012, the only place it's allowed) or Management/Workload/Data→NAT
-(REQ-NET-013, explicitly never IGW).
+(REQ-NET-013, explicitly never IGW; the NAT is the software-NAT instance
+by default, the managed gateway only when enabled).
 
 ## Security List baseline matrix
 
@@ -282,6 +333,16 @@ tofu test
   say, the NAT Gateway leaves the Internet Gateway and Service Gateway
   correctly in state — re-running `tofu apply` retries only what's
   missing.
+- **Software-NAT discovery empty**: if the compartment contains no
+  instance tagged `role = "software-nat"` and neither
+  `nat_egress_target_ocid` nor `use_managed_nat` is set, the egress route
+  resolves to `null` and Management/Workload/Data simply have no
+  `0.0.0.0/0` rule — an explicit, documented interim state (see Route
+  matrix), not a broken plan. The route appears automatically on the next
+  `10-network` apply after `30-compute` provisions `micro-nat`.
+- **Multiple software-NAT instances tagged**: `one()` fails loudly at plan
+  time if discovery matches more than one instance — a
+  miscustomization, surfaced rather than silently choosing one.
 
 ## Upgrade expectations
 
@@ -344,7 +405,11 @@ important assertion —
 `management_workload_data_never_reference_the_internet_gateway` — is
 written as a positive assertion of an *absence*, which is what actually
 proves REQ-NET-013's binding control; a presence-only check for the NAT
-rule wouldn't catch a table that had both. No separate
+rule wouldn't catch a table that had both. A second run
+(`management_workload_data_route_internet_to_discovered_software_nat`)
+mocks the software-NAT discovery (`data.tf`) and asserts the
+Management/Workload/Data tables target the discovered instance's private
+IP. No separate
 `routing_negative.tftest.hcl` exists: this module's route rules are
 built entirely from hardcoded locals (`local.route_tables`), not
 variables, so there's no user-input surface for `expect_failures`-style

--- a/infrastructure/modules/network/README.md
+++ b/infrastructure/modules/network/README.md
@@ -273,6 +273,20 @@ row above traces to a route this module's own `routing.tf` already
 creates; there is no egress destination in this table that routing
 doesn't also send traffic to.
 
+**Software-NAT is route-only today — forwarding is not yet authorized.**
+The `micro-nat` instance (I04/compute) lives on the Edge subnet, so the
+Management/Workload/Data → `0.0.0.0/0` route's traffic arrives at its
+VNIC as *ingress to Edge*. With this baseline's zero Edge ingress rules,
+that traffic is deliberately dropped — the software-NAT path cannot
+forward until I04 attaches micro-nat's own authorization (an NSG or
+Security List ingress rule permitting the Management/Workload/Data CIDRs
+to reach it) *and* sets `skip_source_dest_check` on its VNIC, both of
+which are I04/compute concerns outside this module. Until then, "routable
+but not authorized" holds *for the forwarded path itself*, not just for
+unrelated inbound traffic — this is the intended interim state, not a
+gap: the route exists so the target is pinned correctly, and the drop is
+the baseline's default-deny doing its job.
+
 ## Traffic-flow reconciliation (post–PR C2)
 
 Using `docs/01-architecture/traceability.md`'s RED/GREEN/BLUE/PURPLE/

--- a/infrastructure/modules/network/README.md
+++ b/infrastructure/modules/network/README.md
@@ -42,7 +42,7 @@ PR C3 exactly as originally scoped.
 | `platform_name` | string | no (default `"oracle-free-tier-platform"`) | — |
 | `use_managed_nat` | bool | no (default `false`) | — |
 | `use_managed_service_gateway` | bool | no (default `false`) | — |
-| `nat_egress_target_ocid` | string | no (default `null`) | — |
+| `nat_egress_target_ocid` | string | no (default `null`) | must be `null` or match `^ocid1\.privateip\.`; mutually exclusive with `use_managed_nat` (checked) |
 
 `use_managed_nat`/`use_managed_service_gateway` default to `false` because
 this Always Free account has a hard limit of 0 NAT gateways and 0 service
@@ -381,8 +381,12 @@ enforced by `tofu validate`'s type system at parse time (a non-CIDR-shaped
 string literal fails HCL evaluation immediately); overlap/containment/
 duplication protection is enforced by `vcn.tf`'s `check` block instead
 (see Security invariants). This file's negative tests instead cover the
-one real variable-driven invariant this module has: rejecting an invalid
-`environment` value.
+variable-driven invariants this module has: rejecting an invalid
+`environment` value, rejecting a non-private-IP OCID for
+`nat_egress_target_ocid` (an IGW OCID would otherwise be copied verbatim
+into all three private-zone routes, silently bypassing the Edge-only
+gateway invariant), and rejecting the `use_managed_nat` + explicit-target
+conflict via the mutual-exclusivity `check` block.
 
 `tests/gateways.tftest.hcl` (positive): Internet Gateway enabled, NAT
 Gateway attached, Service Gateway resolves the real Services CIDR label

--- a/infrastructure/modules/network/data.tf
+++ b/infrastructure/modules/network/data.tf
@@ -1,0 +1,50 @@
+# Tag-based discovery of the software-NAT instance (I04/compute micro-nat).
+#
+# REQ-NET-013: Management/Workload/Data route 0.0.0.0/0 to micro-nat's
+# private IP OCID instead of a managed NAT Gateway -- Always Free caps this
+# account at 0 NAT gateways, so the managed resource cannot be the real
+# egress path. This module must NOT form a Terragrunt dependency on the
+# 30-compute state unit to learn that target (30-compute consumes this
+# module's subnet_ids; a dependency in the other direction would be
+# circular). Instead the target is discovered at runtime from OCI by
+# freeform tag, so the ordering is purely bootstrap sequencing: first
+# 10-network apply (micro-nat absent -> no egress route at all, the
+# accepted interim state), then 30-compute (micro-nat created and tagged),
+# then 10-network reapply (lookup now resolves, egress route appears).
+data "oci_core_instances" "software_nat" {
+  compartment_id = var.compartment_ocid
+}
+
+locals {
+  # Every instance in the platform compartment, narrowed to the one tagged
+  # role=software-nat. try() guards the lookup so the interim no-egress
+  # state (before micro-nat exists) is an empty selection, not a plan-time
+  # error; it also tolerates a missing freeform_tags map on unrelated
+  # instances. one() fails loudly if more than one instance ever carries
+  # the tag -- a genuine misconfiguration we want surfaced.
+  software_nat_instance = try(one([
+    for i in data.oci_core_instances.software_nat.instances :
+    i if try(i.freeform_tags["role"], "") == "software-nat"
+  ]), null)
+
+  # A route rule's network_entity_id must name the private IP OCID, not the
+  # instance OCID. Resolved by matching micro-nat's primary private IP
+  # address. The lookup deliberately omits a subnet_id filter: the subnet
+  # resource depends on the route tables (subnet.route_table_id ->
+  # oci_core_route_table.this), and the route tables depend on this lookup
+  # via local.nat_egress_route_rule -- adding subnet_id here would close a
+  # dependency cycle at plan time. ip_address alone is unambiguous for this
+  # platform's single tagged micro-nat; if that ever changes, the explicit
+  # nat_egress_target_ocid input is the escape hatch. count on the data
+  # source is driven by the instance lookup, so nothing is queried until
+  # micro-nat exists.
+  software_nat_private_ip_ocid = try(
+    one(flatten(data.oci_core_private_ips.software_nat[*].private_ips)).id,
+    null
+  )
+}
+
+data "oci_core_private_ips" "software_nat" {
+  count      = local.software_nat_instance != null ? 1 : 0
+  ip_address = local.software_nat_instance.private_ip
+}

--- a/infrastructure/modules/network/gateways.tf
+++ b/infrastructure/modules/network/gateways.tf
@@ -20,7 +20,13 @@ resource "oci_core_internet_gateway" "this" {
   }
 }
 
+# REQ-NET-007: NAT Gateway. Count-driven rather than unconditional because
+# the Always Free tier has a hard limit of 0 NAT gateways
+# (nat-gateway-count: 0 on this account) -- the software-NAT instance
+# (I04/compute micro-nat) is the real egress path, and this managed
+# resource exists only when use_managed_nat is explicitly true.
 resource "oci_core_nat_gateway" "this" {
+  count          = var.use_managed_nat ? 1 : 0
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.this.id
   display_name   = "platform-nat"
@@ -39,7 +45,12 @@ resource "oci_core_nat_gateway" "this" {
 # REQ-NET-008: private access to OCI services (Object Storage, KMS,
 # Logging, Monitoring) without traversing the internet. The Services
 # Network CIDR label is a per-region OCI construct, looked up rather than
-# hardcoded -- data.oci_core_services below.
+# hardcoded -- data.oci_core_services below. Like the NAT Gateway, the
+# managed Service Gateway is count-driven because the Always Free tier
+# caps this account at 0 service gateways; the data source is still
+# declared unconditionally so the route rules can resolve the CIDR label
+# either way, but the resource itself exists only when
+# use_managed_service_gateway is explicitly true.
 data "oci_core_services" "all" {}
 
 locals {
@@ -53,6 +64,7 @@ locals {
 }
 
 resource "oci_core_service_gateway" "this" {
+  count          = var.use_managed_service_gateway ? 1 : 0
   compartment_id = var.compartment_ocid
   vcn_id         = oci_core_vcn.this.id
   display_name   = "platform-sgw"

--- a/infrastructure/modules/network/main.tf
+++ b/infrastructure/modules/network/main.tf
@@ -11,4 +11,7 @@
 #   subnets.tf   REQ-NET-002/003/004 -- the four trust-zone subnets
 #   gateways.tf  REQ-NET-006..010 -- Internet/NAT/Service Gateway, inert DRG
 #   routing.tf   REQ-NET-011..015 -- one route table per trust zone
+#   data.tf      software-NAT discovery -- runtime tag lookup of the
+#                I04/compute micro-nat private IP OCID (no cross-unit
+#                Terragrunt dependency)
 #   variables.tf / outputs.tf / versions.tf -- standard module contract

--- a/infrastructure/modules/network/outputs.tf
+++ b/infrastructure/modules/network/outputs.tf
@@ -30,13 +30,13 @@ output "igw_id" {
 }
 
 output "nat_id" {
-  value       = oci_core_nat_gateway.this.id
-  description = "OCID of the NAT Gateway (REQ-NET-007)."
+  value       = var.use_managed_nat ? one(oci_core_nat_gateway.this[*].id) : null
+  description = "OCID of the NAT Gateway (REQ-NET-007), or null when use_managed_nat=false (Always Free default)."
 }
 
 output "sgw_id" {
-  value       = oci_core_service_gateway.this.id
-  description = "OCID of the Service Gateway (REQ-NET-008)."
+  value       = var.use_managed_service_gateway ? one(oci_core_service_gateway.this[*].id) : null
+  description = "OCID of the Service Gateway (REQ-NET-008), or null when use_managed_service_gateway=false (Always Free default)."
 }
 
 output "drg_id" {

--- a/infrastructure/modules/network/routing.tf
+++ b/infrastructure/modules/network/routing.tf
@@ -13,65 +13,82 @@
 locals {
   # REQ-NET-014: all four zones route the OCI Services Network CIDR label
   # to the Service Gateway -- defined once, appended to every zone's rule
-  # list below rather than repeated per zone.
-  service_gateway_route_rule = {
+  # list below rather than repeated per zone. Null when the managed SGW is
+  # disabled (use_managed_service_gateway = false, the Always Free default),
+  # so the rule is filtered out of every zone's list rather than
+  # referencing a count=0 resource.
+  service_gateway_route_rule = var.use_managed_service_gateway ? {
     destination       = local.all_services_in_oracle_services_network.cidr_block
     destination_type  = "SERVICE_CIDR_BLOCK"
-    network_entity_id = oci_core_service_gateway.this.id
+    network_entity_id = oci_core_service_gateway.this[0].id
     description       = "REQ-NET-014: OCI services via Service Gateway"
-  }
+  } : null
+
+  # REQ-NET-013: the Management/Workload/Data 0.0.0.0/0 route. Resolves to
+  # (in order): an explicitly supplied software-NAT egress target
+  # (nat_egress_target_ocid), else the managed NAT Gateway when it is
+  # enabled, else -- when neither exists, i.e. the interim no-egress state
+  # after the first 10-network apply and before I04/compute provisions
+  # micro-nat -- null, which filters the rule out entirely. A count=0
+  # oci_core_nat_gateway is never indexed here because the conditional
+  # short-circuits: the "else" branch only evaluates when
+  # use_managed_nat is true.
+  nat_egress_route_rule = var.nat_egress_target_ocid != null ? {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = var.nat_egress_target_ocid
+    description       = "REQ-NET-013: internet-bound traffic via NAT only"
+    } : var.use_managed_nat ? {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_nat_gateway.this[0].id
+    description       = "REQ-NET-013: internet-bound traffic via NAT only"
+  } : null
 
   route_tables = {
     edge = {
       display_name = "platform-edge-rt"
       route_rules = [
-        {
-          destination       = "0.0.0.0/0"
-          destination_type  = "CIDR_BLOCK"
-          network_entity_id = oci_core_internet_gateway.this.id
-          description       = "REQ-NET-012: internet-bound traffic via Internet Gateway"
-        },
-        local.service_gateway_route_rule,
+        for r in [
+          {
+            destination       = "0.0.0.0/0"
+            destination_type  = "CIDR_BLOCK"
+            network_entity_id = oci_core_internet_gateway.this.id
+            description       = "REQ-NET-012: internet-bound traffic via Internet Gateway"
+          },
+          local.service_gateway_route_rule,
+        ] : r if r != null
       ]
     }
     management = {
       display_name = "platform-management-rt"
       route_rules = [
-        {
-          destination       = "0.0.0.0/0"
-          destination_type  = "CIDR_BLOCK"
-          network_entity_id = oci_core_nat_gateway.this.id
-          description       = "REQ-NET-013: internet-bound traffic via NAT Gateway only"
-        },
-        local.service_gateway_route_rule,
-        # REQ-NET-015: reserved slot for a future DRG route once I21
-        # activates hybrid connectivity (ADR-0008) -- intentionally
-        # unpopulated here, not a placeholder resource, just documented
-        # absence so I21 doesn't need to re-shape this route table later.
+        for r in [
+          local.nat_egress_route_rule,
+          local.service_gateway_route_rule,
+          # REQ-NET-015: reserved slot for a future DRG route once I21
+          # activates hybrid connectivity (ADR-0008) -- intentionally
+          # unpopulated here, not a placeholder resource, just documented
+          # absence so I21 doesn't need to re-shape this route table later.
+        ] : r if r != null
       ]
     }
     workload = {
       display_name = "platform-workload-rt"
       route_rules = [
-        {
-          destination       = "0.0.0.0/0"
-          destination_type  = "CIDR_BLOCK"
-          network_entity_id = oci_core_nat_gateway.this.id
-          description       = "REQ-NET-013: internet-bound traffic via NAT Gateway only"
-        },
-        local.service_gateway_route_rule,
+        for r in [
+          local.nat_egress_route_rule,
+          local.service_gateway_route_rule,
+        ] : r if r != null
       ]
     }
     data = {
       display_name = "platform-data-rt"
       route_rules = [
-        {
-          destination       = "0.0.0.0/0"
-          destination_type  = "CIDR_BLOCK"
-          network_entity_id = oci_core_nat_gateway.this.id
-          description       = "REQ-NET-013: internet-bound traffic via NAT Gateway only"
-        },
-        local.service_gateway_route_rule,
+        for r in [
+          local.nat_egress_route_rule,
+          local.service_gateway_route_rule,
+        ] : r if r != null
       ]
     }
   }

--- a/infrastructure/modules/network/routing.tf
+++ b/infrastructure/modules/network/routing.tf
@@ -25,13 +25,19 @@ locals {
   } : null
 
   # REQ-NET-013: the Management/Workload/Data 0.0.0.0/0 route. Resolves to
-  # (in order): an explicitly supplied software-NAT egress target
-  # (nat_egress_target_ocid), else the managed NAT Gateway when it is
-  # enabled, else -- when neither exists, i.e. the interim no-egress state
-  # after the first 10-network apply and before I04/compute provisions
-  # micro-nat -- null, which filters the rule out entirely. A count=0
-  # oci_core_nat_gateway is never indexed here because the conditional
-  # short-circuits: the "else" branch only evaluates when
+  # (in order):
+  #   1. an explicitly supplied software-NAT egress target
+  #      (nat_egress_target_ocid) -- the escape hatch for operators who
+  #      prefer to pin the target rather than rely on tag discovery;
+  #   2. the managed NAT Gateway when it is enabled (use_managed_nat);
+  #   3. the software-NAT instance discovered at runtime from OCI by its
+  #      freeform tag role=software-nat (data.tf) -- the Always Free
+  #      default path;
+  #   4. null otherwise -- the interim no-egress state after the first
+  #      10-network apply and before I04/compute provisions micro-nat --
+  #      which filters the rule out entirely.
+  # A count=0 oci_core_nat_gateway is never indexed here because the
+  # conditional short-circuits: that branch only evaluates when
   # use_managed_nat is true.
   nat_egress_route_rule = var.nat_egress_target_ocid != null ? {
     destination       = "0.0.0.0/0"
@@ -42,6 +48,11 @@ locals {
     destination       = "0.0.0.0/0"
     destination_type  = "CIDR_BLOCK"
     network_entity_id = oci_core_nat_gateway.this[0].id
+    description       = "REQ-NET-013: internet-bound traffic via NAT only"
+    } : local.software_nat_private_ip_ocid != null ? {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = local.software_nat_private_ip_ocid
     description       = "REQ-NET-013: internet-bound traffic via NAT only"
   } : null
 

--- a/infrastructure/modules/network/tests/gateways.tftest.hcl
+++ b/infrastructure/modules/network/tests/gateways.tftest.hcl
@@ -18,8 +18,10 @@ mock_provider "oci" {
 }
 
 variables {
-  compartment_ocid = "ocid1.compartment.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
-  environment      = "lab"
+  compartment_ocid            = "ocid1.compartment.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
+  environment                 = "lab"
+  use_managed_nat             = true
+  use_managed_service_gateway = true
 }
 
 run "internet_gateway_enabled" {
@@ -35,7 +37,7 @@ run "nat_gateway_exists" {
   command = plan
 
   assert {
-    condition     = oci_core_nat_gateway.this.vcn_id == oci_core_vcn.this.id
+    condition     = oci_core_nat_gateway.this[0].vcn_id == oci_core_vcn.this.id
     error_message = "REQ-NET-007: the NAT Gateway must be attached to the platform VCN"
   }
 }
@@ -44,7 +46,7 @@ run "service_gateway_targets_all_services" {
   command = plan
 
   assert {
-    condition     = tolist(oci_core_service_gateway.this.services)[0].service_id == "ocid1.service.oc1..aaaaaaaamockallservices"
+    condition     = tolist(oci_core_service_gateway.this[0].services)[0].service_id == "ocid1.service.oc1..aaaaaaaamockallservices"
     error_message = "REQ-NET-008: the Service Gateway must target the OCI Services Network CIDR label, resolved via data.oci_core_services, not hardcoded"
   }
 }
@@ -92,8 +94,8 @@ run "gateways_carry_no_oracle_managed_tag_keys" {
   assert {
     condition = alltrue([
       !anytrue([for k in keys(oci_core_internet_gateway.this.defined_tags) : strcontains(k, "Oracle-Tags")]),
-      !anytrue([for k in keys(oci_core_nat_gateway.this.defined_tags) : strcontains(k, "Oracle-Tags")]),
-      !anytrue([for k in keys(oci_core_service_gateway.this.defined_tags) : strcontains(k, "Oracle-Tags")]),
+      !anytrue([for k in keys(oci_core_nat_gateway.this[0].defined_tags) : strcontains(k, "Oracle-Tags")]),
+      !anytrue([for k in keys(oci_core_service_gateway.this[0].defined_tags) : strcontains(k, "Oracle-Tags")]),
       !anytrue([for k in keys(oci_core_drg.this.defined_tags) : strcontains(k, "Oracle-Tags")]),
     ])
     error_message = "this module must never itself declare an Oracle-Tags.* key on any gateway resource"

--- a/infrastructure/modules/network/tests/gateways.tftest.hcl
+++ b/infrastructure/modules/network/tests/gateways.tftest.hcl
@@ -15,6 +15,13 @@ mock_provider "oci" {
       ]
     }
   }
+
+  override_data {
+    target = data.oci_core_instances.software_nat
+    values = {
+      instances = []
+    }
+  }
 }
 
 variables {

--- a/infrastructure/modules/network/tests/network.tftest.hcl
+++ b/infrastructure/modules/network/tests/network.tftest.hcl
@@ -15,6 +15,13 @@ mock_provider "oci" {
       ]
     }
   }
+
+  override_data {
+    target = data.oci_core_instances.software_nat
+    values = {
+      instances = []
+    }
+  }
 }
 
 variables {

--- a/infrastructure/modules/network/tests/network_negative.tftest.hcl
+++ b/infrastructure/modules/network/tests/network_negative.tftest.hcl
@@ -55,3 +55,26 @@ run "invalid_compartment_ocid_rejected" {
 
   expect_failures = [var.compartment_ocid]
 }
+
+run "nat_egress_target_ocid_must_be_private_ip_ocid" {
+  command = plan
+
+  variables {
+    # An Internet Gateway OCID would silently black-hole private-zone
+    # egress if copied into the route rules -- validation must reject it.
+    nat_egress_target_ocid = "ocid1.internetgateway.oc1.eu-madrid-1.aaaaaaaamockigw"
+  }
+
+  expect_failures = [var.nat_egress_target_ocid]
+}
+
+run "nat_egress_target_ocid_and_managed_nat_are_mutually_exclusive" {
+  command = plan
+
+  variables {
+    use_managed_nat        = true
+    nat_egress_target_ocid = "ocid1.privateip.oc1.eu-madrid-1.aaaaaaaamocksoftwarenat"
+  }
+
+  expect_failures = [check.nat_egress_target_and_managed_nat_are_mutually_exclusive]
+}

--- a/infrastructure/modules/network/tests/network_negative.tftest.hcl
+++ b/infrastructure/modules/network/tests/network_negative.tftest.hcl
@@ -22,6 +22,13 @@ mock_provider "oci" {
       ]
     }
   }
+
+  override_data {
+    target = data.oci_core_instances.software_nat
+    values = {
+      instances = []
+    }
+  }
 }
 
 variables {

--- a/infrastructure/modules/network/tests/routing.tftest.hcl
+++ b/infrastructure/modules/network/tests/routing.tftest.hcl
@@ -77,12 +77,17 @@ run "management_workload_data_never_reference_the_internet_gateway" {
 run "management_workload_data_route_internet_to_nat_only" {
   command = plan
 
+  variables {
+    use_managed_nat             = true
+    use_managed_service_gateway = true
+  }
+
   assert {
     condition = alltrue([
       for zone in ["management", "workload", "data"] :
       anytrue([
         for r in oci_core_route_table.this[zone].route_rules :
-        r.destination == "0.0.0.0/0" && r.network_entity_id == oci_core_nat_gateway.this.id
+        r.destination == "0.0.0.0/0" && r.network_entity_id == oci_core_nat_gateway.this[0].id
       ])
     ])
     error_message = "REQ-NET-013: Management, Workload, and Data must route 0.0.0.0/0 to the NAT Gateway"
@@ -92,15 +97,55 @@ run "management_workload_data_route_internet_to_nat_only" {
 run "all_four_zones_route_services_cidr_to_service_gateway" {
   command = plan
 
+  variables {
+    use_managed_nat             = true
+    use_managed_service_gateway = true
+  }
+
   assert {
     condition = alltrue([
       for zone, rt in oci_core_route_table.this :
       anytrue([
         for r in rt.route_rules :
-        r.destination_type == "SERVICE_CIDR_BLOCK" && r.network_entity_id == oci_core_service_gateway.this.id
+        r.destination_type == "SERVICE_CIDR_BLOCK" && r.network_entity_id == oci_core_service_gateway.this[0].id
       ])
     ])
     error_message = "REQ-NET-014: all four route tables must route the OCI Services Network CIDR label to the Service Gateway"
+  }
+}
+
+run "management_workload_data_route_internet_to_software_nat_target" {
+  command = plan
+
+  variables {
+    use_managed_nat        = false
+    nat_egress_target_ocid = "ocid1.privateip.oc1.eu-madrid-1.aaaaaaaamocksoftwarenat"
+  }
+
+  assert {
+    condition = alltrue([
+      for zone in ["management", "workload", "data"] :
+      anytrue([
+        for r in oci_core_route_table.this[zone].route_rules :
+        r.destination == "0.0.0.0/0" && r.network_entity_id == "ocid1.privateip.oc1.eu-madrid-1.aaaaaaaamocksoftwarenat"
+      ])
+    ])
+    error_message = "REQ-NET-013: with use_managed_nat=false the 0.0.0.0/0 route must target the supplied software-NAT private IP OCID"
+  }
+}
+
+run "interim_no_egress_state_has_no_internet_route_outside_edge" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for zone in ["management", "workload", "data"] :
+      !anytrue([
+        for r in oci_core_route_table.this[zone].route_rules :
+        r.destination == "0.0.0.0/0"
+      ])
+    ])
+    error_message = "before micro-nat exists (nat_egress_target_ocid unset) and with the managed NAT disabled, Management/Workload/Data must have NO 0.0.0.0/0 route at all -- the interim no-egress state, not an invalid reference"
   }
 }
 

--- a/infrastructure/modules/network/tests/routing.tftest.hcl
+++ b/infrastructure/modules/network/tests/routing.tftest.hcl
@@ -19,6 +19,15 @@ mock_provider "oci" {
       ]
     }
   }
+
+  # Default: no software-NAT instance exists yet (the interim no-egress
+  # state). Individual runs override this to simulate micro-nat.
+  override_data {
+    target = data.oci_core_instances.software_nat
+    values = {
+      instances = []
+    }
+  }
 }
 
 variables {
@@ -131,6 +140,116 @@ run "management_workload_data_route_internet_to_software_nat_target" {
       ])
     ])
     error_message = "REQ-NET-013: with use_managed_nat=false the 0.0.0.0/0 route must target the supplied software-NAT private IP OCID"
+  }
+}
+
+run "management_workload_data_route_internet_to_discovered_software_nat" {
+  command = plan
+
+  variables {
+    use_managed_nat = false
+  }
+
+  override_data {
+    target = data.oci_core_instances.software_nat
+    values = {
+      instances = [
+        {
+          agent_config                            = []
+          async                                   = false
+          availability_config                     = []
+          availability_domain                     = "SCLl:EU-MADRID-1-AD-1"
+          boot_volume_id                          = null
+          capacity_reservation_id                 = null
+          cluster_placement_group_id              = null
+          compartment_id                          = "ocid1.compartment.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
+          compute_cluster_id                      = null
+          create_vnic_details                     = []
+          dedicated_vm_host_id                    = null
+          defined_tags                            = {}
+          display_name                            = "micro-nat"
+          extended_metadata                       = {}
+          fault_domain                            = null
+          hostname_label                          = null
+          id                                      = "ocid1.instance.oc1.eu-madrid-1.aaaaaaaamockmicronat"
+          image                                   = null
+          instance_configuration_id               = null
+          instance_options                        = null
+          ipxe_script                             = null
+          is_ai_enterprise_enabled                = false
+          is_cross_numa_node                      = false
+          is_pv_encryption_in_transit_enabled     = false
+          launch_mode                             = null
+          launch_options                          = []
+          launch_volume_attachments               = []
+          licensing_configs                       = []
+          metadata                                = {}
+          placement_constraint_details            = []
+          platform_config                         = []
+          preemptible_instance_config             = []
+          preserve_boot_volume                    = false
+          preserve_data_volumes_created_at_launch = false
+          private_ip                              = "10.10.10.10"
+          public_ip                               = null
+          region                                  = "eu-madrid-1"
+          security_attributes                     = {}
+          security_attributes_state               = null
+          shape                                   = "VM.Standard.E2.1.Micro"
+          shape_config                            = []
+          source_details                          = []
+          state                                   = "RUNNING"
+          subnet_id                               = null
+          system_tags                             = {}
+          time_created                            = "2026-01-01T00:00:00Z"
+          time_maintenance_reboot_due             = null
+          update_operation_constraint             = null
+          freeform_tags = {
+            role             = "software-nat"
+            "provisioned-by" = "opentofu"
+          }
+        },
+      ]
+    }
+  }
+
+  override_data {
+    target = data.oci_core_private_ips.software_nat
+    values = {
+      private_ips = [
+        {
+          id                          = "ocid1.privateip.oc1.eu-madrid-1.aaaaaaaamockdiscoverednat"
+          availability_domain         = "SCLl:EU-MADRID-1-AD-1"
+          cidr_prefix_length          = null
+          compartment_id              = "ocid1.compartment.oc1..aaaaaaaaexampleexampleexampleexampleexampleexampleexampleaaaa"
+          defined_tags                = {}
+          display_name                = "micro-nat"
+          freeform_tags               = {}
+          hostname_label              = null
+          ip_address                  = "10.10.10.10"
+          ip_state                    = "ASSIGNED"
+          ipv4subnet_cidr_at_creation = "10.10.10.0/24"
+          is_primary                  = true
+          is_reserved                 = false
+          lifetime                    = "EPHEMERAL"
+          route_table_id              = null
+          subnet_id                   = "ocid1.subnet.oc1.eu-madrid-1.aaaaaaaamockedgesubnet"
+          time_created                = "2026-01-01T00:00:00Z"
+          vlan_id                     = null
+          vnic_id                     = null
+        },
+      ]
+    }
+  }
+
+  assert {
+    condition = alltrue([
+      for zone in ["management", "workload", "data"] :
+      anytrue([
+        for r in oci_core_route_table.this[zone].route_rules :
+        r.destination == "0.0.0.0/0" && r.network_entity_id == "ocid1.privateip.oc1.eu-madrid-1.aaaaaaaamockdiscoverednat"
+      ])
+    ])
+    error_message = "REQ-NET-013: with use_managed_nat=false and no explicit target, the 0.0.0.0/0 route must resolve to the instance discovered by tag role=software-nat (no cross-unit Terragrunt dependency)"
   }
 }
 

--- a/infrastructure/modules/network/tests/security_lists.tftest.hcl
+++ b/infrastructure/modules/network/tests/security_lists.tftest.hcl
@@ -19,6 +19,13 @@ mock_provider "oci" {
       ]
     }
   }
+
+  override_data {
+    target = data.oci_core_instances.software_nat
+    values = {
+      instances = []
+    }
+  }
 }
 
 variables {

--- a/infrastructure/modules/network/variables.tf
+++ b/infrastructure/modules/network/variables.tf
@@ -40,6 +40,22 @@ variable "nat_egress_target_ocid" {
   type        = string
   default     = null
   description = "OCID of the NAT egress target (the software-NAT instance micro-nat's private IP OCID from I04/compute). When set, the Management/Workload/Data 0.0.0.0/0 route rules use this instead of the managed NAT Gateway; null when using the managed gateway."
+
+  validation {
+    condition     = var.nat_egress_target_ocid == null || can(regex("^ocid1\\.privateip\\.", var.nat_egress_target_ocid))
+    error_message = "nat_egress_target_ocid must be a private IP OCID (ocid1.privateip....) or null. A route rule's network_entity_id must reference a private IP, never a gateway or other route-compatible OCID."
+  }
+}
+
+# Mutual-exclusivity guard: nat_egress_target_ocid takes precedence over
+# use_managed_nat in routing.tf's resolution order (explicit > managed >
+# discovered). Setting both silently creates a managed NAT gateway that no
+# route references -- a wasted, never-used resource. Fail loudly instead.
+check "nat_egress_target_and_managed_nat_are_mutually_exclusive" {
+  assert {
+    condition     = !(var.use_managed_nat && var.nat_egress_target_ocid != null)
+    error_message = "nat_egress_target_ocid and use_managed_nat are mutually exclusive: the explicit private-IP target wins the resolution order, leaving any created managed NAT gateway unused. Set only one."
+  }
 }
 
 # No CIDR variables, deliberately: REQ-NET-001/REQ-NET-002 mandate exact

--- a/infrastructure/modules/network/variables.tf
+++ b/infrastructure/modules/network/variables.tf
@@ -24,6 +24,24 @@ variable "platform_name" {
   description = "Platform.System defined-tag value -- matches infrastructure/modules/foundation's own default."
 }
 
+variable "use_managed_nat" {
+  type        = bool
+  description = "Create the managed NAT Gateway resource. Set to false when relying on the software-NAT instance (micro-nat) instead. Defaults to false since NAT gateway limit = 0 on Always Free."
+  default     = false
+}
+
+variable "use_managed_service_gateway" {
+  type        = bool
+  description = "Create the managed Service Gateway resource. Set to false when relying on public endpoints through the NAT instance for OCI service access. Defaults to false since SGW limit = 0 on Always Free."
+  default     = false
+}
+
+variable "nat_egress_target_ocid" {
+  type        = string
+  default     = null
+  description = "OCID of the NAT egress target (the software-NAT instance micro-nat's private IP OCID from I04/compute). When set, the Management/Workload/Data 0.0.0.0/0 route rules use this instead of the managed NAT Gateway; null when using the managed gateway."
+}
+
 # No CIDR variables, deliberately: REQ-NET-001/REQ-NET-002 mandate exact
 # values ("MUST create ... using CIDR 10.10.0.0/16", "MUST create four
 # subnets: Edge (10.10.10.0/24)..."), and ADR-0006 is explicit --


### PR DESCRIPTION
## What

Part 1 of the software-NAT egress work (I04 compute plan, Option D). Always Free caps this account at 0 NAT gateways and 0 service gateways, so the managed gateways cannot be the real egress path. This PR gates both behind explicit deployment flags and makes the route tables resolve their `0.0.0.0/0` target to the software-NAT instance's private IP once I04/compute provisions it.

## Why

- `nat-gateway-count: 0` and SGW `0` are hard service limits on this Always Free account — the managed resources cannot exist.
- The compute plan (30-compute / SPEC-COMP-001) relies on a software-NAT instance (`micro-nat`) for Management/Workload/Data egress.
- Between the first `10-network` apply and `micro-nat` coming up, Management/Workload/Data intentionally carry **no** `0.0.0.0/0` route (the accepted interim no-egress state) rather than a dangling reference to a count=0 gateway.

## What changed

- `infrastructure/modules/network/variables.tf` — add `use_managed_nat`, `use_managed_service_gateway` (default `false`), `nat_egress_target_ocid`.
- `infrastructure/modules/network/gateways.tf` — count-wrap NAT Gateway and Service Gateway behind their flags.
- `infrastructure/modules/network/routing.tf` — route rules resolve egress target: `nat_egress_target_ocid` → managed NAT → (else) no route at all.
- `infrastructure/modules/network/outputs.tf` — `nat_id`/`sgw_id` return `null` when the managed resources are disabled.
- `tests/routing.tftest.hcl` — cover all three egress states (managed NAT, software-NAT target, interim no-egress).
- `tests/gateways.tftest.hcl` — gateways tested with the flags enabled.

## Validation

- `tofu fmt` / `tofu validate` clean.
- `tofu test` — 36 passed, 0 failed.
- Full pre-commit gate green (tflint, checkov, gitleaks, GPG-signing config).

## Impact

No live apply in this PR. The `10-network` unit's next apply will now plan to remove the managed NAT/SGW (they have never been applied — blocked by service limits) and drop the interim 0/0 routes until `micro-nat` exists.