### PR TITLE
fix(live): sanitize ambient AWS_PROFILE/AWS_PAGER in tg wrapper

### DIFF
--- a/infrastructure/live/scripts/tg
+++ b/infrastructure/live/scripts/tg
@@ -145,6 +145,18 @@ run_with_backend_credentials() {
     pass-cli run -- "$@"
 }
 
+# Sanitize ambient AWS SDK hints inherited from the operator's shell
+# profile. An exported AWS_PROFILE makes the S3 backend's AWS SDK try to
+# load that named profile from root.hcl's deliberately nonexistent
+# shared_config_files/shared_credentials_files, failing init with
+# "failed to get shared config profile, default" -- observed live on
+# `tg init` (2026-08-20). Unsetting here (not in the caller's shell) is
+# not a credential bypass: it changes no credential source -- the OCI
+# Customer Secret Key still comes only from Proton Pass above -- it just
+# removes a variable root.hcl already refuses to honor. AWS_PAGER is
+# unset alongside only to keep tg's output piping predictable.
+unset AWS_PROFILE AWS_PAGER AWS_SDK_LOAD_CONFIG 2>/dev/null || true
+
 # Object Storage namespace is account data, not a secret -- safe to
 # auto-resolve live from the already-configured OCI CLI/API key profile
 # (~/.oci/config) rather than requiring a separate manually-exported env


### PR DESCRIPTION
## Why

An exported `AWS_PROFILE` in the operator's shell made the S3 backend's AWS SDK try to load that named profile from root.hcl's deliberately nonexistent `shared_config_files`/`shared_credentials_files`, failing `tg init` with `failed to get shared config profile, default` (observed live 2026-08-20 while planning #55).

## What changes

`infrastructure/live/scripts/tg` unsets `AWS_PROFILE`, `AWS_PAGER`, and `AWS_SDK_LOAD_CONFIG` before exec'ing `pass-cli run -- terragrunt`. This is **not** a credential bypass: the OCI Customer Secret Key still resolves only via the Proton Pass path — the unset just removes ambient variables root.hcl already refuses to honor.

## Validation evidence

- Reproduced the failure first (`tg init` → `failed to get shared config profile, default`).
- After the change: `AWS_PROFILE=some-unrelated-profile AWS_PAGER=less tg plan` against the lab converges with **No changes** (matches the post-#55 applied state).
- `pre-commit run --all-files` green on commit.

## Infrastructure impact

None — script-local environment hygiene only; no state operations.

Relates to the follow-up noted in #55.